### PR TITLE
Logic for moving failed coops correctly

### DIFF
--- a/EGG9000.Bot/Automated/CoopDeleteChannel.cs
+++ b/EGG9000.Bot/Automated/CoopDeleteChannel.cs
@@ -32,7 +32,7 @@ namespace EGG9000.Bot.Automated {
             //var coops = await _db.Coops.AsQueryable().Where(x => x.CoopEnds.HasValue && x.CoopEnds.Value.AddDays(1) < DateTimeOffset.Now && !x.DeletedChannel).ToListAsync();
 
 
-            coops.AddRange(await _db.Coops.AsQueryable().Where(x => x.Finished && !x.DeletedChannel && (x.CoopCompleted == null || x.CoopCompleted < DateTimeOffset.Now.AddDays(-2))).ToListAsync());
+            coops.AddRange(await _db.Coops.AsQueryable().Where(x => (x.Finished || x.FinishedOrFailed) && !x.DeletedChannel && (x.CoopCompleted == null || x.CoopCompleted < DateTimeOffset.Now.AddDays(-2))).ToListAsync());
             //coops.AddRange(await _db.Coops.AsQueryable().Where(x => x.Finished && !x.DeletedChannel && (x.CoopCompleted == null || x.CoopCompleted < DateTimeOffset.Now.AddHours(-12))).ToListAsync());
 
 

--- a/EGG9000.Bot/Automated/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/CoopStatusUpdater.cs
@@ -945,6 +945,8 @@ namespace EGG9000.Bot.Automated {
                             var coopFailedCategory = await _client.GetCategoryAsync(GuildChannelType.FailedCategory, guild);
                             if(coopFailedCategory is null)
                                 coopFailedCategory = _client.GetGuild(coop.OverflowGuildId).CategoryChannels.Where(x => x.Name != null).FirstOrDefault(x => x.Name.ToLower().Contains("failed") && x.Name.ToLower().Contains("coops"));
+                            if(coopFailedCategory is null)
+                                coopFailedCategory = _client.GetGuild(coop.OverflowGuildId).CategoryChannels.Where(x => x.Name != null).FirstOrDefault(x => x.Name.ToLower().Contains("finished") && x.Name.ToLower().Contains("coops"));
                             await coopChannel.ModifyAsync(x => { x.CategoryId = coopFailedCategory.Id; });
                         } catch(Exception) {
 


### PR DESCRIPTION
Change logic for failed coop channel moving in overflows, as well as failed coop channel deletion