### PR TITLE
Update links from Google Ajax to jsdelivr/cdnjs

### DIFF
--- a/EGG9000.Site/Views/Shared/_Layout.cshtml
+++ b/EGG9000.Site/Views/Shared/_Layout.cshtml
@@ -98,9 +98,8 @@
 	</footer>
 	<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
 	<script src="~/lib/js-cookie/dist/js.cookie.js"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/angular@1.7.6/angular.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js"></script>
-	@*<script src="~/lib/jquery/dist/jquery.min.js"></script>*@
 	<script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
 	<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
 	<script src="~/js/site.js" asp-append-version="true"></script>
@@ -110,12 +109,12 @@
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-moment/1.2.0/angular-moment.min.js"></script>
 
 
-	<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.12/angular-material.min.css">
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular-animate.min.js"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular-aria.min.js"></script>
-	<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.7.6/angular-messages.min.js"></script>
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.12/angular-material.min.css">
+	<script src="https://cdn.jsdelivr.net/npm/angular-animate@1.7.6/angular-animate.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/angular-aria@1.7.6/angular-aria.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/angular-messages@1.7.6/angular-messages.min.js"></script>
 	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-	<script src="https://ajax.googleapis.com/ajax/libs/angular_material/1.1.12/angular-material.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.12/angular-material.min.js"></script>
 	<script src="https://cdn.jsdelivr.net/g/angular.ui-sortable"></script>
 	@RenderSection("Scripts", required: false)
 	<script>


### PR DESCRIPTION
Due to Google's AJAX API links being somewhat deprecated, replace with other CDN links