### PR TITLE
Daveed changes

### DIFF
--- a/EGG9000.Bot/Automated/ContractUpdater.cs
+++ b/EGG9000.Bot/Automated/ContractUpdater.cs
@@ -257,7 +257,7 @@ namespace EGG9000.Bot.Automated {
                 }
 
                 var findSpotButton = (dbGuild.DisableBG && dbGuild.Id != 1108127105088241746 /*DEV server*/) ? null : 
-                    ((DateTimeOffset.Now > guildContract.Contract.Created.AddHours(guildContract.CcOnly ? 24 : 18) && guildContract.Contract.GoodUntil > DateTimeOffset.Now) ? 
+                    (dbGuild.Id == 1108127105088241746 || ((DateTimeOffset.Now > guildContract.Contract.Created.AddHours(guildContract.CcOnly ? 24 : 18) && guildContract.Contract.GoodUntil > DateTimeOffset.Now)) ? 
                         new ComponentBuilder().WithButton("Find Coop Spot", customId: $"FindCoopSpot").Build() 
                         : null);
 

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -151,18 +151,23 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
 
         public class CreateCoopContractAutoComplete : AutoCompleteHandler {
             private readonly ApplicationDbContext _db;
-            public CreateCoopContractAutoComplete(ApplicationDbContext db) {
+            private readonly DiscordSocketClient _discord;
+            public CreateCoopContractAutoComplete(ApplicationDbContext db, DiscordSocketClient client) {
                 _db = db;
+                _discord = client;
             }
             public async Task Run(SocketAutocompleteInteraction arg) {
                 var guild = _db.Guilds.FirstOrDefault(x => x.Id == arg.GuildId || x.OverflowServersJson.Contains(arg.GuildId.ToString()));
+                var discordGuild = _discord.GetGuild(guild.Id);
+                var discordUserPerms = discordGuild.GetUser(arg.User.Id).GuildPermissions.ToList();
+                var isStaff = discordUserPerms.Contains(GuildPermission.Administrator) || discordUserPerms.Contains(GuildPermission.ManageChannels) || discordUserPerms.Contains(GuildPermission.CreatePrivateThreads) || discordUserPerms.Contains(GuildPermission.ModerateMembers);
                 var dbUser = _db.DBUsers.FirstOrDefault(x => x.DiscordId == arg.User.Id);
-                var hasSubscriptionAccounts = dbUser.EggIncAccounts.Where(x => x.HasActiveSubscription()).Any();
+                var hasSubscriptionAccounts = dbUser?.EggIncAccounts.Where(x => x.HasActiveSubscription()).Any() ?? false;
 
                 var contracts = _db.Contracts.Where(x => hasSubscriptionAccounts ? (x.GoodUntil > DateTimeOffset.Now) : (x.GoodUntil > DateTimeOffset.Now && !x.cc_only)).ToList();
                 var stringArg = (string)arg.Data.Current.Value;
                 if(!string.IsNullOrEmpty(stringArg) && stringArg != " ") contracts = contracts.Where(x => x.Name.Contains(stringArg) || x.ID.Contains(stringArg)).ToList(); //Filter by name
-                if(guild is not null && !guild.DisableBG) {
+                if(guild is not null && !guild.DisableBG && !isStaff) {
                     //Limit contracts to those that have had longer than 16 hours to launch (i.e. all three boarding groups)
                     contracts = contracts.Where(x => (DateTimeOffset.Now - x.Created).TotalHours > 17).ToList();
                 }

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -249,7 +249,8 @@ namespace EGG9000.Bot.Commands {
                 return new PotentialCoopResponse { Response = PotentialCoopCode.NoGrade };
             }
 
-            var coops = await db.Coops.Include(c => c.Contract).Include(c => c.UserCoopsXrefs).Where(c => c.Contract == contract && c.GuildId == guild.Id && c.League == (uint)account.GetGrade()
+            var coops = await db.Coops.Include(c => c.Contract).Include(c => c.UserCoopsXrefs).Where(c => c.Contract == contract && c.GuildId == guild.Id 
+             && (c.League == (uint)account.GetGrade() || c.AnyLeague)
              && c.CurrentUsers < c.MaxUsers && (int)c.Status > 2 && (int)c.Status < 13 && c.CoopEnds > DateTimeOffset.Now && c.ProjectedFinish > DateTimeOffset.Now).ToListAsync();
 
             if(!coops.Any()) {
@@ -307,7 +308,7 @@ namespace EGG9000.Bot.Commands {
                     return;
                 case PotentialCoopCode.NoSpots1:
                 case PotentialCoopCode.NoSpots2:
-                    await command.RespondAsync(content: "", embed: EmbedError($"No open Grade {PlayerGradeDetails.GetEmoji(account.GetGrade())} coop spots found for {contract.Name}"));
+                    await command.RespondAsync(content: "", embed: EmbedError($"No open{(contract.cc_only ? "" : $" Grade {PlayerGradeDetails.GetEmoji(account.GetGrade())}")} coop spots found for {contract.Name}"));
                     return;
             }
 
@@ -743,7 +744,7 @@ namespace EGG9000.Bot.Commands {
                 case PotentialCoopCode.NoSpots2:
                     _ = Emote.TryParse(PlayerGradeDetails.GetEmoji(account.LastGrade), out var emote);
                     //var createNewCoopComponent = new ComponentBuilder().WithButton("Create New Coop", customId: $"NoSpotsCreateCoop:{guildContract.ContractID}|{account.Id}", emote: emote).Build();
-                    await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"No open Grade {PlayerGradeDetails.GetEmoji(account.GetGrade())} coop spots found for {contract.Name}"); /*x.Components = createNewCoopComponent;*/ });
+                    await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"No open{(contract.cc_only ? "" : $" Grade {PlayerGradeDetails.GetEmoji(account.GetGrade())}")} coop spots found for {contract.Name}"); /*x.Components = createNewCoopComponent;*/ });
                     return;
                 default:
                     var coop = newCoopResponse.FoundCoop;

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -507,17 +507,19 @@ namespace EGG9000.Bot.Commands {
             var dbguild = await db.Guilds.AsQueryable().FirstAsync(x => x.Id == targetCoop.GuildId);
             await coopStatusUpdater.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default, db);
 
-            await command.ModifyOriginalResponseAsync(x => { x.Content = "", x.Embed = EmbedSuccess($"Fixed {targetuser.Mention}'s reference."); });
+            await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess($"Fixed {targetuser.Mention}'s reference."); });
         }
 
         [SlashCommand(Description = "Move a user to a co-op.", AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task MoveToCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, [SlashParam(AutocompleteHandler = typeof(UserAccountAutoComplete))] string useraccount, [SlashParam(AutocompleteHandler = typeof(MoveToCoopCoopNameAutoComplete))] string coopid) {
+            await command.DeferAsync();
+
             var coop = await db.Coops.Include(x => x.Contract).FirstOrDefaultAsync(x => x.Id == Guid.Parse(coopid));
             Guid userid;
             try {
                 userid = Guid.Parse(useraccount.Split("|")[0]);
             } catch(Exception) {
-                  await command.RespondAsync(content: "", embed: EmbedError("Unable to parse user account, please use the autocomplete dropdown."));
+                  await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to parse user account, please use the autocomplete dropdown."); });
                 return;
             }
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.Id == userid);
@@ -529,13 +531,12 @@ namespace EGG9000.Bot.Commands {
             var newxref = await CreateCoopsV2.MoveUser(coop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", discordUser, dbuser, (SocketTextChannel)coopChannel, (SocketTextChannel)command.Channel);
 
             if(newxref == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to add permission for {discordUser.Mention}{(coop.GuildId != coop.OverflowGuildId ? ", possibly not in overflow server" : "")}"));
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to add permission for {discordUser.Mention}{(coop.GuildId != coop.OverflowGuildId ? ", possibly not in overflow server" : "")}"); });
                 return;
             }
-
             db.Add(newxref);
 
-            await command.RespondAsync($"Moved {discordUser.Mention} ({account.Backup?.UserName ?? "(No Name)"}) to {((ITextChannel)coopChannel).Mention}");
+            await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess($"Moved {discordUser.Mention} ({account.Backup?.UserName ?? "(No Name)"}) to {((ITextChannel)coopChannel).Mention}"); });
             await db.SaveChangesAsync();
         }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -581,7 +581,7 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Create a co-op with the selected contract for you")]
