### PR TITLE
Changed message wording/order to put coop code first

### DIFF
--- a/EGG9000.Bot/Automated/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/CoopStatusUpdater.cs
@@ -876,7 +876,7 @@ namespace EGG9000.Bot.Automated {
                                     }
                                 } catch(Exception) { }
                             }
-                            lastMessage += $"Ready for the following to join the coop **{coop.Name}**: {string.Join(", ", userList)}\n";
+                            lastMessage += $"Coop **{coop.Name}** is ready for the following to join: {string.Join(", ", userList)}\n";
                         }
 
                         if(status.Public) {


### PR DESCRIPTION
Per a suggestion from Alessio, change the order of this around so that the coop name fits in the notification preview.