### PR TITLE
Replace instances of 'GetRandomWord() + GetRandomWord()' with new met…

### DIFF
--- a/EGG9000.Bot/Commands/NewCode.cs
+++ b/EGG9000.Bot/Commands/NewCode.cs
@@ -16,7 +16,9 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "Generate a new co-op code, a channel will be created for the co-op", AdminOnly =true, AllowFarmHand = true)]
         public static async Task NewCoopCode(FauxCommand command, ApplicationDbContext db, DiscordSocketClient client) {
             var words = new Words();
-            var code = words.GetRandomWord() + words.GetRandomWord() + words.GetRandomNumber();
+            var wordOne = words.GetRandomWord();
+            var wordTwo = words.GetRandomSecondWord(wordOne);
+            var code = wordOne + wordTwo + words.GetRandomNumber();
 
             var guild = client.Guilds.FirstOrDefault(x => x.TextChannels.Any(y => y.Id == command.Channel.Id));
 

--- a/EGG9000.Common/Helpers/Words.cs
+++ b/EGG9000.Common/Helpers/Words.cs
@@ -28,6 +28,12 @@ namespace EGG9000.Bot
             return FirstCharToUpper(WordList[_rnd.Next(WordList.Count)]);
         }
 
+        public string GetRandomSecondWord(string firstWord)
+        {
+            var FilteredWordList = WordList.FindAll(e => !e.StartsWith(firstWord.Last()));
+            return FirstCharToUpper(FilteredWordList[_rnd.Next(FilteredWordList.Count)]);
+        }
+
         public string GetRandomNumber()
         {
             int number;
@@ -48,7 +54,7 @@ namespace EGG9000.Bot
 
         public string GetCoopName(List<UserFarmDetails> prefarms, SocketGuild discordguild, Guild dbguild) {
             if(!string.IsNullOrWhiteSpace(dbguild.CoopNamePrefix))
-                return $"{dbguild.CoopNamePrefix}{GetRandomWord()}{GetRandomNumber()}";
+                return $"{dbguild.CoopNamePrefix}{GetRandomSecondWord(dbguild.CoopNamePrefix)}{GetRandomNumber()}";
 
             var customNames = prefarms.Where(x => !string.IsNullOrEmpty(x.DBUser?.CustomCoopName)).GroupBy(x => x.DBUser.Id).ToList();
             var customNamesExpired = customNames.Where(x => x.First().DBUser.ExpireCustomCoopName.HasValue && x.First().DBUser.ExpireCustomCoopName.Value < DateTimeOffset.Now);
@@ -65,12 +71,16 @@ namespace EGG9000.Bot
                 var name = customNames.First().First().DBUser.CustomCoopName;
 
                 if(name.Count(c => Char.IsUpper(c)) > 1 && name.Length > 5) {
-                    return customNames.First().First().DBUser.CustomCoopName + GetRandomNumber();
+                    return name + GetRandomNumber();
                 } else {
-                    return customNames.First().First().DBUser.CustomCoopName + GetRandomWord() + GetRandomNumber();
+                    return name + GetRandomSecondWord(name) + GetRandomNumber();
                 }
+            } else {
+                var wordOne = GetRandomWord();
+                var wordTwo = GetRandomSecondWord(wordOne);
+                return wordOne + wordTwo + GetRandomNumber();
             }
-            return GetRandomWord() + GetRandomWord() + GetRandomNumber();
+            
         }
 
         private List<String> WordList {


### PR DESCRIPTION
...od calls

- Coop names will now not generate with words ending/starting with the same letter (i.e. BrightThump)
- This will apply to all coops where a random second word is generated:
-- Users who have one-word custom prefixes
-- Completely random coops