### PR TITLE
Command links

### DIFF
--- a/EGG9000.Bot/Automated/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/CoopStatusUpdater.cs
@@ -928,8 +928,15 @@ namespace EGG9000.Bot.Automated {
                             lastMessage += "\nLooks like everyone's shipping and/or habs are full or they haven't joined yet, so gifting chickens isn't useful.\n";
                         }
 
-                        lastMessage += "Co-op Commands:\n`/pingonhighesteb` **NEW!** Receive DM ping when the highest EB has joined \n`/pingonfull` Receive DM ping when everyone has joined\n`/callstaff` Use this instead of pinging us for help with things like typing in the wrong code (don't restart until we tell you to)";
-                        lastMessage += "\n`/fixjoinedwrongcoop` Use this command if you mistyped the co-op name, if you joined a co-op for the wrong contract use `/callstaff`";
+                        //New commands list, each is a quick-link to start using the command
+                        lastMessage += "__Co-op Commands (click to use):__\n";
+                        lastMessage += "\n</pingonhighesteb:1095116354169864206> **NEW!** Receive DM ping when the highest EB has joined ";
+                        lastMessage += "\n</pingonfull:1095116354169864205> Receive DM ping when everyone has joined";
+                        lastMessage += "\n</fixjoinedwrongcoop:1095116354010493081> Use this command if you mistyped the co-op name";
+                        lastMessage += "\n</callstaff:1095116354169864210> Use this command if you joined a co-op for the wrong contract, or have other questions or concerns";
+
+                        /*lastMessage += "Co-op Commands:\n`/pingonhighesteb` **NEW!** Receive DM ping when the highest EB has joined \n`/pingonfull` Receive DM ping when everyone has joined\n`/callstaff` Use this instead of pinging us for help with things like typing in the wrong code (don't restart until we tell you to)";
+                        lastMessage += "\n`/fixjoinedwrongcoop` Use this command if you mistyped the co-op name, if you joined a co-op for the wrong contract use `/callstaff`";*/
 
 
                         foreach(var u in usersWithStatus.Where(x => x.Xref is not null)) {

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -418,7 +418,7 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "Start co-ops with users above a certain percent and backfill with low EB users", AdminOnly = true)]
         public static async Task StartFill(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, APILink _apiLink, Words _words, [SlashParam(Description = "Percent at which a user will be started")] int percenttostart) {
             if(percenttostart < 120) {
-                await command.RespondAsync($"Minumum percent for /startfill is 120%");
+                await command.RespondAsync($"Minumum percent for </startfill:1095116344392941610> is 120%");
                 return;
             }
             await _StartUser(command, db, _client, _apiLink, _words, true, percent: percenttostart);

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -497,9 +497,9 @@ namespace EGG9000.Bot.Commands {
         }
 
         [Obsolete("TakeABreak is deprecated, please use MyContractSettings instead.")]
-        [SlashCommand(Description = "Please use the command </mycontractsettings:1100476258518839336>' instead")]
+        [SlashCommand(Description = "Please use the `mycontractsettings` command instead")]
         public static async Task TakeABreak(FauxCommand command) {
-            await command.RespondAsync("Please use the command </mycontractsettings:1100476258518839336> to take a break.", ephemeral: true);
+            await command.RespondAsync("Please use the </mycontractsettings:1100476258518839336> command to take a break.", ephemeral: true);
         }
 
         [SlashCommand(Description = "Disable user, user will not be assigned to co-ops until re-enabled", AdminOnly = true)]

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -174,7 +174,7 @@ namespace EGG9000.Bot.Commands {
             }
 
             if(user.EggIncAccounts.Count > 0 && user.GuildId > 0) {
-                await command.RespondAsync($"{targetUser.Mention}, looks like you are registered with another server, if you would like to move to this server use the command  __**/moveserver**__");
+                await command.RespondAsync($"{targetUser.Mention}, looks like you are registered with another server, if you would like to move to this server use the </moveserver:1095116354329268366> command");
             } else {
                 string channelText = "";
                 var talkChannel = guild.TextChannels.FirstOrDefault(x => x.Id == 746509501271769210);
@@ -183,7 +183,7 @@ namespace EGG9000.Bot.Commands {
                 }
                 if(user.EggIncAccounts.Count > 0) {
                     if(user.GuildId != guild.Id) {
-                        await command.RespondAsync($"{targetUser.Mention}, now run the command /moveserver");
+                        await command.RespondAsync($"{targetUser.Mention}, now run the </moveserver:1095116354329268366> command");
                     } else if(user.TempDisabled) {
                         await command.RespondAsync($"Looks like you are currently disabled, please wait for someone from staff to get you re-enabled.");
                     } else {
@@ -459,7 +459,7 @@ namespace EGG9000.Bot.Commands {
                 }
 
                 if(dbuser.GuildId != guild.Id) {
-                    msg += $"\nNot registered with this server, try the /moveserver command";
+                    msg += $"\nNot registered with this server, try the </moveserver:1095116354329268366> command";
                 }
             }
 
@@ -497,9 +497,9 @@ namespace EGG9000.Bot.Commands {
         }
 
         [Obsolete("TakeABreak is deprecated, please use MyContractSettings instead.")]
-        [SlashCommand(Description = "Please use the command '/mycontractsettings' instead")]
+        [SlashCommand(Description = "Please use the command </mycontractsettings:1100476258518839336>' instead")]
         public static async Task TakeABreak(FauxCommand command) {
-            await command.RespondAsync("Please use the command '/mycontractsettings' to take a break.", ephemeral: true);
+            await command.RespondAsync("Please use the command </mycontractsettings:1100476258518839336> to take a break.", ephemeral: true);
         }
 
         [SlashCommand(Description = "Disable user, user will not be assigned to co-ops until re-enabled", AdminOnly = true)]

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -134,7 +134,7 @@ namespace EGG9000.Common.Services {
             } else {
                 var welcomeChannel = await _discord.GetChannelAsync(GuildChannelType.Welcome, user.Guild);
                 var rulesChannel = await _discord.GetChannelAsync(GuildChannelType.Rules, user.Guild);
-                var msg = $"Welcome to the server {user.Mention}! Please read {rulesChannel.Mention} and then send the message __**/accept**__ when you are ready.";
+                var msg = $"Welcome to the server {user.Mention}! Please read {rulesChannel.Mention} and then use the </accept:1095116354329268368> command when you are ready.";
                 var talkChannel = user.Guild.TextChannels.FirstOrDefault(x => x.Id == 746509501271769210);
                 if(talkChannel != null)
                     msg += $" If you have any questions feel free to ask us in {talkChannel.Mention}, we are glad you are here!";


### PR DESCRIPTION
Replaced instances of plaintext "Use x command" or "Use `x` command" with the:

</command:ID_OF_COMMAND>

formatting. This includes:

- Coop Commands List
- #Welcome, telling user to "send /accept" -> "use the </accept:....> command"
- More misc. ones