### PR TITLE
Daveed changes

### DIFF
--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -1144,9 +1144,9 @@ namespace EGG9000.Bot.Automated.Coops {
                         .WithDescription($"{gradeMessage}{highestEBMessage}{createdByMessage}{publicMessage}\n" + 
                         (
                             (status.Finished()
-                            ? "This co-op is finished!"
+                            ? "\nThis co-op is finished!"
                             : coopDetails.PercentProjectedForJoined >= 100 && !coop.FinishedOrFailed()
-                            ? "This co-op is projected to succeed without growth as long as there are no sleepers!"
+                            ? "\nThis co-op is projected to succeed without growth as long as there are no sleepers!"
                             : "") + $"\n[View on egg9000.com](https://egg9000.com/coop/{coop.ContractID}/{coop.Name})"
                         ))
                         .WithColor(color)

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -795,17 +795,16 @@ namespace EGG9000.Bot.Automated.Coops {
                                     if(!xref.JoinWarning24TillFinish && timeRemaining.TotalHours < 24 && xref.CreatedOn < DateTimeOffset.Now.AddHours(-1)) {
                                         xref.JoinWarning24TillFinish = true;
                                         await _db.SaveChangesAsync();
-                                        await SendDMWarning(db, discordUser, coopChannel, $"{discordUser.Mention} reminder to join - co-op will be finished in under {Math.Ceiling(timeRemaining.TotalHours)} hours", coop);
+                                        await SendDMWarning(db, discordUser, coopChannel, $"reminder to join - co-op will be finished in under {Math.Ceiling(timeRemaining.TotalHours)} hours", coop);
                                     } else if(!xref.JoinWarning24h && xref.CreatedOn < DateTimeOffset.Now.AddHours(-24)) {
                                         xref.JoinWarning24h = true;
                                         xref.JoinWarning12h = true;
                                         await _db.SaveChangesAsync();
-                                        //await coopChannel.SendMessageAsync($"{discordUser.Mention} reminder to join - 24h since added to co-op");
-                                        await SendDMWarning(db, discordUser, coopChannel, $"{discordUser.Mention} reminder to join - 24h since added to co-op", coop);
+                                        await SendDMWarning(db, discordUser, coopChannel, $"reminder to join - 24h since added to co-op", coop);
                                     } else if(!xref.JoinWarning12h && xref.CreatedOn < DateTimeOffset.Now.AddHours(-12)) {
                                         xref.JoinWarning12h = true;
                                         await _db.SaveChangesAsync();
-                                        await SendDMWarning(db, discordUser, coopChannel, $"{discordUser.Mention} reminder to join - 12h since added to co-op", coop);
+                                        await SendDMWarning(db, discordUser, coopChannel, $"reminder to join - 12h since added to co-op", coop);
                                     }
 
 

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -32,6 +32,7 @@ using static Ei.Backup.Types;
 using Microsoft.AspNetCore.Http;
 using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 using EGG9000.Bot.Common.Helpers;
+using EGG9000.Common.Contracts;
 
 namespace EGG9000.Bot.Automated.Coops {
     public class CoopStatusUpdater : _UpdaterBase<CoopStatusUpdater> {
@@ -784,7 +785,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
                                 if(userFarmDetails.Account is not null || userFarmDetails.Backup is not null) {
                                     var grade = userFarmDetails.Account?.GetGrade() ?? userFarmDetails.Backup.Grade;
-                                    if((uint)grade != coop.League && !coop.Contract.cc_only) {
+                                    if((uint)grade != coop.League && !(coop.Contract.cc_only || coop.AnyLeague)) {
                                         mention += $" (Wrong {grade})";
                                     }
                                 }
@@ -904,8 +905,10 @@ namespace EGG9000.Bot.Automated.Coops {
                     lastMessage += $"\n</fixfullcooperror:{slashCommands.FirstOrDefault(c => c.Name.ToLower() == "fixfullcooperror")?.Id ?? 0}> **NEW!** If you get the error co-op is full, try running this command to free up the space.";
 
 
-
-                    lastMessage += $"\n\nCo-op Grade: {(Ei.Contract.Types.PlayerGrade)(int)coop.League}";
+                    lastMessage += $"\n\nCo-op Grade: {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)coop.League)}";
+                    if(coop.AnyLeague) {
+                        lastMessage += " (<:ultra:1131045418319495369> Any-Grade)";
+                    }
 
 
                     if(!string.IsNullOrEmpty(coop.CreatorID)) {

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -1122,23 +1122,23 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(lastMessage != "")
                             msgs.AddRange(DiscordMessageSplitter.SplitMessage(lastMessage, "\n"));
 
-                        var gradeMessage = $"**Co-op Grade**: {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)coop.League)}{(coop.AnyLeague ? " (<:ultra:1131045418319495369> **Any-Grade**)" : "")}\n";
+                        var gradeMessage = $"**Co-op Grade**: {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)coop.League)}{(coop.AnyLeague ? " (<:ultra:1131045418319495369> **Any-Grade**)" : "")}";
 
                         var highestEB = coopDetails.CoopParticipants.Where(x => x.Backup is not null).OrderByDescending(x => x.Backup.EarningsBonus).FirstOrDefault();
                         var highestEBMessage = "";
                         if(highestEB != null)
-                            highestEBMessage = $"**Highest EB**: {highestEB.DBUser.DiscordUsername} at {highestEB.Backup.EarningsBonus.ToEggString()} {(usersNotJoined.Any(x => x?.EggIncId == highestEB.Backup.EggIncId) ? "has not joined yet." : "**has joined!**")}\n";
+                            highestEBMessage = $"**\nHighest EB**: {highestEB.DBUser.DiscordUsername} at {highestEB.Backup.EarningsBonus.ToEggString()} {(usersNotJoined.Any(x => x?.EggIncId == highestEB.Backup.EggIncId) ? "has not joined yet." : "**has joined!**")}";
 
                         var createdByMessage = "";
                         if(!string.IsNullOrEmpty(coop.CreatorID)) {
                             var creator = users.FirstOrDefault(x => x.Backup?.EggIncId == coop.CreatorID);
                             if(creator != null) {
                                 var account = creator.User.EggIncAccounts.First(x => x.Id == coop.CreatorID);
-                                createdByMessage += $"**Created By**: {creator.User.DiscordUsername} {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)account.LastGrade)}\n";
+                                createdByMessage += $"**\nCreated By**: {creator.User.DiscordUsername} {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)account.LastGrade)}";
                             }
                         }
 
-                        var publicMessage = status.Public ? $"**This co-op is public**.\n" : "";
+                        var publicMessage = status.Public ? $"**\nThis co-op is public**." : "";
 
                         var embedBuilder = new EmbedBuilder()
                         .WithDescription($"{gradeMessage}{highestEBMessage}{createdByMessage}{publicMessage}\n" + 

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -838,12 +838,6 @@ namespace EGG9000.Bot.Automated.Coops {
                         lastMessage += $"Coop **{coop.Name}** is ready for the following to join: {string.Join(", ", userList)}\n";
                     }
 
-                    if(status.Public) {
-                        lastMessage += $"This co-op is public.\n";
-                    }
-
-
-
 
                     //var usersAssigned = coop.UserCoopsXrefs.Select(x => {
                     //    var User = users.FirstOrDefault(y => y.Id == x.GetID());
@@ -857,9 +851,6 @@ namespace EGG9000.Bot.Automated.Coops {
                     //        Backup = User.Backups?.First(y => y.EggIncId == x.EggIncId)
                     //    };
                     //}).Where(x => x != null);
-                    var highestEB = coopDetails.CoopParticipants.Where(x => x.Backup is not null).OrderByDescending(x => x.Backup.EarningsBonus).FirstOrDefault();
-                    if(highestEB != null)
-                        lastMessage += $"Highest EB: {highestEB.DBUser.DiscordUsername} at {highestEB.Backup.EarningsBonus.ToEggString()} {(usersNotJoined.Any(x => x?.EggIncId == highestEB.Backup.EggIncId) ? "has not joined yet." : "**has joined!**")}\n";
 
 
                     var giftInfos = usersWithStatus.Where(x => x.Status is not null && x.Status.FarmInfo is not null && x.FarmStats is not null).Select(x => new {
@@ -889,9 +880,9 @@ namespace EGG9000.Bot.Automated.Coops {
                                 new FixedWidthCell($"{Math.Round(x.Habs)}%", CellAlignment.Right),
                                 new FixedWidthCell($"{Math.Round(x.Shipping)}%", CellAlignment.Right),
                             }).ToList());
-                        lastMessage += $"\nFarms that would benefit from gifting chickens: \n```{string.Join("\n", GetTable(table))}```\n";
+                        lastMessage += $"\nFarms that would benefit from gifting chickens: \n```{string.Join("\n", GetTable(table))}```\n\n";
                     } else if(coopDetails.CoopParticipants.Any(y => y.CoopStatus is not null && y.FarmStats is not null)) {
-                        lastMessage += "\nLooks like everyone's shipping and/or habs are full or they haven't joined yet, so gifting chickens isn't useful.\n";
+                        lastMessage += "\nLooks like everyone's shipping and/or habs are full or they haven't joined yet, so gifting chickens isn't useful.\n\n";
                     }
 
                     //New commands list, each is a quick-link to start using the command
@@ -903,22 +894,6 @@ namespace EGG9000.Bot.Automated.Coops {
                     }
                     lastMessage += $"\n</coopsettings:{slashCommands.FirstOrDefault(c => c.Name.ToLower() == "coopsettings")?.Id ?? 0}> Receive DM pings for various events in the co-op";
                     lastMessage += $"\n</fixfullcooperror:{slashCommands.FirstOrDefault(c => c.Name.ToLower() == "fixfullcooperror")?.Id ?? 0}> **NEW!** If you get the error co-op is full, try running this command to free up the space.";
-
-
-                    lastMessage += $"\n\nCo-op Grade: {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)coop.League)}";
-                    if(coop.AnyLeague) {
-                        lastMessage += " (<:ultra:1131045418319495369> Any-Grade)";
-                    }
-
-
-                    if(!string.IsNullOrEmpty(coop.CreatorID)) {
-                        var creator = users.FirstOrDefault(x => x.Backup?.EggIncId == coop.CreatorID);
-                        if(creator != null) {
-                            var account = creator.User.EggIncAccounts.First(x => x.Id == coop.CreatorID);
-                            lastMessage += $"\nCreated By {creator.User.DiscordUsername} {account.LastGrade}";
-
-                        }
-                    }
 
 
 
@@ -1147,15 +1122,33 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(lastMessage != "")
                             msgs.AddRange(DiscordMessageSplitter.SplitMessage(lastMessage, "\n"));
 
+                        var gradeMessage = $"**Co-op Grade**: {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)coop.League)}{(coop.AnyLeague ? " (<:ultra:1131045418319495369> **Any-Grade**)" : "")}\n";
+
+                        var highestEB = coopDetails.CoopParticipants.Where(x => x.Backup is not null).OrderByDescending(x => x.Backup.EarningsBonus).FirstOrDefault();
+                        var highestEBMessage = "";
+                        if(highestEB != null)
+                            highestEBMessage = $"**Highest EB**: {highestEB.DBUser.DiscordUsername} at {highestEB.Backup.EarningsBonus.ToEggString()} {(usersNotJoined.Any(x => x?.EggIncId == highestEB.Backup.EggIncId) ? "has not joined yet." : "**has joined!**")}\n";
+
+                        var createdByMessage = "";
+                        if(!string.IsNullOrEmpty(coop.CreatorID)) {
+                            var creator = users.FirstOrDefault(x => x.Backup?.EggIncId == coop.CreatorID);
+                            if(creator != null) {
+                                var account = creator.User.EggIncAccounts.First(x => x.Id == coop.CreatorID);
+                                createdByMessage += $"**Created By**: {creator.User.DiscordUsername} {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)(int)account.LastGrade)}\n";
+                            }
+                        }
+
+                        var publicMessage = status.Public ? $"**This co-op is public**.\n" : "";
 
                         var embedBuilder = new EmbedBuilder()
-                        .WithDescription(
+                        .WithDescription($"{gradeMessage}{highestEBMessage}{createdByMessage}{publicMessage}\n" + 
+                        (
                             (status.Finished()
                             ? "This co-op is finished!"
                             : coopDetails.PercentProjectedForJoined >= 100 && !coop.FinishedOrFailed()
                             ? "This co-op is projected to succeed without growth as long as there are no sleepers!"
                             : "") + $"\n[View on egg9000.com](https://egg9000.com/coop/{coop.ContractID}/{coop.Name})"
-                        )
+                        ))
                         .WithColor(color)
                         .WithTimestamp(DateTimeOffset.UtcNow)
                         .WithAuthor(new EmbedAuthorBuilder().WithName($"{coop.Contract.Name} - Coop Code: {coop.Name}").WithIconUrl(EggIncEggs.GetEggById((int)coop.Contract.Details.Egg).Image))

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -1165,13 +1165,10 @@ namespace EGG9000.Bot.Automated.Coops {
 
 
                         var ends = DiscordHelpers.TimeStamper(TimeSpan.FromSeconds(status.SecondsRemaining));
-                        //var ends = TimeSpan.FromSeconds(status.SecondsRemaining).Humanize(precision: 2).ShortenTime();
-
-                        if(status.SecondsRemaining <= 0)
+                        if(status.SecondsRemaining <= 0) {
                             ends = $"Expired {ends}";
-                        //ends = $"Expired {ends} ago";
-
-
+                            if(!coop.PseudoExpired) coop.PseudoExpired = true;
+                        }
 
                         for(var i = 0; i < 3; i++) {
                             if(coop.Contract.Details.GetGoals(league).Count > i) {

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -896,11 +896,12 @@ namespace EGG9000.Bot.Automated.Coops {
                     //New commands list, each is a quick-link to start using the command
                     lastMessage += "__Co-op Commands (click to use):__\n";
 
+                    var slashCommands = (await guild.GetApplicationCommandsAsync()).ToList().Where(c => c.Type == ApplicationCommandType.Slash).ToList();
                     if(_client.GetChannelAsync(GuildChannelType.CallStaffChannel, guild) != null) {
-                        lastMessage += "\n</callstaff:1095116334599241747> Use this command if you joined a co-op for the wrong contract, or have other questions or concerns";
+                        lastMessage += $"\n</callstaff:{slashCommands.FirstOrDefault(c => c.Name.ToLower() == "callstaff")?.Id ?? 0}> Use this command if you joined a co-op for the wrong contract, or have other questions or concerns";
                     }
-                    lastMessage += "\n</coopsettings:1107809801469173933> Receive DM pings for various events in the co-op";
-                    lastMessage += "\n</fixfullcooperror:1111043604178276463> **NEW!** If you get the error co-op is full, try running this command to free up the space.";
+                    lastMessage += $"\n</coopsettings:{slashCommands.FirstOrDefault(c => c.Name.ToLower() == "coopsettings")?.Id ?? 0}> Receive DM pings for various events in the co-op";
+                    lastMessage += $"\n</fixfullcooperror:{slashCommands.FirstOrDefault(c => c.Name.ToLower() == "fixfullcooperror")?.Id ?? 0}> **NEW!** If you get the error co-op is full, try running this command to free up the space.";
 
 
 

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -38,7 +38,7 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                 foreach(var account in accounts.DistinctBy(x => x.Account.Id)) {
                     if(account.User.EggIncAccounts.Count > 1) {
                         var name = account.Account.Backup?.UserName;
-                        results.Add(new AutocompleteResult($"{account.User.DiscordUsername} - {name ?? account.Account.Backup?.UserName ?? "(No Name)"} {account.Account.Backup.EarningsBonus.ToEggString()}", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
+                        results.Add(new AutocompleteResult($"{account.User.DiscordUsername} - {name ?? account.Account.Backup?.UserName ?? "(No Name)"} ({account.Account.Backup.EarningsBonus.ToEggString()})", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
                     } else {
                         results.Add(new AutocompleteResult($"{account.User.DiscordUsername}", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
                     }
@@ -183,12 +183,12 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                 _db = db;
             }
             public async Task Run(SocketAutocompleteInteraction arg) {
-                var users = await _db.UserCoopXrefs.Where(x => x.Coop.DiscordChannelId == arg.Channel.Id).Select(x => new { x.UserId, x.EggIncId, x.User.DiscordUsername }).ToListAsync();
+                var users = await _db.UserCoopXrefs.Where(x => x.Coop.DiscordChannelId == arg.Channel.Id).Select(x => new { x.UserId, x.EggIncId, x.User.DiscordUsername, x.User }).ToListAsync();
                 if(users.Count == 0) await arg.RespondAsync("Command only works in a co-op channel and where users are assigned.");
                 if(!string.IsNullOrWhiteSpace((string)arg.Data.Current.Value)) {
                     users = users.Where(x => x.DiscordUsername.Contains((string)arg.Data.Current.Value, StringComparison.OrdinalIgnoreCase)).ToList();
                 }
-                await arg.RespondAsync(users.DistinctBy(x => x.EggIncId).ToList().Select(x => new AutocompleteResult(x.DiscordUsername, x.UserId.ToString())));
+                await arg.RespondAsync(users.DistinctBy(x => x.EggIncId).ToList().Select(x => new AutocompleteResult(x.DiscordUsername + " - " + x.User.EggIncAccounts.FirstOrDefault(a => a.Id == x.EggIncId)?.Backup?.UserName ?? "(No Name)", x.UserId.ToString())));
             }
         }
         #endregion

--- a/EGG9000.Bot/Commands/ContextUserCommands.cs
+++ b/EGG9000.Bot/Commands/ContextUserCommands.cs
@@ -39,14 +39,14 @@ namespace EGG9000.Bot.Commands {
         [UserCommand(Name = "Rockets Tracker", AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task RocketsTrackerLinks(SocketUserCommand command, ApplicationDbContext db)
         {
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.Data.Member.Id);
-            if(user == null) {
-                await command.RespondAsync(text: "", embed: EmbedError("Unable to find backups for this user"));
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.Data.Member.Id);
+            if(dbUser == null) {
+                await command.RespondAsync(text: "", embed: EmbedError($"Unable to locate DBUser entry for <@{command.Data.Member.Id}>"));
                 return;
             } else {
                 var sb = new StringBuilder();
-                foreach(var id in user.EggIncAccounts) {
-                    var backup = user.EggIncAccounts.FirstOrDefault(x => x.Id == id.Id).Backup;
+                foreach(var id in dbUser.EggIncAccounts) {
+                    var backup = dbUser.EggIncAccounts.FirstOrDefault(x => x.Id == id.Id).Backup;
                     if(sb.ToString() != "") sb.Append("\n\n");
                     sb.Append(backup.UserName + ": " + $"<https://wasmegg-carpet.netlify.app/rockets-tracker/?playerId={id.Id}>");
                 }

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -499,7 +499,12 @@ namespace EGG9000.Bot.Commands {
                 xref = await db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == targetuser.Id && x.Coop.DiscordChannelId == command.Channel.Id);
             }
             if(xref == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find user assignment to co-op"); });
+                var moveText = "";
+                var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == command.GuildId || g.OverflowServersJson.Contains(command.GuildId.ToString()));
+                if(dbGuild is not null) {
+                    moveText = "A </movetocoop:" + (await discord.GetGuild(dbGuild.Id).GetApplicationCommandsAsync()).FirstOrDefault(c => c.Type == ApplicationCommandType.Slash && c.Name == "movetocoop").Id + "> may be needed.";
+                }
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find user assignment to co-op.\n{moveText}"); });
                 return;
             }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -272,6 +272,7 @@ namespace EGG9000.Bot.Commands {
                 && c.CurrentUsers < c.MaxUsers
                 && (int)c.Status > 2 && (int)c.Status < 13
                 && c.CoopEnds > DateTimeOffset.Now
+                && !c.PseudoExpired
                 && c.ProjectedFinish > DateTimeOffset.Now
             ).ToListAsync();
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -265,9 +265,15 @@ namespace EGG9000.Bot.Commands {
                 return new PotentialCoopResponse { Response = PotentialCoopCode.NoGrade };
             }
 
-            var coops = await db.Coops.Include(c => c.Contract).Include(c => c.UserCoopsXrefs).Where(c => c.Contract == contract && c.GuildId == guild.Id 
-             && (c.League == (uint)account.GetGrade() || c.AnyLeague)
-             && c.CurrentUsers < c.MaxUsers && (int)c.Status > 2 && (int)c.Status < 13 && c.CoopEnds > DateTimeOffset.Now && c.ProjectedFinish > DateTimeOffset.Now).ToListAsync();
+            var coops = await db.Coops.Include(c => c.Contract).Include(c => c.UserCoopsXrefs).Where(c =>
+                c.Contract == contract
+                && c.GuildId == guild.Id
+                && (c.League == (uint)account.GetGrade() || c.AnyLeague)
+                && c.CurrentUsers < c.MaxUsers
+                && (int)c.Status > 2 && (int)c.Status < 13
+                && c.CoopEnds > DateTimeOffset.Now
+                && c.ProjectedFinish > DateTimeOffset.Now
+            ).ToListAsync();
 
             if(!coops.Any()) {
                 return new PotentialCoopResponse { Response = PotentialCoopCode.NoSpots1 };

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -581,8 +581,8 @@ namespace EGG9000.Bot.Commands {
             }
 
             var userid = Guid.Parse(useraccount.Split("|")[0]);
-
             var xref = await db.UserCoopXrefs.Include(x => x.User).Where(xref => xref.UserId == userid && xref.CoopId == targetCoop.Id).OrderBy(x => x.JoinedCoop).FirstOrDefaultAsync();
+            var username = xref.User.EggIncAccounts.FirstOrDefault(x => x.Id == xref.EggIncId)?.Backup?.UserName ?? "(No Name)";
 
             if(xref == null) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find user in co-op"); });
@@ -592,7 +592,7 @@ namespace EGG9000.Bot.Commands {
             db.Remove(xref);
             await db.SaveChangesAsync();
 
-            await command.ModifyOriginalResponseAsync(x => x.Content = $"Removed <@{xref.User.DiscordId}> from co-op");
+            await command.ModifyOriginalResponseAsync(x => x.Content = $"Removed <@{xref.User.DiscordId}> ({username}) from co-op");
 
         }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -87,12 +87,18 @@ namespace EGG9000.Bot.Commands {
 
             var details = new CoopDetails(coop, coop.Contract, coop.League, coop.UserCoopsXrefs.SelectMany(y => y.User.EggIncAccounts.Select(x => new UserWithBackup { Backup = x.Backup, User = y.User })).ToList(), _client, status);
 
-            if(details is null) { // Edge cases were throwing when details was null
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to locate user in co-op. (Co-op may be, or have been public/late joined)"); });
+            if(details is null || details.CoopParticipants is null || details.CoopParticipants.Count == 0) { // Edge cases were throwing when details was null
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to locate user in co-op. Co-op may be, or may have been public, or user may no longer be assigned to coop."); });
                 return;
             }
 
-            var xref = details.CoopParticipants.FirstOrDefault(x => x.DBUser.Id == dbuser.Id && x.EggsShipped == 0);
+            UserFarmDetails xref = null;
+            try {
+                xref = details.CoopParticipants.FirstOrDefault(x => x.DBUser.Id == dbuser.Id && x.EggsShipped == 0);
+            } catch(Exception) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to locate user in co-op. Co-op may be, or may have been public, or user may no longer be assigned to coop."); });
+                return;
+            }
 
             if(xref is null) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to locate user with zero production."); });

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -711,6 +711,10 @@ namespace EGG9000.Bot.Commands {
                 await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Could not find your record - are you registered correctly?"); });
                 return;
             }
+            if(dbUser.TempDisabled) {
+                await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Looks like you are currently disabled, and therefore cannot be assigned to a co-op."); });
+                return;
+            }
             var dbguild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == component.GuildId);
             if(dbguild is null) {
                 await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"This command must be used in a server.\n\nCome to think of it, how did you even do this?"); });

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -522,7 +522,8 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Move a user to a co-op.", AdminOnly = StaffOnlyLevel.FarmHand)]
-        public static async Task MoveToCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, [SlashParam(AutocompleteHandler = typeof(UserAccountAutoComplete))] string useraccount, [SlashParam(AutocompleteHandler = typeof(MoveToCoopCoopNameAutoComplete))] string coopid) {
+        public static async Task MoveToCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, [SlashParam(AutocompleteHandler = typeof(UserAccountAutoComplete))] string useraccount, 
+            [SlashParam(AutocompleteHandler = typeof(MoveToCoopCoopNameAutoComplete))] string coopid, [SlashParam(Required = false, Description = "If true, will not ping user in coop channel")] bool silent = false) {
             await command.DeferAsync();
 
             var coop = await db.Coops.Include(x => x.Contract).FirstOrDefaultAsync(x => x.Id == Guid.Parse(coopid));
@@ -539,7 +540,7 @@ namespace EGG9000.Bot.Commands {
             var discordUser = _client.GetUser(dbuser.DiscordId);
             var coopChannel = _client.GetChannel(coop.DiscordChannelId);
 
-            var newxref = await CreateCoopsV2.MoveUser(coop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", discordUser, dbuser, (SocketTextChannel)coopChannel, (SocketTextChannel)command.Channel);
+            var newxref = await CreateCoopsV2.MoveUser(coop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", discordUser, dbuser, (SocketTextChannel)coopChannel, (SocketTextChannel)command.Channel, silent);
 
             if(newxref == null) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to add permission for {discordUser.Mention}{(coop.GuildId != coop.OverflowGuildId ? ", possibly not in overflow server" : "")}"); });

--- a/EGG9000.Bot/Commands/ContractSettings.cs
+++ b/EGG9000.Bot/Commands/ContractSettings.cs
@@ -61,7 +61,7 @@ namespace EGG9000.Bot.Commands {
         public static async Task ContractSettings(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketUser user) {
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
-                await command.RespondAsync(content: "", embed: EmbedError("Unable to find user, are they registered?"), ephemeral: !System.Diagnostics.Debugger.IsAttached);
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"), ephemeral: !System.Diagnostics.Debugger.IsAttached);
             } else {
                 await command.RespondAsync("Select which account you would like to manage", components: GetAccountButtons(dbuser, "MCSMenu"), ephemeral: !System.Diagnostics.Debugger.IsAttached);
             }
@@ -73,7 +73,7 @@ namespace EGG9000.Bot.Commands {
         public static async Task MyContractSettings(FauxCommand command, ApplicationDbContext db) {
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(dbuser == null) {
-                await command.RespondAsync(content: "", embed: EmbedError("Unable to find user, are you registered?"), ephemeral: !System.Diagnostics.Debugger.IsAttached);
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"), ephemeral: !System.Diagnostics.Debugger.IsAttached);
             } else {
                 await command.RespondAsync("Select which account you would like to manage", components: GetAccountButtons(dbuser, "MCSMenu"), ephemeral: !System.Diagnostics.Debugger.IsAttached);
             }

--- a/EGG9000.Bot/Commands/ContractSettings.cs
+++ b/EGG9000.Bot/Commands/ContractSettings.cs
@@ -58,7 +58,7 @@ namespace EGG9000.Bot.Commands {
 
         #region AdminBypass
         [SlashCommand(Description = "Set another user's settings", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static async Task ContractSettings(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketGuildUser user) {
+        public static async Task ContractSettings(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketUser user) {
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
                 await command.RespondAsync(content: "", embed: EmbedError("Unable to find user, are they registered?"), ephemeral: !System.Diagnostics.Debugger.IsAttached);

--- a/EGG9000.Bot/Commands/CoopSettings.cs
+++ b/EGG9000.Bot/Commands/CoopSettings.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Bugsnag.Payload;
 
 namespace EGG9000.Bot.Commands {
     public class CoopSettingsCommand {
@@ -20,7 +21,7 @@ namespace EGG9000.Bot.Commands {
             await command.DeferAsync(ephemeral: true);
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(dbuser == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find user, are you registered?"); });
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
             }
 
             var inCoopChannel = await db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.DiscordChannelId == command.ChannelId);

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -103,16 +103,16 @@ namespace EGG9000.Bot.Commands {
                 index = 1;
                 lockSet = false;
             }
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find backups for this user"); });
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
             EggIncAccount account = null;
             int accountIndex = 0;
             try {
                 accountIndex = int.Parse(useraccount.Split("|")[1]);
-                account = user.EggIncAccounts[accountIndex];
+                account = dbUser.EggIncAccounts[accountIndex];
             } catch(Exception) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Please select an account from the list, instead of typing an input."); });
                 return;
@@ -129,7 +129,7 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var builder = AFXSetEmbedBuilder(user, accountIndex, afxSets, afxSets[index - 1]);
+            var builder = AFXSetEmbedBuilder(dbUser, accountIndex, afxSets, afxSets[index - 1]);
             await command.ModifyOriginalResponseAsync(x => {
                 x.Content = "";
                 x.Components = lockSet ? null : builder.ComponentBuilder?.Build();

--- a/EGG9000.Bot/Commands/Informational/ChasingCommand.cs
+++ b/EGG9000.Bot/Commands/Informational/ChasingCommand.cs
@@ -19,39 +19,39 @@ using static EGG9000.Bot.Commands.ContractCommandsSlash;
 namespace EGG9000.Bot.Commands {
     public class ChasingCommand {
         [SlashCommand(Description = "Show you players ahead and behind you.", AllowInDMs = true)]
-        public static async Task Chasing(FauxCommand command, [SlashParam] ChasingParameters parameter, ApplicationDbContext db, DiscordSocketClient discord, ILogger logger) {
+        public static async Task Chasing(FauxCommand command, [SlashParam] ChasingParameters parameter, ApplicationDbContext db, DiscordSocketClient discord) {
             await command.DeferAsync();
 
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find backups for this user"); });
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
 
-            if(user.EggIncAccounts.Count == 1) {
-                var contentString = await ChasingStringBuilder(discord, parameter, user.GuildId, user.EggIncAccounts.First(), db);
+            if(dbUser.EggIncAccounts.Count == 1) {
+                var contentString = await ChasingStringBuilder(discord, parameter, dbUser.GuildId, dbUser.EggIncAccounts.First(), db);
                 await command.ModifyOriginalResponseAsync(contentString);
             } else {
                 var builder = new ComponentBuilder();
-                foreach(var account in user.EggIncAccounts) {
+                foreach(var account in dbUser.EggIncAccounts) {
                     builder.WithButton($"{account.Backup?.UserName ?? "(No Name)"} {account.Backup?.EarningsBonus.ToEggString()}", customId: $"ChasingAccountButton:{account.Id}|{((int)parameter)}");
                 }
                 await command.ModifyOriginalResponseAsync(x => { x.Content = "Please select the account you would like to chase with."; x.Components = builder.Build(); x.Embed = null; });
             }
 
-            user.UpdateAccounts();
+            dbUser.UpdateAccounts();
             await db.SaveChangesAsync();
         }
         
         [ComponentCommand]
         public static async Task ChasingAccountButton(SocketMessageComponent component, DiscordSocketClient _client, Words _words, IServiceProvider _provider, [ComponentData] string data, ApplicationDbContext db) {
-            var user = await db.DBUsers.FirstAsync(x => x.DiscordId == component.User.Id);
-            if(user is null) return;
+            var dbUser = await db.DBUsers.FirstAsync(x => x.DiscordId == component.User.Id);
+            if(dbUser is null) return;
             var dataObjs = data.Split("|");
-            var account = user.EggIncAccounts.FirstOrDefault(x => x.Id == dataObjs[0]);
+            var account = dbUser.EggIncAccounts.FirstOrDefault(x => x.Id == dataObjs[0]);
             var parameter = (ChasingParameters)int.Parse(dataObjs[1]);
 
-            var contentString = await ChasingStringBuilder(_client, parameter, user.GuildId, account, db);
+            var contentString = await ChasingStringBuilder(_client, parameter, dbUser.GuildId, account, db);
             await component.UpdateAsync(x => { x.Components = null; x.Content = "Success"; });
             await component.Channel.SendMessageAsync(contentString);
         }

--- a/EGG9000.Bot/Commands/Informational/CraftCommand.cs
+++ b/EGG9000.Bot/Commands/Informational/CraftCommand.cs
@@ -31,27 +31,27 @@ namespace EGG9000.Bot.Commands {
 
             await command.DeferAsync(ephemeral: true);
 
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find backups for this user"); });
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
 
             var contentString = "";
 
-            if(user.EggIncAccounts.Count == 1) {
-                contentString = await CraftStringBuilder(user.EggIncAccounts.First(), quantity, quality, requestedArtifact);
+            if(dbUser.EggIncAccounts.Count == 1) {
+                contentString = await CraftStringBuilder(dbUser.EggIncAccounts.First(), quantity, quality, requestedArtifact);
                 await command.DeleteOriginalResponseAsync();
                 await command.Channel.SendMessageAsync(contentString);
             } else {
                 var builder = new ComponentBuilder();
-                foreach(var account in user.EggIncAccounts) {
+                foreach(var account in dbUser.EggIncAccounts) {
                     builder.WithButton($"{account.Backup?.UserName ?? "(No Name)"} {account.Backup?.EarningsBonus.ToEggString()}", customId: $"CraftAccountButton:{account.Id}|{((int)quality)}|{quantity}|{artifact}");
                 }
                 await command.ModifyOriginalResponseAsync(x => { x.Content = "Please select the account you would like to craft with."; x.Embed = null; x.Components = builder.Build(); });
             }
 
-            user.UpdateAccounts();
+            dbUser.UpdateAccounts();
             await db.SaveChangesAsync();
         }
 

--- a/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
@@ -24,18 +24,18 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "Calculate your Mystical Egg Ratio (MER)", ParentCommand = "formulae", AllowInDMs = true)]
         public static async Task Mer(FauxCommand command, ApplicationDbContext db, [SlashParam(Required = false)] MERChoice MERValue = MERChoice.Current) {
             await command.RespondAsync("Getting account backups...");
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null || !user.EggIncAccounts.Any(x => x.Backup is not null)) {
-                await command.RespondAsync(content: "", embed: EmbedError("Unable to find backups for this user"));
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null || !dbUser.EggIncAccounts.Any(x => x.Backup is not null)) {
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"));
                 return;
             }
 
             var sb = new StringBuilder();
 
-            foreach(var account in user.EggIncAccounts.Where(x => x.Backup is not null)) {
-                if(user.EggIncAccounts.Count > 1)
+            foreach(var account in dbUser.EggIncAccounts.Where(x => x.Backup is not null)) {
+                if(dbUser.EggIncAccounts.Count > 1)
                     sb.AppendLine($"\n**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})**");
-                MERCalculate(account, sb, user.DiscordUsername, (int)MERValue);
+                MERCalculate(account, sb, dbUser.DiscordUsername, (int)MERValue);
             }
 
             await command.ModifyOriginalResponseAsync(x => x.Content = sb.ToString());
@@ -93,19 +93,18 @@ namespace EGG9000.Bot.Commands {
 
         [SlashCommand(Description = "Calculate your Legendary Luck Coefficient (LLC)", ParentCommand = "formulae", AllowInDMs = true)]
         public static async Task Llc(FauxCommand command, ApplicationDbContext db) {
-            await command.RespondAsync("Getting account backups...");
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null || !user.EggIncAccounts.Any(x => x.Backup is not null)) {
-                await command.RespondAsync(content: "", embed: EmbedError("Unable to find backups for this user"));
+            await command.DeferAsync();
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null || !dbUser.EggIncAccounts.Any(x => x.Backup is not null)) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
 
             var sb = new StringBuilder();
-
-            foreach(var account in user.EggIncAccounts.Where(x => x.Backup is not null)) {
-                if(user.EggIncAccounts.Count > 1)
+            foreach(var account in dbUser.EggIncAccounts.Where(x => x.Backup is not null)) {
+                if(dbUser.EggIncAccounts.Count > 1)
                     sb.AppendLine($"\n**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})**");
-                LLCCalculate(account, sb, user.DiscordUsername);
+                LLCCalculate(account, sb, dbUser.DiscordUsername);
             }
 
             await command.ModifyOriginalResponseAsync(x => x.Content = sb.ToString());

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -41,21 +41,21 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "Track your EB since the last time you ran this command", AllowInDMs = true)]
         public static async Task TrackEB(FauxCommand command, ApplicationDbContext db, ILogger logger) {
             await command.DeferAsync();
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find backups for this user"); });
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
 
             var builder = new EmbedBuilder {
                 Title = $"EB Tracking"
             };
-            foreach(var id in user.EggIncAccounts) {
+            foreach(var id in dbUser.EggIncAccounts) {
                 var backup = id.Backup;
                 if(backup == null)
                     continue;
                 backup = new CustomBackup((await ContractsAPI.FirstContact(id.Id)).Backup);
-                if(user.EggIncAccounts.Count > 1) {
+                if(dbUser.EggIncAccounts.Count > 1) {
                     builder.AddField("――――――――――――――――――", $"**{backup.UserName}**");
                 }
 
@@ -89,7 +89,7 @@ namespace EGG9000.Bot.Commands {
                 }
             }
 
-            user.UpdateAccounts();
+            dbUser.UpdateAccounts();
             await db.SaveChangesAsync();
             await command.ModifyOriginalResponseAsync(x => {
                 x.Embed = builder.Build();
@@ -100,16 +100,16 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "How many SE/PE needed for next rank up", AllowInDMs = true)]
         public static async Task NextRank(FauxCommand command, ApplicationDbContext db, [SlashParam(Required = false)] bool ShowInChannel = false) {
             await command.DeferAsync(ephemeral: !ShowInChannel);
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find backups for this user"); });
+            var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
 
             var builder = new EmbedBuilder() {
                 Title = "Next Rank Details"
             };
-            foreach(var id in user.EggIncAccounts) {
+            foreach(var id in dbUser.EggIncAccounts) {
                 var backup = id.Backup;
                 if(backup == null)
                     continue;
@@ -123,7 +123,7 @@ namespace EGG9000.Bot.Commands {
                         break;
                 }
 
-                builder.AddField(new EmbedFieldBuilder { IsInline = true, Name = (user.EggIncAccounts.Count > 1 ? $"{backup.UserName}\n" : "") + $"{nextSubRank.First().Rank} [{nextSubRank.First().EarningsBonus.ToEggString()}]", Value = nextRankText });
+                builder.AddField(new EmbedFieldBuilder { IsInline = true, Name = (dbUser.EggIncAccounts.Count > 1 ? $"{backup.UserName}\n" : "") + $"{nextSubRank.First().Rank} [{nextSubRank.First().EarningsBonus.ToEggString()}]", Value = nextRankText });
 
                 var nextRank = SIPrefix.GetNextRankInfo(backup, false);
                 var currentRank = SIPrefix.GetPrefixFromEB(backup.EarningsBonus);
@@ -135,7 +135,7 @@ namespace EGG9000.Bot.Commands {
                             break;
                     }
 
-                    builder.AddField(new EmbedFieldBuilder { IsInline = true, Name = (user.EggIncAccounts.Count > 1 ? $"{backup.UserName}\n" : "") + $"{nextRank.First().Rank} [{nextRank.First().EarningsBonus.ToEggString()}]", Value = nextRankText });
+                    builder.AddField(new EmbedFieldBuilder { IsInline = true, Name = (dbUser.EggIncAccounts.Count > 1 ? $"{backup.UserName}\n" : "") + $"{nextRank.First().Rank} [{nextRank.First().EarningsBonus.ToEggString()}]", Value = nextRankText });
                 }
 
                 var ge = backup.GoldenEggsEarned - backup.GoldenEggsSpent;

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -540,7 +540,7 @@ namespace EGG9000.Bot.Commands {
         }*/
 
         [SlashCommand(Description = "Get a users status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, [SlashParam] SocketGuildUser user, [SlashParam(Required = false)] bool ShowInChannel = false) {
+        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, [SlashParam] SocketUser user, [SlashParam(Required = false)] bool ShowInChannel = false) {
             return _userstatus(command, db, _client, apiLink, user, true, ShowInChannel);
         }
 

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -231,7 +231,8 @@ namespace EGG9000.Bot.Commands {
                     await command.RespondAsync($"Looks like you are currently disabled, please wait for someone from staff to get you re-enabled.");
                     return;
                 } else if(user.GuildId != guild.Id) {
-                    await command.RespondAsync($"{targetUser.Mention}, now run the </moveserver:1095116354329268366> command");
+                    var moveservercommand = (await guild.GetApplicationCommandsAsync()).FirstOrDefault(c => c.Type == ApplicationCommandType.Slash && c.Name == "moveserver");
+                    await command.RespondAsync($"{targetUser.Mention}, now run the </moveserver:{moveservercommand?.Id ?? 0}> command");
                     return;
                 } else {
 
@@ -319,11 +320,11 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Register your EggInc account with the bot", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by numbers")] string eggincid, [SlashParam] SocketGuildUser user) {
+        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by 16 numbers")] string eggincid, [SlashParam] SocketGuildUser user) {
             return _Register(command, db, _client, apiLink, bugsnag, eggincid, user, logger);
         }
         [SlashCommand(Description = "Register your EggInc account with the bot")]
-        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by numbers")] string eggincid) {
+        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by 16 numbers")] string eggincid) {
             return _Register(command, db, _client, apiLink, bugsnag, eggincid, command.User, logger);
         }
         public static async Task _Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, string eggincid, IUser user, ILogger logger) {
@@ -337,7 +338,6 @@ namespace EGG9000.Bot.Commands {
                 var bannedUsers = db.DBUsers.Where(x => x.Banned).ToList().SelectMany(u => u.EggIncAccounts).ToList();
                 if(bannedUsers is not null) {
                     if(bannedUsers.Select(e => e.Id.ToUpper()).ToList().Contains(eggincid)) {
-                        //1132753030022975499 - dev server banned thread
                         var bannedUserThread = guildObj.ChannelDetails.FirstOrDefault(x => x.ChannelType == GuildChannelType.BannedUserThread);
                         if(bannedUserThread is not null) {
                             var thread = guild.GetThreadChannel(bannedUserThread.Id);

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -50,27 +50,27 @@ namespace EGG9000.Bot.Commands {
 
 
         [SlashCommand(Description = "Use to move registration to a different discord server")]
-        public static async Task MoveServer(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag) {
-            var user = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+        public static async Task MoveServer(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink) {
+            var dbUser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             var guild = _client.Guilds.FirstOrDefault(x => x.TextChannels.Any(y => y.Id == command.Channel.Id));
-            if(user == null) {
-                await command.RespondAsync($"Cannot find user");
-            } else if(user.GuildId == guild.Id) {
-                if(user.TempDisabled) {
+            if(dbUser == null) {
+                await command.RespondAsync($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?");
+            } else if(dbUser.GuildId == guild.Id) {
+                if(dbUser.TempDisabled) {
                     await command.RespondAsync($"It looks like you have been disabled, ask staff for help.");
                 } else {
                     await command.RespondAsync($"Already configured for the current server, you should get your roles during the next Leaderboard update.");
                 }
             } else {
                 await command.RespondAsync($"Please wait...");
-                if(user.GuildId == 428181243474214942) {
+                if(dbUser.GuildId == 428181243474214942) {
                     await ((SocketGuildUser)command.User).AddRoleAsync(guild.Roles.FirstOrDefault(x => x.Name == "Prophet"));
                 }
-                user.GuildId = guild.Id;
+                dbUser.GuildId = guild.Id;
                 await db.SaveChangesAsync();
 
                 //var Response = await ContractsAPI.FirstContact(user.EggIncIds.First().Id);
-                var Response = await apiLink.GetBackup(user.EggIncAccounts.First().Id);
+                var Response = await apiLink.GetBackup(dbUser.EggIncAccounts.First().Id);
                 var earningsBonus = Response.EarningsBonus;
 
                 var guildUser = guild.Users.First(x => x.Id == command.User.Id);
@@ -86,7 +86,7 @@ namespace EGG9000.Bot.Commands {
                     }
                 }
 
-                var role = await DiscordHelpers.CheckRoles(db, guild, guildUser, user, _client, null, new List<LeaderboardUser>());
+                var role = await DiscordHelpers.CheckRoles(db, guild, guildUser, dbUser, _client, null, new List<LeaderboardUser>());
 
                 var welcomeChannel = await _client.GetChannelAsync(GuildChannelType.Welcome, guild);
                 if(welcomeChannel.Id == command.Channel.Id) {
@@ -101,7 +101,7 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Removed registered EggInc ID from your account", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static Task RemoveID(FauxCommand command, ApplicationDbContext db, APILink apiLink, [SlashParam] string eggincid, [SlashParam] SocketGuildUser targetUser) {
+        public static Task RemoveID(FauxCommand command, ApplicationDbContext db, APILink apiLink, [SlashParam] string eggincid, [SlashParam] SocketUser targetUser) {
             return _RemoveID(command, db, apiLink, eggincid, targetUser.Id);
         }
         /* Moving to a staff-only command, leaving commented out in case of re-activation in future
@@ -110,22 +110,26 @@ namespace EGG9000.Bot.Commands {
             return _RemoveID(command, db, apiLink, eggincid, command.User.Id);
         }*/
         public static async Task _RemoveID(FauxCommand command, ApplicationDbContext db, APILink apiLink, string eggincid, ulong userid) {
-            var user = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == userid);
-            if(user == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Cannot find user"));
+            await command.DeferAsync();
+            var dbUser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == userid);
+            if(dbUser == null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{userid}>"); });
                 return;
-            } else if(user.EggIncAccounts.Any(x => x.Id == eggincid)) {
-                user.RemoveID(eggincid);
+            } else if(dbUser.EggIncAccounts.Any(x => x.Id == eggincid)) {
+                dbUser.RemoveID(eggincid);
             } else {
-                await command.RespondAsync($"⚠️ERROR: Unable to find the following EggIncId {eggincid}", embeds: AccountsString(db, user, apiLink, false).Result.Select(b => b.Build()).ToArray());
+                Embed[] embedArrayErr = { EmbedError($"Unable to find the EggIncId `{eggincid}` registered with <@{userid}>") };
+                embedArrayErr = embedArrayErr.Concat(AccountsString(db, dbUser, apiLink, false).Result.Select(b => b.Build()).ToArray()).ToArray();
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embeds = embedArrayErr; });
                 return;
             }
 
             await db.SaveChangesAsync();
+            var json = JsonConvert.SerializeObject(dbUser.EggIncAccounts, Formatting.Indented);
 
-            var json = JsonConvert.SerializeObject(user.EggIncAccounts, Formatting.Indented);
-
-            await command.RespondAsync($"ID removed", embeds: AccountsString(db, user, apiLink, false).Result.Select(b => b.Build()).ToArray());
+            Embed[] embedArray = { EmbedSuccess($"ID `{eggincid}` removed from <@{userid}>") };
+            embedArray = embedArray.Concat(AccountsString(db, dbUser, apiLink, false).Result.Select(b => b.Build()).ToArray()).ToArray();
+            await command.ModifyOriginalResponseAsync(x => { x.Content = $"ID removed"; x.Embeds = embedArray; });
         }
 
         [SlashCommand(Description = "Used to remove a user from a co-op to fix a glitch.", AdminOnly = StaffOnlyLevel.FarmHand)]
@@ -136,9 +140,13 @@ namespace EGG9000.Bot.Commands {
                 await command.ModifyOriginalResponseAsync( x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in a co-op channel"); });
                 return;
             }
-            var dbuser = await db.DBUsers.AsQueryable().FirstAsync(x => x.DiscordId == targetUser.Id);
+            var dbUser = await db.DBUsers.AsQueryable().FirstAsync(x => x.DiscordId == targetUser.Id);
+            if(dbUser is null) {
+                await command.RespondAsync($"Unable to locate DBUser entry for <@{targetUser.Id}>");
+                return;
+            }
 
-            var xrefs = await db.UserCoopXrefs.AsQueryable().Where(x => x.UserId == dbuser.Id && x.CoopId == coop.Id).ToListAsync();
+            var xrefs = await db.UserCoopXrefs.AsQueryable().Where(x => x.UserId == dbUser.Id && x.CoopId == coop.Id).ToListAsync();
 
 
             var contract = await db.Contracts.FirstAsync(x => x.ID == coop.ContractID);
@@ -183,7 +191,7 @@ namespace EGG9000.Bot.Commands {
             //}
 
             if(status.Participants.Count < contract.MaxUsers) {
-                logger.LogInformation("Successfully remove {user} from {coop}", dbuser.DiscordUsername, coop.Name);
+                logger.LogInformation("Successfully remove {user} from {coop}", dbUser.DiscordUsername, coop.Name);
                 var guild = _client.Guilds.First(x => x.Id == coop.OverflowGuildId);
                 var users = await db.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == coop.Id)).ToListAsync();
                 var dbguild = await db.Guilds.AsQueryable().FirstAsync(x => x.Id == coop.GuildId);
@@ -192,7 +200,7 @@ namespace EGG9000.Bot.Commands {
                 await command.Channel.SendMessageAsync($"Successfully removed {targetUser.Mention} from co-op, they should be able to rejoin now.");
                 await command.DeleteOriginalResponseAsync();
             } else {
-                logger.LogInformation("Did not {user} from {coop}", dbuser.DiscordUsername, coop.Name);
+                logger.LogInformation("Did not {user} from {coop}", dbUser.DiscordUsername, coop.Name);
                 await command.ModifyOriginalResponseAsync($"Attempted to remove {targetUser.Mention} from co-op, please check again in a few minutes.");
             }
         }
@@ -206,31 +214,32 @@ namespace EGG9000.Bot.Commands {
             await _Accept(command, db, _client, targetUser);
         }
         public static async Task _Accept(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, IUser targetUser) {
-            var user = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == targetUser.Id);
+            var dbUser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == targetUser.Id);
             var guild = _client.Guilds.FirstOrDefault(x => x.TextChannels.Any(y => y.Id == command.Channel.Id));
             if(guild == null) {
                 await command.RespondAsync("Unable to find server, please run this command in a server");
                 return;
             }
-            if(user is not null) {
-                if(user.GuildId == command.GuildId && user.EggIncAccounts.Count > 0) {
-                    if(user.TempDisabled) {
+            if(dbUser is not null) {
+                if(dbUser.GuildId == command.GuildId && dbUser.EggIncAccounts.Count > 0) {
+                    if(dbUser.TempDisabled) {
                         await command.RespondAsync($"Looks like you are currently disabled, please ask for someone from staff to find out about getting re-enabled.");
                         return;
                     } else {
                         await command.RespondAsync($"{targetUser.Mention}, you have already accepted the rules. Your roles should show up during the next leaderboard update.");
+                        await DiscordHelpers.CheckRoles(db, guild, (command.User as SocketGuildUser), dbUser, _client, null, new List<LeaderboardUser>());
                         return;
                     }
-                } else if(user.GuildId == command.GuildId && user.EggIncAccounts.Count == 0) {
+                } else if(dbUser.GuildId == command.GuildId && dbUser.EggIncAccounts.Count == 0) {
                     await command.RespondAsync($"{targetUser.Mention}, you have already accepted the rules. Please use the command `/register EI#####`, where EI##### is your Egg Inc ID, to find your ID please go to Settings, then Privacy & Data, and find the letters & numbers in the bottom center of the window.");
                     return;
-                } else if(user.EggIncAccounts.Count > 0 && user.GuildId > 0 & !user.TempDisabled) {
+                } else if(dbUser.EggIncAccounts.Count > 0 && dbUser.GuildId > 0 & !dbUser.TempDisabled) {
                     await command.RespondAsync($"{targetUser.Mention}, looks like you are registered with another server, if you would like to move to this server use the </moveserver:1095116354329268366> command");
                     return;
-                } else if(user.TempDisabled) {
+                } else if(dbUser.TempDisabled) {
                     await command.RespondAsync($"Looks like you are currently disabled, please wait for someone from staff to get you re-enabled.");
                     return;
-                } else if(user.GuildId != guild.Id) {
+                } else if(dbUser.GuildId != guild.Id) {
                     var moveservercommand = (await guild.GetApplicationCommandsAsync()).FirstOrDefault(c => c.Type == ApplicationCommandType.Slash && c.Name == "moveserver");
                     await command.RespondAsync($"{targetUser.Mention}, now run the </moveserver:{moveservercommand?.Id ?? 0}> command");
                     return;
@@ -248,7 +257,7 @@ namespace EGG9000.Bot.Commands {
                 }
             }
 
-            user = new DBUser {
+            dbUser = new DBUser {
                 DiscordId = targetUser.Id,
                 DiscordUsername = targetUser.Username,
                 AcceptedRules = true,
@@ -256,7 +265,7 @@ namespace EGG9000.Bot.Commands {
                 GuildId = guild.Id,
                 showEB = true
             };
-            db.DBUsers.Add(user);
+            db.DBUsers.Add(dbUser);
 
             var dbGuild = db.Guilds.FirstOrDefault(g => g.Id == guild.Id);
 
@@ -320,14 +329,14 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Register your EggInc account with the bot", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by 16 numbers")] string eggincid, [SlashParam] SocketGuildUser user) {
+        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by 16 numbers")] string eggincid, [SlashParam] SocketGuildUser user) {
             return _Register(command, db, _client, apiLink, bugsnag, eggincid, user, logger);
         }
         [SlashCommand(Description = "Register your EggInc account with the bot")]
-        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by 16 numbers")] string eggincid) {
+        public static Task Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, IClient bugsnag, ILogger logger, [SlashParam(Description = "EggIncID which begins with EI followed by 16 numbers")] string eggincid) {
             return _Register(command, db, _client, apiLink, bugsnag, eggincid, command.User, logger);
         }
-        public static async Task _Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, Bugsnag.IClient bugsnag, string eggincid, IUser user, ILogger logger) {
+        public static async Task _Register(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, IClient bugsnag, string eggincid, IUser user, ILogger logger) {
             await command.RespondAsync("Processing...");
             eggincid = eggincid.ToUpper();
 
@@ -552,7 +561,7 @@ namespace EGG9000.Bot.Commands {
             await command.DeferAsync(ephemeral: !showInChannel);
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DB object for <@{user.Id}>"); });
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"); });
                 return;
             }
 
@@ -725,10 +734,11 @@ namespace EGG9000.Bot.Commands {
 
 
         [SlashCommand(Description = "Disable user, user will not be assigned to co-ops until re-enabled", AdminOnly = StaffOnlyLevel.FarmHand)]
-        public static async Task Disable(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketGuildUser user) {
+        public static async Task Disable(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketUser user) {
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Cannot find database user"));
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"));
+                return;
             }
 
             dbuser.TempDisabled = true;
@@ -738,10 +748,11 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Re-enable user", AdminOnly = StaffOnlyLevel.Admin)]
-        public static async Task Enable(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketGuildUser user) {
+        public static async Task Enable(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketUser user) {
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Cannot find database user"));
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"));
+                return;
             }
 
             dbuser.TempDisabled = false;
@@ -792,7 +803,7 @@ namespace EGG9000.Bot.Commands {
         public static async Task ShowEB(FauxCommand command, ApplicationDbContext db) {
             var dbUser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(dbUser == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Cannot find database user"));
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"));
                 return;
             }
             if(dbUser.showEB) {
@@ -817,22 +828,18 @@ namespace EGG9000.Bot.Commands {
 
         [SlashCommand(Description = "Remove the EB from your nickname")]
         public static async Task HideEB(FauxCommand command, ApplicationDbContext db) {
-            var user = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
-            if(user == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Cannot find database user"));
+            var dbUser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
+            if(dbUser == null) {
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"));
             }
 
-            user.showEB = false;
+            dbUser.showEB = false;
             await db.SaveChangesAsync();
-
-
 
             var ebrgx = new Regex(@"\(\d+.?\d*\w?\)");
             var newName = ((IGuildUser)command.User).GetCleanName();
 
             await ((SocketGuildUser)command.User).ModifyAsync(x => x.Nickname = newName);
-
-
             await command.RespondAsync($"{command.User.Mention} will no longer be updated with their EB.", ephemeral: true);
         }
 

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -582,7 +582,7 @@ namespace EGG9000.Bot.Commands {
             if(dbuser.TempDisabled) lastBuilder.Footer.Text += $"\n❗User is disabled";
 
             if(admin && !showInChannel && !string.IsNullOrWhiteSpace(dbuser.Notes)) {
-                lastBuilder.Footer.Text += $"\n**Notes:** {dbuser.Notes}";
+                lastBuilder.Footer.Text += $"\nNotes:\n {dbuser.Notes}";
             }
 
             if(command.Channel is SocketDMChannel) {
@@ -692,7 +692,7 @@ namespace EGG9000.Bot.Commands {
                 }
 
                 if(backup.ClientVersion < ContractsAPI.ClientVersion && backup.ClientVersion > 0) {
-                    footers.Add($"⚠️ **Game outdated for {backup.UserName}, showing {backup.ClientVersion}, new version is {ContractsAPI.ClientVersion}** ⚠️");
+                    footers.Add($"⚠️ Game outdated for {backup.UserName}, showing {backup.ClientVersion}, new version is {ContractsAPI.ClientVersion} ⚠️");
                 }
 
                 /*

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -88,7 +88,7 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Log a Message", AdminOnly = StaffOnlyLevel.Admin)]
-        public static async Task AS(FauxCommand command, ApplicationDbContext db, DiscordSocketClient client, [SlashParam] string message, [SlashParam(Required = false)] SocketChannel channel = null, [SlashParam(Required = false, Description = "Message ID to reply to")] string replyto = null) {
+        public static async Task AS(FauxCommand command, [SlashParam] string message, [SlashParam(Required = false)] SocketChannel channel = null, [SlashParam(Required = false, Description = "Message ID to reply to")] string replyto = null) {
             try {
                 if(channel == null) {
                     if(replyto == null) await command.Channel.SendMessageAsync(message);
@@ -132,64 +132,6 @@ namespace EGG9000.Bot.Commands {
                 await command.RespondAsync(content: "", embed: EmbedError($"Unable to parse role `{role}`.\n\n**Message**\n{ex.Message}"));
                 return;
             }
-        }
-
-        [SlashCommand(Description = "Look for a coop with certain search parameters", AdminOnly = StaffOnlyLevel.FarmHand)]
-        public static async Task LocateCoop(FauxCommand command, ApplicationDbContext db, [SlashParam(Required = true)] string coopname = "", [SlashParam(Required = false)] SocketChannel contractchannel = null) {
-            //Coop name was not passed correctly, error out
-            if(string.IsNullOrEmpty(coopname) || string.IsNullOrWhiteSpace(coopname)) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to parse the coop name `{coopname}`. Check you've entered a value?"), ephemeral: true);
-                return;
-            } else coopname = coopname.ToLower(); //To-lower it
-
-            //Define a condition for lessening the DB load
-            Func<Coop, bool> rightContract = coop => {
-                if(contractchannel is null) return true;
-                else if(coop?.Contract is null) return false;
-                else return (coop.Contract.ID == contractchannel.ToString());
-            };
-
-
-            var guild = await db.Guilds.FirstOrDefaultAsync(x => x.Id == command.GuildId || x.OverflowServersJson.Contains(command.GuildId.ToString()));
-
-            //Attempt to find the coop
-            var findCoop = await db.Coops.Include(x => x.Contract).Include(x => x.UserCoopsXrefs).ThenInclude(u => u.User).AsQueryable().FirstOrDefaultAsync(x => x.GuildId == guild.Id && x.Name.ToLower() == coopname);
-
-            //If it can't be found, error out
-            if(findCoop is null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find a coop named `{coopname + (contractchannel is null ? "" : $"for the contract {contractchannel}")}`"), ephemeral: true);
-                return;
-            }
-
-            var builder = new EmbedBuilder()
-                .WithAuthor(new EmbedAuthorBuilder()
-                    .WithName($"{findCoop.Contract.Name} - {findCoop.Name}")
-                    .WithIconUrl(EggIncEggs.GetEggById((int)findCoop.Contract.Details.Egg).Image)
-                    .WithUrl($"https://egg9000.com/coop/{findCoop.Contract.ID}/{findCoop.Name.ToLower()}"))
-                .WithColor((!findCoop.Finished && findCoop.FinishedOrFailed()) ? Color.Red : (findCoop.ProjectedToFinish ? Color.Green : Color.Blue));
-
-            //For each item in coopName.UserCoopsXrefs, append a user mention to a variable
-            var userList = new List<string> {
-                $"**__Coop Users {findCoop?.UserCoopsXrefs.Count(u => u.JoinedCoop) ?? 0}/{findCoop?.UserCoopsXrefs.Count ?? 0}__:**"
-            };
-            userList.AddRange(findCoop?.UserCoopsXrefs?.Select(u => $"{(u.JoinedCoop ? "✓" : "❌")} <@{u.User.DiscordId}>").ToList());
-            if(userList.Count == 1) {
-                userList.Add("..._No users_");
-            } else if(userList.Count > 10) {
-                userList = userList.Take(10).ToList();
-                userList.Add("..._(Trimmed list)_");
-            }
-
-            builder.WithDescription(string.Join("\n", userList));
-
-            builder.AddField("Channel", $"{(findCoop.DeletedChannel ? "**Channel Deleted**" : "<#" + findCoop.DiscordChannelId + ">")}");
-            builder.AddField("League", (findCoop.AnyLeague ? "<:ultra:1131045418319495369> Any Grade" : "") + PlayerGradeDetails.GetEmoji(findCoop.League));
-
-            if(findCoop.Finished) builder.AddField("Status", "**Finished**");
-            else if(findCoop.FinishedOrFailed()) builder.AddField("Status", "**Failed**");
-            else builder.AddField("Projected to finish?", $"{(findCoop.ProjectedToFinish ? "Yes" : "No")}");
-
-            await command.RespondAsync("", embed: builder.Build(), ephemeral: true);
         }
 
         [SlashCommand(Description = "Add a temporary prefex for a users co-op (PrefixWord11)", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -147,7 +147,7 @@ namespace EGG9000.Bot.Commands {
 
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = $""; x.Embed = EmbedError("Unable to find user"); });
+                await command.ModifyOriginalResponseAsync(x => { x.Content = $""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"); });
                 return;
             }
 

--- a/EGG9000.Bot/Jobs/UserDMsJob.cs
+++ b/EGG9000.Bot/Jobs/UserDMsJob.cs
@@ -49,7 +49,7 @@ namespace EGG9000.Bot.Jobs {
                     }
 
                     if(!account.SentBreakWarning && account.OnBreakUntil > DateTimeOffset.FromUnixTimeSeconds(0).AddDays(1)) {
-                        _logger.LogInformation($"Sending warning to {user.DiscordUsername}");
+                        _logger.LogInformation("Sending warning to {user}", user.DiscordUsername);
                         var nextContract = CronExpression.Parse("0 11 * * MON,WED,FRI").GetNextOccurrence(account.OnBreakUntil, TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time"));
 
                         var mcs = (await _discord.GetGlobalApplicationCommandsAsync()).FirstOrDefault(c => c.Type == Discord.ApplicationCommandType.Slash && c.Name == "mycontractsettings");

--- a/EGG9000.Bot/Jobs/UserDMsJob.cs
+++ b/EGG9000.Bot/Jobs/UserDMsJob.cs
@@ -44,7 +44,7 @@ namespace EGG9000.Bot.Jobs {
                     }
                     var dmChannel = await discorduser.CreateDMChannelAsync();
                     if(dmChannel is null) {
-                        _logger.LogWarning($"Could not create DM channel with {user.DiscordUsername}");
+                        _logger.LogWarning("Could not create DM channel with {user}", user.DiscordUsername);
                         continue;
                     }
 
@@ -52,8 +52,9 @@ namespace EGG9000.Bot.Jobs {
                         _logger.LogInformation($"Sending warning to {user.DiscordUsername}");
                         var nextContract = CronExpression.Parse("0 11 * * MON,WED,FRI").GetNextOccurrence(account.OnBreakUntil, TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time"));
 
+                        var mcs = (await _discord.GetGlobalApplicationCommandsAsync()).FirstOrDefault(c => c.Type == Discord.ApplicationCommandType.Slash && c.Name == "mycontractsettings");
                         var message = $"Your break for {account.Backup?.UserName ?? "(No Name)"} is expiring {DiscordHelpers.TimeStamper(account.OnBreakUntil, DiscordHelpers.DiscordTimestampFormat.Relative)}." +
-                            $"\n\nPlease use the `/mycontractsettings` command to extend your break if you need more time, otherwise you will be assigned a co-op for the next contract on " +
+                            $"\n\nPlease use the {(mcs is not null ? $"</mycontractsettings:{mcs?.Id ?? 0}>" : "`/mycontractsettings`")} command to extend your break if you need more time, otherwise you will be assigned a co-op for the next contract on " +
                             $"{DiscordHelpers.TimeStamper(nextContract.Value, DiscordHelpers.DiscordTimestampFormat.LongDateWShortTime)}.";
                         var retEx = await DiscordHelpersExt.BoolSendDm(dmChannel, message);
                         if((retEx == null) == user.DMSBlocked) {

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -43,6 +43,7 @@ namespace EGG9000.Common.Database.Entities {
 
         public CoopStatusEnum Status { get; set; }
         //public int UnableToFind { get; set; }
+        public bool PseudoExpired { get; set; } = false;
 
         public Contract Contract { get; set; }
         //public List<CoopStatus> CoopStatuses { get; set; }

--- a/EGG9000.Common/Database/Entities/Guild.cs
+++ b/EGG9000.Common/Database/Entities/Guild.cs
@@ -105,45 +105,45 @@ namespace EGG9000.Common.Database.Entities {
         WarningMessagesForUser = 9,
         [Description("Optional: Shows limited time shells")]
         LimitedTimeShells = 10,
-        [Description("Optional: Limited time shells notification role")]
+        [Description("/R/Optional: Limited time shells notification role")]
         LimitedTimeShellsRole = 11,
         [Description("/TC/Optional: Outside Co-op Log")]
         OutsideCoopLog = 12,
-        [Description("Optional: Missing Boarding Group Role")]
+        [Description("/R/Optional: Missing Boarding Group Role")]
         MissingBoardingGroupRole = 14,
-        [Description("Optional: Active Role (participated in a co-op in the last 3 weeks)")]
+        [Description("/R/Optional: Active Role (participated in a co-op in the last 3 weeks)")]
         ActiveRole = 15,
-        [Description("Optional: Grade AAA Role")]
+        [Description("/R/Optional: Grade AAA Role")]
         GradeAAA = 16,
-        [Description("Optional: Grade AA Role")]
+        [Description("/R/Optional: Grade AA Role")]
         GradeAA = 17,
-        [Description("Optional: Grade A Role")]
+        [Description("/R/Optional: Grade A Role")]
         GradeA = 18,
-        [Description("Optional: Grade B Role")]
+        [Description("/R/Optional: Grade B Role")]
         GradeB = 19,
-        [Description("Optional: Grade C Role")]
+        [Description("/R/Optional: Grade C Role")]
         GradeC = 20,
-        [Description("Optional: Game Version Outdated Role")]
+        [Description("/R/Optional: Game Version Outdated Role")]
         GameVersionOutdated = 21,
         [Description("/TC/Optional: Demerit Log, adding this channel will automate demerits in co-ops")]
         DemeritLogChannel = 22,
-        [Description("Optional: 'Android' Role")]
+        [Description("/R/Optional: 'Android' Role")]
         AndroidRole = 24,
-        [Description("Optional: 'iOS/Apple' Role")]
+        [Description("/R/Optional: 'iOS/Apple' Role")]
         IosRole = 25,
-        [Description("Optional: 'Enlightenment Diamond' Role")]
+        [Description("/R/Optional: 'Enlightenment Diamond' Role")]
         EnDRole = 26,
-        [Description("Optional: 'Nobel prize in Animal Husbandry' Role")]
+        [Description("/R/Optional: 'Nobel prize in Animal Husbandry' Role")]
         NAHRole = 27,
-        [Description("Optional: 'All-Star Club' Role")]
+        [Description("/R/Optional: 'All-Star Club' Role")]
         ASCRole = 28,
         [Description("/TC/Optional: Where /callstaff messages will appear")]
         CallStaffChannel = 29,
-        [Description("Optional: Role for staff to ping in /callstaff instances")]
+        [Description("/R/Optional: Role for staff to ping in /callstaff instances")]
         CallStaffTagRole = 30,
-        [Description("Optional: Role for standard subscriptions")]
+        [Description("/R/Optional: Role for standard subscriptions")]
         StandardSubscription = 31,
-        [Description("Optional: Role for pro subscriptions")]
+        [Description("/R/Optional: Role for pro subscriptions")]
         ProSubscription = 32,
         [Description("Optional: Subscription-Only Contract Category, adding this will prevent sub-only contracts from appearing elsewhere.")]
         SubscriptionContractCategory = 33,
@@ -162,6 +162,10 @@ namespace EGG9000.Common.Database.Entities {
         [Description("/TC/Optional: Where players who join coops while on break will be logged")]
         BreakCoopLog = 40,
         [Description("/TC/Optional: Where players can talk to staff of the server")]
-        TalkToStaff = 41
+        TalkToStaff = 41,
+        [Description("/R/Optional: Role for users that have the Standard Permit")]
+        StandardPermitRole = 42,
+        [Description("/R/Optional: Role for users that have the Pro Permit")]
+        ProPermitRole = 43
     }
 }

--- a/EGG9000.Common/Database/Entities/Guild.cs
+++ b/EGG9000.Common/Database/Entities/Guild.cs
@@ -163,9 +163,9 @@ namespace EGG9000.Common.Database.Entities {
         BreakCoopLog = 40,
         [Description("/TC/Optional: Where players can talk to staff of the server")]
         TalkToStaff = 41,
-        [Description("/R/Optional: Role for users that have the Standard Permit")]
+        [Description("/R/Optional: Role for users that have the Standard Permit (must be paired with Pro Permit role)")]
         StandardPermitRole = 42,
-        [Description("/R/Optional: Role for users that have the Pro Permit")]
+        [Description("/R/Optional: Role for users that have the Pro Permit (must be paired with Standard Permit role)")]
         ProPermitRole = 43
     }
 }

--- a/EGG9000.Common/Database/Entities/Guild.cs
+++ b/EGG9000.Common/Database/Entities/Guild.cs
@@ -99,7 +99,7 @@ namespace EGG9000.Common.Database.Entities {
         FaqChannel = 5,
         [Description("Required: Category for contract channels")]
         ContractCategory = 6,
-        [Description("Optional: Category for failed co-ops")]
+        [Description("Required: Category for failed co-ops")]
         FailedCategory = 8,
         [Description("/TC/Optional: Channel for warning messages like having bot DMs blocked (can be the same as another channel)")]
         WarningMessagesForUser = 9,

--- a/EGG9000.Common/Helpers/CreateCoopsV2.cs
+++ b/EGG9000.Common/Helpers/CreateCoopsV2.cs
@@ -155,7 +155,7 @@ namespace EGG9000.Common.Helpers {
         }
 
 
-        public static async Task<UserCoopXref> MoveUser(Coop targetCoop, Guid dbuserid, String EggIncId, String eggIncName, IUser user, DBUser dbuser, SocketTextChannel targetChannel, SocketTextChannel commandChannel) {
+        public static async Task<UserCoopXref> MoveUser(Coop targetCoop, Guid dbuserid, string EggIncId, string eggIncName, IUser user, DBUser dbuser, SocketTextChannel targetChannel, SocketTextChannel commandChannel, bool silent = false) {
             var newxref = new UserCoopXref {
                 AddedToChannel = true,
                 CoopId = targetCoop.Id,
@@ -179,13 +179,12 @@ namespace EGG9000.Common.Helpers {
                 try {
                     await commandChannel.SendMessageAsync(commandChannel.Guild.Id != targetChannel.Guild.Id ? $"{mention} looks like you are not in the overflow servers. **Make sure and join the overflow servers in <#775558629671698442> to see your co-op, it's in {targetChannel.Guild.Name}**." : "Looks like an error happened, please use /callstaff");
                 } catch(Exception) {
-                    await targetChannel.SendMessageAsync($"Added {mention}, please join {targetCoop.Name} for the contract {targetCoop.Contract.Name}");
+                    if(!silent) await targetChannel.SendMessageAsync($"Added {mention}, please join {targetCoop.Name} for the contract {targetCoop.Contract.Name}");
                     return newxref;
                 }
             }
 
-
-            await targetChannel.SendMessageAsync($"Please join {targetCoop.Name} {mention} for the contract {eggEmoji} {targetCoop.Contract.Name}");
+            if(!silent) await targetChannel.SendMessageAsync($"Please join {targetCoop.Name} {mention} for the contract {eggEmoji} {targetCoop.Contract.Name}");
             return newxref;
         }
     }

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -120,7 +120,7 @@ namespace EGG9000.Bot.Helpers {
             await CheckHatchlingRole(guild, discordUser, dbUser);
             await CheckFreshEggsRole(guild, discordUser, dbUser);
             await CheckBG(_client, guild, discordUser, dbUser);
-            await CheckPermitRoles(guild, discordUser, dbUser);
+            await CheckPermitRoles(_client, guild, discordUser, dbUser);
             await CheckGrades(discordUser, dbUser, grades);
             await CheckOudatedGameRole(_client, guild, discordUser, dbUser);
             await CheckUserOSRole(_client, guild, discordUser, dbUser);
@@ -289,33 +289,33 @@ namespace EGG9000.Bot.Helpers {
             return ($"<t:{time.ToUnixTimeSeconds()}:{ender}>");
         }
 
+        private static async Task CheckPermitRoles(DiscordHostedService _client, SocketGuild Guild, IGuildUser DiscordUser, DBUser dbUser) {
+            var standardPermitRole = await _client.GetRoleAsync(GuildChannelType.StandardPermitRole, Guild);
+            var proPermitRole = await _client.GetRoleAsync(GuildChannelType.ProPermitRole, Guild);
 
-        public static ulong ProPermitRoleID = 966017147350446121;
-        public static ulong StandardPermitRoleID = 966017278078517248;
-        private static async Task CheckPermitRoles(SocketGuild Guild, IGuildUser DiscordUser, DBUser dbUser) {
-            if(Guild.Roles.Any(x => x.Id == ProPermitRoleID)) {
-                var hasPro = DiscordUser.RoleIds.Any(x => x == ProPermitRoleID);
-                var hasStandard = DiscordUser.RoleIds.Any(x => x == StandardPermitRoleID); ;
+            if(standardPermitRole is not null && proPermitRole is not null) {
+                var hasPro = DiscordUser.RoleIds.Any(x => x == proPermitRole.Id);
+                var hasStandard = DiscordUser.RoleIds.Any(x => x == standardPermitRole.Id); ;
 
                 var needsPro = dbUser.EggIncAccounts.Any(x => x.Backup.PermitLevel == 1);
                 var needsStandard = dbUser.EggIncAccounts.Any(x => x.Backup.PermitLevel == 0);
 
 
                 if(!hasPro && needsPro) {
-                    await DiscordUser.AddRoleAsync(Guild.Roles.First(x => x.Id == ProPermitRoleID));
+                    await DiscordUser.AddRoleAsync(proPermitRole);
                     GetLogger<DiscordHelpers>().LogInformation("Adding ProPermit role for {user}", DiscordUser.GetName());
                 }
                 if(hasPro && !needsPro) {
-                    await DiscordUser.RemoveRoleAsync(Guild.Roles.First(x => x.Id == ProPermitRoleID));
+                    await DiscordUser.RemoveRoleAsync(proPermitRole);
                     GetLogger<DiscordHelpers>().LogInformation("Removing ProPermit role for {user}", DiscordUser.GetName());
                 }
                 if(!hasStandard && needsStandard) {
-                    await DiscordUser.AddRoleAsync(Guild.Roles.First(x => x.Id == StandardPermitRoleID));
+                    await DiscordUser.AddRoleAsync(standardPermitRole);
                     GetLogger<DiscordHelpers>().LogInformation("Adding StandardPermit role for {user}", DiscordUser.GetName());
 
                 }
                 if(hasStandard && !needsStandard) {
-                    await DiscordUser.RemoveRoleAsync(Guild.Roles.First(x => x.Id == StandardPermitRoleID));
+                    await DiscordUser.RemoveRoleAsync(standardPermitRole);
                     GetLogger<DiscordHelpers>().LogInformation("Removing StandardPermit role for {user}", DiscordUser.GetName());
                 }
 

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -121,7 +121,7 @@ namespace EGG9000.Bot.Helpers {
             await CheckFreshEggsRole(guild, discordUser, dbUser);
             await CheckBG(_client, guild, discordUser, dbUser);
             await CheckPermitRoles(guild, discordUser, dbUser);
-            await CheckGrades(guild, discordUser, dbUser, grades);
+            await CheckGrades(discordUser, dbUser, grades);
             await CheckOudatedGameRole(_client, guild, discordUser, dbUser);
             await CheckUserOSRole(_client, guild, discordUser, dbUser);
             await CheckUnjoined(guild, discordUser, leaderboardUsers.FirstOrDefault(x => x.User.Id == dbUser.Id));
@@ -321,7 +321,7 @@ namespace EGG9000.Bot.Helpers {
 
             }
         }
-        private static async Task CheckGrades(SocketGuild Guild, IGuildUser DiscordUser, DBUser dbuser, List<(Ei.Contract.Types.PlayerGrade grade, SocketRole role)> grades) {
+        private static async Task CheckGrades(IGuildUser DiscordUser, DBUser dbuser, List<(Ei.Contract.Types.PlayerGrade grade, SocketRole role)> grades) {
             var neededGrades = dbuser.EggIncAccounts.Select(x => x.GetGrade());
 
             var neededRoles = neededGrades.Select(x => grades.First(g => g.grade == x).role).Where(x => x is not null && !DiscordUser.RoleIds.Any(y => y == x.Id)).ToList();

--- a/EGG9000.Common/Migrations/20240119004953_PseudoExpiredCoop.Designer.cs
+++ b/EGG9000.Common/Migrations/20240119004953_PseudoExpiredCoop.Designer.cs
@@ -4,6 +4,7 @@ using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240119004953_PseudoExpiredCoop")]
+    partial class PseudoExpiredCoop
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EGG9000.Common/Migrations/20240119004953_PseudoExpiredCoop.cs
+++ b/EGG9000.Common/Migrations/20240119004953_PseudoExpiredCoop.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    public partial class PseudoExpiredCoop : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "PseudoExpired",
+                table: "Coops",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PseudoExpired",
+                table: "Coops");
+        }
+    }
+}

--- a/EGG9000.Site/Views/Admin/ConfigureServer.cshtml
+++ b/EGG9000.Site/Views/Admin/ConfigureServer.cshtml
@@ -15,6 +15,7 @@
 
 	.table {
 		border-bottom: 1px solid #ccc;
+		caption-side: top !important;
 	}
 
 	div.custom-card {
@@ -30,6 +31,12 @@
 	div.tc-card {
 		background-color: gray;
 		border-color: darkgray;
+		color: black;
+	}
+
+	div.requ-card {
+		background-color: lightsalmon;
+		border-color: darksalmon;
 		color: black;
 	}
 
@@ -127,6 +134,7 @@
 
 <table class="table table-striped">
 	<thead>
+		<tr style="text-align: center; font-size: larger"><th colspan="3">Channels, Threads & Categories</th></tr>
 		<tr>
 			<th>Type</th>
 			<th>Description</th>
@@ -139,10 +147,11 @@
 			FieldInfo fi = val.GetType().GetField(val.ToString());
 			DescriptionAttribute[] attributes = fi.GetCustomAttributes(typeof(DescriptionAttribute), false) as DescriptionAttribute[];
 			var description = (attributes != null && attributes.Any()) ? attributes.First().Description : val.ToString();
+			if (description.StartsWith("/R/")) continue;
 			<tr>
 				<td>
 					@val.ToString()
-					@if(description.StartsWith("/TC/") || description.Contains("Optional:")){
+					@if(description.StartsWith("/TC/") || description.Contains("Optional:") || description.StartsWith("Required: ")){
 						<br/>
 						@if (description.StartsWith("/TC/")){
 							<div class="custom-card tooltip-custom tc-card">
@@ -156,10 +165,16 @@
 								<span class="tooltiptext-custom speech-bubble">This parameter is not required, and it is up to your discretion to choose to use it or not.</span>
 							</div>
 						}
+						@if (description.StartsWith("Required:")){
+							<div class="custom-card tooltip-custom requ-card">
+								Required
+								<span class="tooltiptext-custom speech-bubble">This parameter is required for your server to function correctly.</span>
+							</div>
+						}
 					}
 				</td>
 				<td>
-					@description.Replace("/TC/", "").Replace("Optional: ", "")
+					@description.Replace("/TC/", "").Replace("Optional: ", "").Replace("Required: ", "")
 				</td>
 				<td>
 					@{
@@ -169,6 +184,39 @@
 				</td>
 				<td>
 					@discord.GetGuild(Model.Id).GetChannel(@detail.Id)?.Name
+				</td>
+			</tr>
+		}
+	</tbody>
+</table>
+
+<table class="table table-striped">
+	<thead>
+		<tr style="text-align: center; font-size: larger"><th colspan="3">Roles</th></tr>
+		<tr>
+			<th>Description</th>
+			<th>ID</th>
+			<th>Name</th>
+		</tr>
+	</thead>
+	<tbody>
+		@foreach (var val in Enum.GetValues<GuildChannelType>())
+		{
+			FieldInfo fi = val.GetType().GetField(val.ToString());
+			DescriptionAttribute[] attributes = fi.GetCustomAttributes(typeof(DescriptionAttribute), false) as DescriptionAttribute[];
+			var description = (attributes != null && attributes.Any()) ? attributes.First().Description : val.ToString();
+			if (!description.StartsWith("/R/")) continue;
+			<tr>
+				<td>
+					@description.Replace("Optional: ", "").Replace("/R/", "")
+				</td>
+				<td>
+					@{
+						var detail = channelDetails.FirstOrDefault(x => x.ChannelType == val) ?? new ChannelDetail { ChannelType = val };
+						<input class="custom-input channelDetail" id="@val.ToString()" value="@detail.Id" />
+					}
+				</td>
+				<td>
 					@discord.GetGuild(Model.Id).GetRole(@detail.Id)?.Name
 				</td>
 			</tr>


### PR DESCRIPTION
Miscellaneous changes:
- Change `/A UserStatus` to SocketUser instead of `SocketGuildUser` to allow Staff to look-up users that have since left the server
- Add a `silent` flag to `/MoveToCoop` for cases where staff need to fix something in the background and don't want to ping the user
- Fix some duplicated pings for 12/24/Finish soon warnings (both the message and `SendDMWarning` mentioned the user)
- Changed as many instances as I could find of "static command IDs" in the code, and changed them to be lookups on the client side, this should lead to clickable commands 100% of the time
- Split `/ConfigureServer` UI into two sections, one for Channels/Threads/Categories, one for Roles
- Moved Standard/Pro permit roles to GuildChannelType, and updated assignments in `DiscordHelper`
- Added more layers of error checking to `/FixFullCoopError`, as there were still Object reference errors being shot from line 95
- Remove the `LocateCoop` command - had originally been implemented when ghost channels were being created, no longer in-use
- Added new DB field on Coops for `PseudoExpired` to track the in-between state of a coop where it is waiting on check-in of users, but the coop itself is no longer joinable ( fixes #132 )
- Edit `FindCoopSpot` buttons to prevent users who are disabled from using them
- Standardized instances of lookups on `DBUser`s in commands to always be named `dbUser` to make it easier to check type at a glance
- Standardized error message(s) when `DBUser` lookup returns null
- Made `/Enable` a `SocketUser` command
- Made `/Disable` a `SocketUser` command
- Made `/A RemoveId` a `SocketUser` command
- Fixed option populations for `/RemoveFromCoop` to have Username in them
- Fixed option populations for `/MoveToCoop` to be more consistently formatted


Changes to coop embeds:
- Move coop Grade to top of embed, change to emoji instead of enum name
- Add indicator if the bot knows that the coop is Any-Grade
- Move Highest EB to top of embed
- Move creator to top of EB, change grade to emoji from enum name
- Move "this coop is public" to top of embed
- Changed statically defined command text to perform look-ups (clickable reliability)
- Various formatting changes for newlines