-        public static async Task CreateCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, Words _words, IServiceProvider _provider, CoopStatusUpdater coopStatusUpdater, [SlashParam(AutocompleteHandler = typeof(CreateCoopContractAutoComplete))] string contractid) {
+        public static async Task CreateCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, Words _words, IServiceProvider _provider, [SlashParam(AutocompleteHandler = typeof(CreateCoopContractAutoComplete))] string contractid) {
             await command.DeferAsync(ephemeral: true);
             var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(user is null) {

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -80,7 +80,17 @@ namespace EGG9000.Bot.Commands {
         private static async Task _fixFullCoopError(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, CoopStatusUpdater coopStatusUpdater, ILogger logger, DBUser dbuser, Coop coop) {
             var status = await ContractsAPI.GetCoopStatus(coop.ContractID, coop.Name);
 
+            if(status is null) { //Safeguarding
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("The API is unresponsive, please try again in a minute or two."); });
+                return;
+            }
+
             var details = new CoopDetails(coop, coop.Contract, coop.League, coop.UserCoopsXrefs.SelectMany(y => y.User.EggIncAccounts.Select(x => new UserWithBackup { Backup = x.Backup, User = y.User })).ToList(), _client, status);
+
+            if(details is null) { // Edge cases were throwing when details was null
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to locate user in co-op. (Co-op may be, or have been public/late joined)"); });
+                return;
+            }
 
             var xref = details.CoopParticipants.FirstOrDefault(x => x.DBUser.Id == dbuser.Id && x.EggsShipped == 0);
 

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -96,25 +96,43 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Show off your saved Artifact Sets")]
-        public static async Task SavedAfSets(FauxCommand command, ApplicationDbContext db, [SlashParam(AutocompleteHandler = typeof(PersonalUserAccountAutoComplete))] string useraccount) {
+        public static async Task SavedAfSets(FauxCommand command, ApplicationDbContext db, [SlashParam(AutocompleteHandler = typeof(PersonalUserAccountAutoComplete))] string useraccount, [SlashParam(Description = "Set # to statically display", Required = false, PositiveOnly = true)] int index = 0) {
             await command.DeferAsync();
+            var lockSet = true;
+            if(index == 0) {
+                index = 1;
+                lockSet = false;
+            }
             var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(user == null) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find backups for this user"); });
                 return;
             }
-            var accountIndex = int.Parse(useraccount.Split("|")[1]);
-            var account = user.EggIncAccounts[accountIndex];
+            EggIncAccount account = null;
+            int accountIndex = 0;
+            try {
+                accountIndex = int.Parse(useraccount.Split("|")[1]);
+                account = user.EggIncAccounts[accountIndex];
+            } catch(Exception) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Please select an account from the list, instead of typing an input."); });
+                return;
+            }
+
             var afxSets = account.Backup?.ArtifactSets;
             if(afxSets is null || afxSets.Count == 0) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Backup is empty, or no Artifact Sets were found for this account"); });
                 return;
             }
 
-            var builder = AFXSetEmbedBuilder(user, accountIndex, afxSets, afxSets[0]);
+            if(index < 1 || (index != 1 && index > afxSets.Count)) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Set number `{index}` larger than maximum set number `{afxSets.Count}`."); });
+                return;
+            }
+
+            var builder = AFXSetEmbedBuilder(user, accountIndex, afxSets, afxSets[index - 1]);
             await command.ModifyOriginalResponseAsync(x => {
                 x.Content = "";
-                x.Components = builder.ComponentBuilder?.Build();
+                x.Components = lockSet ? null : builder.ComponentBuilder?.Build();
                 x.Embed = builder.EmbedBuilder.Build();
             });
         }
@@ -163,8 +181,7 @@ namespace EGG9000.Bot.Commands {
                     .WithIconUrl("https://cdn.discordapp.com/emojis/877681508607987772.webp")
                 ).WithColor(RandomColor())
                 .WithDescription(GetAfxSetString(currentSet));
-            if(accText != "")
-                embedBuilder.WithFooter(new EmbedFooterBuilder().WithText(accText));
+            if(accText != "") embedBuilder.WithFooter(new EmbedFooterBuilder().WithText(accText));
 
             if(currentSetIndex > 0 && afxSets.Count > 1 && afxSets[currentSetIndex - 1] is not null) {
                 componentBuilder.WithButton($"← Set {currentSetIndex}", $"LoadAFXSet:{user.DiscordId},{accountIndex},{currentSetIndex - 1}"); buttonCount++;

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -43,6 +43,7 @@ using Bugsnag;
 using static EGG9000.Bot.Commands.ContractCommandsSlash;
 using EGG9000.Bot.Automated.Coops;
 using EGG9000.Bot.Common.Helpers;
+using System.Data;
 
 namespace EGG9000.Bot.Commands {
     public static class RegisterCommandsSlash {
@@ -837,27 +838,37 @@ namespace EGG9000.Bot.Commands {
 
         [SlashCommand(Description = "Check the list of Users/EIDs that have been banned from the server via /kick", ParentCommand = "b", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task BanList(FauxCommand command, ApplicationDbContext db) {
-            var bannedUsers = await db.DBUsers.Where(u => u.Banned && u.GuildId == command.GuildId).ToListAsync();
+            await command.DeferAsync();
+            var bannedUsers = await db.DBUsers.Where(u => u.Banned && (u.LastGuild == command.GuildId || u.GuildId == command.GuildId)).ToListAsync();
             if(bannedUsers is null || bannedUsers.Count == 0) {
-                await command.RespondAsync("No users are banned from this guild");
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess("No users are banned from this guild."); });
                 return;
             }
             var userList = string.Join("\n", bannedUsers.Select(u => $"{u.DiscordUsername}\t{u.DiscordId}\t" + string.Join(", ", u.EggIncAccounts.Select(a => a.Id).ToList()))) ?? "Could not compile list";
-            await command.RespondAsync(userList);
+            var guildName = (await db.Guilds.FirstOrDefaultAsync(x => x.Id == command.GuildId)).Name;
+
+            var responseEmbedBuilder = new EmbedBuilder()
+                .WithAuthor(new EmbedAuthorBuilder().WithName("Banned Users").WithIconUrl("https://cdn.discordapp.com/avatars/514257192803893272/47be266c55cab32eacfb33c9affc82dd.webp")).WithColor(Color.DarkRed)
+                        .WithDescription($"Users Banned from {guildName}\n\n" +
+                        $"{(userList.Length > 1600 ? "_(List too large for Discord - see attached file)_\n" : userList)}");
+
+            //Catch content that is too large, respond with file instead
+            if(userList.Length > 1600) await command.RespondWithFileAsync(new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(userList.Replace("<@", "").Replace(">", ""))), "BannedUsers.txt"), text: "", embed: responseEmbedBuilder.Build());
+            else await command.RespondAsync(content: "", embed: responseEmbedBuilder.Build());
         }
 
         [SlashCommand(Description = "Remove the ban placed on a user, and their associated EID(s)", ParentCommand = "b", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
-        public static async Task RemoveBan(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, [SlashParam(Description = "Discord ID of user to unban")] ulong discordid) {
-            var user = db.DBUsers.FirstOrDefault(u => u.DiscordId == discordid);
-            if(user is null || !user.Banned) {
+        public static async Task RemoveBan(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, [SlashParam(Description = "Discord ID of user to unban")] SocketUser user) {
+            var dbuser = db.DBUsers.FirstOrDefault(u => u.DiscordId == user.Id);
+            if(dbuser is null || !dbuser.Banned) {
                 await command.RespondAsync("Could not find a banned user with that ID in the DB.");
                 return;
             }
-            user.Banned = false;
+            dbuser.Banned = false;
             await db.SaveChangesAsync();
 
-            var socketGuild = _client.GetGuild(command.GuildId ?? user.GuildId);
-            var targetUser = socketGuild.GetUser(discordid);
+            var socketGuild = _client.GetGuild(command.GuildId ?? dbuser.GuildId);
+            var targetUser = socketGuild.GetUser(user.Id);
             //Check if running user has ban perms
             var runningUser = socketGuild?.Users?.ToList().FirstOrDefault(u => u.Id == command.User.Id);
             if(runningUser is not null && runningUser.GuildPermissions.ToList().Contains(GuildPermission.BanMembers)) {

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -581,9 +581,9 @@ namespace EGG9000.Bot.Commands {
                 } else {
                     lastBuilder.Footer.Text += $"\nNot registered with a guild";
                 }
-            } else if(dbuser.GuildId == guild.Id && !dbuser.TempDisabled) {
+            } else if(guild is not null && dbuser.GuildId == guild.Id && !dbuser.TempDisabled) {
                 lastBuilder.Footer.Text += $"\nProperly registered with this server";
-            } else if(dbuser.GuildId != guild.Id) {
+            } else if(guild is null || dbuser.GuildId != guild.Id) {
                 lastBuilder.Footer.Text += $"\nNot registered with this server, try the /moveserver command";
             }
 
@@ -593,7 +593,7 @@ namespace EGG9000.Bot.Commands {
                 lastBuilder.Footer.Text += $"\nMissing bot registration date";
             }
 
-            if(dbuser.GuildId > 0 && !dbuser.TempDisabled && user is SocketGuildUser && guild.Id == (user as SocketGuildUser).Guild.Id) {
+            if(guild is not null && dbuser.GuildId > 0 && !dbuser.TempDisabled && user is SocketGuildUser && guild.Id == (user as SocketGuildUser).Guild.Id) {
                 _ = await DiscordHelpers.CheckRoles(db, _client.GetGuild(dbuser.GuildId), (SocketGuildUser)user, dbuser, _client, null, new List<LeaderboardUser>());
             }
 
@@ -896,9 +896,9 @@ namespace EGG9000.Bot.Commands {
                 var runningUser = _client.Guilds?.FirstOrDefault(g => g.Id == command.GuildId)?.Users?.ToList().FirstOrDefault(u => u.Id == command.User.Id);
                 if(banaccount && runningUser is not null && runningUser.GuildPermissions.ToList().Contains(GuildPermission.BanMembers)) await targetUser.BanAsync();
                 else await targetUser.KickAsync();
-                await command.ModifyOriginalResponseAsync(x => { x.Content = $"Kicked <@{targetUser}> with DM"; });
+                await command.ModifyOriginalResponseAsync(x => { x.Content = $"Kicked <@{targetUser.Id}> with DM"; });
             } catch(HttpException) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = $"Unable to send DM, <@{targetUser}> was not kicked"; });
+                await command.ModifyOriginalResponseAsync(x => { x.Content = $"Unable to send DM, <@{targetUser.Id}> was not kicked"; });
             }
         }
     }

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -41,14 +41,12 @@ using EGG9000.Common.Extensions;
 using EGG9000.Bot.Automated.Coops;
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 using static EGG9000.Bot.Commands.ContractCommandsSlash;
-using System.Numerics;
-using AutoMapper;
 
 namespace EGG9000.Bot.Services {
 
     public class UserNotInServerException : Exception {
         public ulong User { get; }
-        public UserNotInServerException(string message, ulong user) : base(message) {
+        public UserNotInServerException(string message, ulong user) : base(message) { 
             User = user;
         }
     }

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -53,15 +53,6 @@ namespace EGG9000.Bot.Services {
         }
     }
 
-    public class NumOverflowException : Exception {
-        public Type ExpectedType { get; }
-        public BigInteger ProvidedValue { get; }
-        public NumOverflowException(Type expectedType, BigInteger providedValue) {
-            ExpectedType = expectedType;
-            ProvidedValue = providedValue;
-        }
-    }
-
     public class CommandService : IHostedService {
         private readonly DiscordHostedService _discord;
         private List<SlashCommandFunction> _slashCommandFunctions;
@@ -213,8 +204,6 @@ namespace EGG9000.Bot.Services {
                     await (Task)command.MethodInfo.Invoke(null, parameters.ToArray());
                 } catch(UserNotInServerException unfe) {
                     await arg.RespondAsync(text: "", embed: EmbedError($"Could not convert the id `{unfe.User}` to a `SocketGlobalUser` instance.\nUser (<@{unfe.User}>) may not be in the server anymore."));
-                } catch(NumOverflowException nofe) {
-                    await arg.RespondAsync(text: "", embed: EmbedError($"Provided value `{nofe.ProvidedValue}` does not fall within the bounds of expected type `{nofe.ExpectedType}`."));
                 } catch(Exception e) {
                     try {
                         _bugsnag.Notify(e);
@@ -428,16 +417,6 @@ namespace EGG9000.Bot.Services {
                         throw new UserNotInServerException(ex.Message, (value as SocketUser).Id);
                     }
                 }
-
-                if(parameterInfo.ParameterType == typeof(int) ||  parameterInfo.ParameterType == typeof(long)) { 
-                    var value = FindOption(name, fauxCommand.Data.Options)?.Value;
-                    try {
-                        dynamic changedObj = Convert.ChangeType(value, parameterInfo.ParameterType);
-                    } catch(OverflowException) {
-                        throw new NumOverflowException(parameterInfo.ParameterType, BigInteger.Parse(value.ToString()));
-                    }
-                }
-
                 if(parameterInfo.ParameterType.IsEnum) {
                     var value = FindOption(name, fauxCommand.Data.Options)?.Value;
                     return value == null ? null : Enum.Parse(parameterInfo.ParameterType, value.ToString());

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -41,13 +41,24 @@ using EGG9000.Common.Extensions;
 using EGG9000.Bot.Automated.Coops;
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 using static EGG9000.Bot.Commands.ContractCommandsSlash;
+using System.Numerics;
+using AutoMapper;
 
 namespace EGG9000.Bot.Services {
 
     public class UserNotInServerException : Exception {
         public ulong User { get; }
-        public UserNotInServerException(string message, ulong user) : base(message) { 
+        public UserNotInServerException(string message, ulong user) : base(message) {
             User = user;
+        }
+    }
+
+    public class NumOverflowException : Exception {
+        public Type ExpectedType { get; }
+        public BigInteger ProvidedValue { get; }
+        public NumOverflowException(Type expectedType, BigInteger providedValue) {
+            ExpectedType = expectedType;
+            ProvidedValue = providedValue;
         }
     }
 
@@ -202,6 +213,8 @@ namespace EGG9000.Bot.Services {
                     await (Task)command.MethodInfo.Invoke(null, parameters.ToArray());
                 } catch(UserNotInServerException unfe) {
                     await arg.RespondAsync(text: "", embed: EmbedError($"Could not convert the id `{unfe.User}` to a `SocketGlobalUser` instance.\nUser (<@{unfe.User}>) may not be in the server anymore."));
+                } catch(NumOverflowException nofe) {
+                    await arg.RespondAsync(text: "", embed: EmbedError($"Provided value `{nofe.ProvidedValue}` does not fall within the bounds of expected type `{nofe.ExpectedType}`."));
                 } catch(Exception e) {
                     try {
                         _bugsnag.Notify(e);
@@ -416,6 +429,15 @@ namespace EGG9000.Bot.Services {
                     }
                 }
 
+                if(parameterInfo.ParameterType == typeof(int) ||  parameterInfo.ParameterType == typeof(long)) { 
+                    var value = FindOption(name, fauxCommand.Data.Options)?.Value;
+                    try {
+                        dynamic changedObj = Convert.ChangeType(value, parameterInfo.ParameterType);
+                    } catch(OverflowException) {
+                        throw new NumOverflowException(parameterInfo.ParameterType, BigInteger.Parse(value.ToString()));
+                    }
+                }
+
                 if(parameterInfo.ParameterType.IsEnum) {
                     var value = FindOption(name, fauxCommand.Data.Options)?.Value;
                     return value == null ? null : Enum.Parse(parameterInfo.ParameterType, value.ToString());
@@ -556,7 +578,8 @@ namespace EGG9000.Bot.Services {
             };
 
             if(types.Any(x => x.Key == parameterInfo.ParameterType)) {
-                AddOption(name, types.First(x => x.Key == parameterInfo.ParameterType).Value, description: slashParamDetails.Description, isRequired: slashParamDetails.Required, isAutocomplete: slashParamDetails.AutocompleteHandler is not null, guildCommand, subCommand);
+                var maxVal = parameterInfo.ParameterType == typeof(int) ? int.MaxValue : double.MinValue;
+                AddOption(name, types.First(x => x.Key == parameterInfo.ParameterType).Value, description: slashParamDetails.Description, isRequired: slashParamDetails.Required, isAutocomplete: slashParamDetails.AutocompleteHandler is not null, positiveOnly: slashParamDetails.PositiveOnly, maxValue: maxVal, guildCommand, subCommand);
                 return;
             }
             if(parameterInfo.ParameterType.IsEnum) {
@@ -567,24 +590,23 @@ namespace EGG9000.Bot.Services {
                         Value = Convert.ToInt32(value)
                     });
                 }
-                AddOption(name, ApplicationCommandOptionType.Integer, description: slashParamDetails.Description, isRequired: slashParamDetails.Required, isAutocomplete: slashParamDetails.AutocompleteHandler is not null, guildCommand, subCommand, choices.ToArray());
+                AddOption(name, ApplicationCommandOptionType.Integer, description: slashParamDetails.Description, isRequired: slashParamDetails.Required, isAutocomplete: slashParamDetails.AutocompleteHandler is not null, positiveOnly: slashParamDetails.PositiveOnly, maxValue: double.MinValue, guildCommand, subCommand, choices.ToArray());
                 return;
             }
             if(parameterInfo.ParameterType == typeof(SocketGuildUser[])) {
                 for(var i = 1; i <= 10; i++) {
-                    AddOption($"{name}{i}", ApplicationCommandOptionType.User, description: $"{slashParamDetails.Description} {i}", isRequired: i > 1 ? false : slashParamDetails.Required, isAutocomplete: slashParamDetails.AutocompleteHandler is not null, guildCommand, subCommand);
+                    AddOption($"{name}{i}", ApplicationCommandOptionType.User, description: $"{slashParamDetails.Description} {i}", isRequired: i > 1 ? false : slashParamDetails.Required, isAutocomplete: slashParamDetails.AutocompleteHandler is not null, positiveOnly: slashParamDetails.PositiveOnly, maxValue: double.MinValue, guildCommand, subCommand);
                 }
                 return;
             }
             throw new NotImplementedException($"Parameter not implemented for {parameterInfo.Name} of type {parameterInfo.ParameterType}");
         }
 
-        private void AddOption(string name, ApplicationCommandOptionType type, string description, bool isRequired, bool isAutocomplete, SlashCommandBuilder guildCommand = null, SlashCommandOptionBuilder subCommand = null, params ApplicationCommandOptionChoiceProperties[] choices) {
+        private void AddOption(string name, ApplicationCommandOptionType type, string description, bool isRequired, bool isAutocomplete, bool positiveOnly, double maxValue, SlashCommandBuilder guildCommand = null, SlashCommandOptionBuilder subCommand = null, params ApplicationCommandOptionChoiceProperties[] choices) {
             if(guildCommand != null) {
-
-                guildCommand.AddOption(name, type, description, isRequired, null, isAutocomplete: isAutocomplete, null, null, null, null, null, null, null, null, choices);
+                guildCommand.AddOption(name, type, description, isRequired, null, isAutocomplete: isAutocomplete, minValue: positiveOnly ? 0 : null, maxValue: maxValue == double.MinValue ? null : maxValue, null, null, null, null, null, null, choices);
             } else {
-                subCommand.AddOption(name, type, description, isRequired, false, isAutocomplete: isAutocomplete, null, null, null, null, null, null, null, null, choices);
+                subCommand.AddOption(name, type, description, isRequired, false, isAutocomplete: isAutocomplete, minValue: positiveOnly ? 0 : null, maxValue: maxValue == double.MinValue ? null : maxValue, null, null, null, null, null, null, choices);
             }
 
         }

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -161,6 +161,10 @@ namespace EGG9000.Common.Services {
                 }
             }
 
+#if DEV9002
+            return;
+#endif
+
             var welcomeChannel = await _discord.GetChannelAsync(GuildChannelType.Welcome, user.Guild);
             var rulesChannel = await _discord.GetChannelAsync(GuildChannelType.Rules, user.Guild);
             var msg = $"Welcome to the server {user.Mention}! Please read {rulesChannel.Mention} and then use the </accept:1095116354329268368> command when you are ready.";

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Text.RegularExpressions;
-using Discord.Net.Udp;
 using EGG9000.Bot;
 using EGG9000.Bot.EggIncAPI;
 using EGG9000.Common.Database.Entities;

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Text.RegularExpressions;
+using Discord.Net.Udp;
 using EGG9000.Bot;
 using EGG9000.Bot.EggIncAPI;
 using EGG9000.Common.Database.Entities;

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -191,11 +191,11 @@ namespace EGG9000.Common.Helpers {
         }
 
         public static string GetAfxSetString(List<EggIncArtifactInstance> set) {
-            return string.Join("\n", set.Select(s => ArtifactHelpers.GetAfEmoji(s) + ArtifactHelpers.GetRarityEmoji(s) + string.Join("", s.Stones.Select(st => ArtifactHelpers.GetAfEmoji(st)).ToList())));
+            return string.Join("\n", set.Select(GetAfxString));
         }
 
         public static string GetAfxString(EggIncArtifactInstance instance) {
-            return ArtifactHelpers.GetAfEmoji(instance) + ArtifactHelpers.GetRarityEmoji(instance) + string.Join("", instance.Stones.Select(st => ArtifactHelpers.GetAfEmoji(st))).ToString();
+            return GetAfEmoji(instance) + GetRarityEmoji(instance) + string.Join("", instance.Stones.Select(GetAfEmoji)).ToString();
         }
 
         #region InventoryImages

--- a/EGG9000.Common/Services/CommandAttributes.cs
+++ b/EGG9000.Common/Services/CommandAttributes.cs
@@ -41,6 +41,7 @@ namespace EGG9000.Common.Commands {
         public string Description = "";
         public bool Required = true;
         public Type AutocompleteHandler;
+        public bool PositiveOnly = false;
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]


### PR DESCRIPTION
- Add logic to "Find a coop spot for a user" method to allow offerings of any-grade coops
- Fix IDs in kick messages
- Defer MoveToCoop, change to embed messages
- Fix an issue in register commands where `Userstatus` would error out if the user did not have a guild set (left the server, etc.)