### PR TITLE
Daveed changes

### DIFF
--- a/EGG9000.Bot/Automated/ArtifactCheaters.cs
+++ b/EGG9000.Bot/Automated/ArtifactCheaters.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Principal;
 using System.Threading;
@@ -144,11 +145,16 @@ namespace EGG9000.Bot.Automated {
                     else user = dbusers.FirstOrDefault(u => u.EggIncAccounts.Any(a => a.Name == outlier.Name));
                     var outlierScore = scoreSet[outlier];
 
-                    var guild = _client.Guilds.FirstOrDefault(x => x.Id == user.GuildId);
-                    if(guild is null) continue;
-
-                    var clientGuild = dbguilds.FirstOrDefault(x => x.Id == guild.Id);
+                    var clientGuild = _client.Guilds.FirstOrDefault(x => x.Id == user.GuildId);
                     if(clientGuild is null) continue;
+
+                    var dbGuild = dbguilds.FirstOrDefault(x => x.Id == clientGuild.Id);
+                    if(dbGuild is null) continue;
+
+                    var doesCheaterChannelExist = ChannelHelper.DetermineChannelType(dbGuild, clientGuild, GuildChannelType.CheaterThread);
+
+                    //Only run through if the channel exists
+                    if(doesCheaterChannelExist is null) continue;
 
                     var identifier = string.IsNullOrEmpty(outlier.Backup?.UserName) ? (string.IsNullOrEmpty(outlier.Name) ? outlier.Id : outlier.Name) : outlier.Backup.UserName;
 #if DEV9002
@@ -157,7 +163,28 @@ namespace EGG9000.Bot.Automated {
                     var message = $"User <@{user.DiscordId}> may be using cheated artifacts - the account `{identifier}` has an AFS of `{outlierScore}` compared to the average of `{averageScore}`";
 #endif
 
-                    var response = await ChannelHelper.DetermineAndSend(_db, _client, clientGuild, guild, GuildChannelType.CheaterThread, new() { Text = message});
+                    var (B64, Config) = ArtifactHelpers.InventoryB64(outlier);
+                    if(string.IsNullOrEmpty(B64)) {
+                        var sendResponse = await ChannelHelper.DetermineAndSend(_db, _client, dbGuild, clientGuild, GuildChannelType.CheaterThread, new() {
+                            Text = message
+                        });
+                    } else {
+                        var image = new FileAttachment(new MemoryStream(Convert.FromBase64String(B64)), "Inventory.jpeg", "Inventory Image");
+                        var sendResponse = await ChannelHelper.DetermineAndSend(_db, _client, dbGuild, clientGuild, GuildChannelType.CheaterThread, new() {
+                            Text = message,
+                            Embed = Commands.ArtifactCommands._inventoryEmbed(user, outlier),
+                            File = image,
+                            SendFile = true,
+                        });
+                        var baseUrl = sendResponse.Embeds.First().Image.ToString();
+                        var formatIndex = baseUrl.IndexOf("&format", StringComparison.OrdinalIgnoreCase);
+                        var imageUrl = formatIndex is int index && index != -1 ? baseUrl[..(index + "&format".Length)] : baseUrl;
+
+                        await sendResponse.ModifyAsync(x => {
+                            x.Content = message;
+                            x.Embed = Commands.ArtifactCommands._inventoryEmbed(user, outlier, imageUrl);
+                        });
+                    }
 
                     outlier.AFSWarningSent = true;
                     user.UpdateAccounts();

--- a/EGG9000.Bot/Automated/ContractUpdater.cs
+++ b/EGG9000.Bot/Automated/ContractUpdater.cs
@@ -149,8 +149,12 @@ namespace EGG9000.Bot.Automated {
                 }
 
                 foreach(var pCoop in potentialCoops.Where(x => x.userids.Count > 1)) {
+
+                    var dbGuild = await _db.Guilds.FirstOrDefaultAsync(g => g.Id == pCoop.guildid);
+                    if(!dbGuild.AddOutsideCoops) continue;
+
                     var contract = contracts.First(x => x.ID == pCoop.contractid);
-                    var exisitingCoop = await _db.Coops.FirstOrDefaultAsync(x => x.ContractID == pCoop.contractid && EF.Functions.Like(x.Name, pCoop.coopname));
+                    var exisitingCoop = await _db.Coops.FirstOrDefaultAsync(x => x.GuildId == pCoop.guildid && x.ContractID == pCoop.contractid && EF.Functions.Like(x.Name, pCoop.coopname));
                     if(exisitingCoop is not null) {
                         _logger.LogInformation("Co-op {coopname} already exists, skipping", pCoop.coopname);
                         continue;
@@ -159,7 +163,8 @@ namespace EGG9000.Bot.Automated {
                     var coop = new Coop {
                         ContractID = pCoop.contractid, Created = DateTimeOffset.Now, GuildId = pCoop.guildid, Name = pCoop.coopname,
                         MaxUsers = contract.MaxUsers, Status = CoopStatusEnum.WaitingOnAssigned, League = pCoop.grade,
-                        CoopEnds = DateTimeOffset.FromUnixTimeSeconds(pCoop.endtime)
+                        CoopEnds = DateTimeOffset.FromUnixTimeSeconds(pCoop.endtime),
+                        AddedFromBackup = true,
                     };
                     coops.Add(new { Name = coop.Name });
                     _db.Add(coop);

--- a/EGG9000.Bot/Automated/EventUpdater.cs
+++ b/EGG9000.Bot/Automated/EventUpdater.cs
@@ -6,9 +6,7 @@ using EGG9000.Bot.EggIncAPI;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
-
 using Ei;
-
 using Humanizer;
 
 using Microsoft.EntityFrameworkCore;
@@ -31,14 +29,29 @@ namespace EGG9000.Bot.Automated {
             ) : base(TimeSpan.FromMinutes(1), TimeSpan.Zero, provider) {
         }
 
+        private class EventWithCustom {
+            public Event Event { get; set; }
+            public EventCustomization Customization { get; set; }
+        }
+
+        public static async Task<EventCustomization> GetCustomizationAsync(ApplicationDbContext _db, Guild dbguild, Event customEvent) {
+            var dbguilds = await _db.Guilds.AsQueryable().ToListAsync();
+            var palaceGuild = dbguilds.FirstOrDefault(g => g.Id == 656455567858073601);
+            var customization = dbguild.EventCustomzations?.FirstOrDefault(ec => ec.Type == customEvent.Type);
+            if(customization is null) {
+                //The only time this should happen is when we first push this live
+                if(palaceGuild?.EventCustomzations is null || palaceGuild.EventCustomzations.Any(e => e.Type == customEvent.Type)) return null;
+                customization = palaceGuild.EventCustomzations?.FirstOrDefault(ec => ec.Type == customEvent.Type);
+            }
+            return customization;
+        }
+
         public override async Task Run(object state, CancellationToken cancellationToken) {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
             await CheckShells(_db);
 
             var response = await ContractsAPI.GetPeriodicalsAsync();
-
-            var eventCustomizations = await _db.EventCustomizations.AsQueryable().ToListAsync();
 
             var recentEvents = await _db.Events.AsQueryable().Where(x => x.Ends > DateTimeOffset.Now.AddDays(-1)).ToListAsync();
 
@@ -51,26 +64,18 @@ namespace EGG9000.Bot.Automated {
 
             foreach(var e in endedEvents) {
                 e.Ended = true;
-                var customization = eventCustomizations.First(x => x.Type == e.Type);
-                var embed = GetEmbed(e, customization, Ended: true);
-                await UpdateMessages(e, embed, customization, _db);
+                await UpdateMessages(e, _db, Ended: true);
             }
 
             var events = response.Events.Events.ToList();
             foreach(var evt in events) {
                 var currentEvent = recentEvents.FirstOrDefault(x => x.Identifier == evt.Identifier);
-                var customization = eventCustomizations.FirstOrDefault(x => x.Type == evt.Type);
-                if(customization is null) {
-                    continue;
-                }
                 if(currentEvent == null) {
                     var newEvent = new Event(evt);
                     _db.Add(newEvent);
                     recentEvents.Add(newEvent);
 
-                    var embed = GetEmbed(newEvent, customization);
-
-                    await PostMessages(newEvent, embed, customization, _db);
+                    await PostMessages(newEvent, _db);
 
                     await _db.SaveChangesAsync();
                 } else {
@@ -100,13 +105,10 @@ namespace EGG9000.Bot.Automated {
 
                     if(!string.IsNullOrEmpty(currentEvent.MessageIds)) {
                         if(significantChange) {
-                            var embed = GetEmbed(currentEvent, customization, false);
-                            var crossOutEmbed = GetEmbed(currentEvent, customization, true);
-                            await UpdateMessages(currentEvent, crossOutEmbed, customization, _db);
-                            await PostMessages(currentEvent, embed, customization, _db);
+                            await UpdateMessages(currentEvent, _db, Crossout: true);
+                            await PostMessages(currentEvent, _db);
                         } else if (timeChange) {
-                            var embed = GetEmbed(currentEvent, customization, false);
-                            await UpdateMessages(currentEvent, embed, customization, _db);
+                            await UpdateMessages(currentEvent, _db);
                         }
                     }
                 }
@@ -122,13 +124,16 @@ namespace EGG9000.Bot.Automated {
                 /* 'Normal' Game Events channel*/
                 var channel = await _client.GetChannelAsync(GuildChannelType.GameEvents, guild);
                 if(channel != default) {
-                    var eventsWithCustom = recentEvents.Where(x => !x.Ended && !x.CcOnly).Select(x => new { Event = x, Custom = eventCustomizations.First(y => y.Type == x.Type) }).OrderByDescending(x => x.Custom.Priority);
+                    var eventsWithCustom = recentEvents.Where(x => !x.Ended && !x.CcOnly).Select(async x => new EventWithCustom {
+                        Event = x,
+                        Customization = await GetCustomizationAsync(_db, dbguild, x)
+                    }).Select(t => t.Result).ToList();
 
                     foreach(var e in eventsWithCustom) {
-                        if(e.Custom.Priority > 0 || true) {
-                            stackedEmoji += e.Custom.Emoji ?? "";
+                        if(e.Customization?.Priority > 0 || true) {
+                            stackedEmoji += e.Customization?.Emoji ?? "";
                         } else {
-                            singleEmoji = e.Custom.Emoji ?? "";
+                            singleEmoji = e.Customization?.Emoji ?? "";
                         }
                     }
                     if(stackedEmoji.Length > 0) {
@@ -150,12 +155,16 @@ namespace EGG9000.Bot.Automated {
                 /* Subscriber-Only Game Events channel */
                 var ccChannel = await _client.GetChannelAsync(GuildChannelType.SubscriptionGameEvents, guild);
                 if(ccChannel != null) {
-                    var ccEventsWithCustom = recentEvents.Where(x => !x.Ended && x.CcOnly).Select(x => new { Event = x, Custom = eventCustomizations.First(y => y.Type == x.Type) }).OrderByDescending(x => x.Custom.Priority);
+                    var ccEventsWithCustom = recentEvents.Where(x => !x.Ended && x.CcOnly).Select(async x => new EventWithCustom {
+                        Event = x,
+                        Customization = await GetCustomizationAsync(_db, dbguild, x)
+                    }).Select(t => t.Result).ToList();
+
                     foreach(var se in ccEventsWithCustom) {
-                        if(se.Custom.Priority > 0 || true) {
-                            stackedEmoji += se.Custom.Emoji ?? "";
+                        if(se.Customization?.Priority > 0 || true) {
+                            stackedEmoji += se.Customization?.Emoji ?? "";
                         } else {
-                            singleEmoji = se.Custom.Emoji ?? "";
+                            singleEmoji = se.Customization?.Emoji ?? "";
                         }
                     }
                     if(stackedEmoji.Length > 0) {
@@ -170,11 +179,16 @@ namespace EGG9000.Bot.Automated {
                 }
             }
         }
-        private async Task PostMessages(Event newEvent, Embed embed, EventCustomization customization, ApplicationDbContext _db) {
+        private async Task PostMessages(Event newEvent, ApplicationDbContext _db) {
             var messageIds = new List<ulong>();
             var dbguilds = await _db.Guilds.AsQueryable().ToListAsync();
             foreach(var dbguild in dbguilds) {
                 var guild = _client.Guilds.First(x => x.Id == dbguild.DiscordSeverId);
+
+                var customization = await GetCustomizationAsync(_db, dbguild, newEvent);
+                if(customization is null) continue;
+
+                var embed = GetEmbed(newEvent, customization, false, false);
 
                 var ccEventChannel = await _client.GetChannelAsync(GuildChannelType.SubscriptionGameEvents, guild);
                 var eventChannel = await _client.GetChannelAsync(GuildChannelType.GameEvents, guild);
@@ -186,7 +200,6 @@ namespace EGG9000.Bot.Automated {
 
                 //If the event is subscriber-only
                 if(newEvent.CcOnly) {
-
                     //Send to non-CCs without ping
                     if(eventChannel != null) {
                         message = await eventChannel.SendMessageAsync(null, embed: embed);
@@ -214,11 +227,17 @@ namespace EGG9000.Bot.Automated {
 
         }
 
-        private async Task UpdateMessages(Event currentEvent, Embed embed, EventCustomization customization, ApplicationDbContext _db) {
+        private async Task UpdateMessages(Event currentEvent, ApplicationDbContext _db, bool Ended = false, bool Crossout = false) {
             var messageIds = JsonConvert.DeserializeObject<List<ulong>>(currentEvent.MessageIds);
             var dbguilds = await _db.Guilds.AsQueryable().ToListAsync();
+            var palaceGuild = dbguilds.FirstOrDefault(g => g.Id == 656455567858073601);
             foreach(var dbguild in dbguilds) {
                 var guild = _client.Guilds.First(x => x.Id == dbguild.DiscordSeverId);
+
+                var customization = await GetCustomizationAsync(_db, dbguild, currentEvent);
+                if(customization is null) continue;
+
+                var embed = GetEmbed(currentEvent, customization, Ended, Crossout);
 
                 var eventChannel = await _client.GetChannelAsync(GuildChannelType.GameEvents, guild);
                 if(eventChannel != null) {
@@ -226,6 +245,7 @@ namespace EGG9000.Bot.Automated {
                         try {
                             var message = (RestUserMessage)await eventChannel.GetMessageAsync(mid);
                             if(message != null) {
+
                                 var notification = customization.Settings.Notifications?
                                     .OrderByDescending(x => x.MinValue)
                                     .FirstOrDefault(x => (decimal)currentEvent.Multiplier >= x.MinValue && x.GuildID == dbguild.DiscordSeverId);
@@ -368,7 +388,7 @@ namespace EGG9000.Bot.Automated {
             var embed = new EmbedBuilder()
                 .WithColor(shell.SecondsRemaining > 0 ? Color.Blue : Color.DarkGrey)
                 .WithAuthor("Egg, Inc Limited Time Shell", "https://vignette.wikia.nocookie.net/egg-inc/images/2/23/Egg-inc-icon.jpg/revision/latest/scale-to-width-down/180?cb=20160721002751")
-                .WithDescription($"New {expiringShell.AssetType.ToString()}: {expiringShell.Name} for {expiringShell.Price}<:tickets:998630687831769189>\nExpires <t:{DateTimeOffset.Now.AddSeconds(shell.SecondsRemaining).ToUnixTimeSeconds()}:R>")
+                .WithDescription($"New {expiringShell.AssetType}: {expiringShell.Name} for {expiringShell.Price}<:tickets:998630687831769189>\nExpires <t:{DateTimeOffset.Now.AddSeconds(shell.SecondsRemaining).ToUnixTimeSeconds()}:R>")
                 ;
             return embed.Build();
 

--- a/EGG9000.Bot/Automated/ShipReturnDM.cs
+++ b/EGG9000.Bot/Automated/ShipReturnDM.cs
@@ -54,7 +54,7 @@ namespace EGG9000.Bot.Automated {
                         var fuelingShip = backup.SpaceMissions.FirstOrDefault(m => m.Status == MissionInfo.Types.Status.Fueling);
                         var needsFuel = NeedsFuel(backup);
                         var nextShipDue = DateTimeOffset.FromUnixTimeSeconds(mission.ReturnTime);//.AddMinutes(needsFuel ? user.ShipReturnStillFuelingMinutes : user.ShipReturnMinutes);
-                        var nextShipName = mission.Ship.ToString().Replace("_", " ");
+                        var nextShipName = MissionHelpers.GetProperShipName(mission.Ship);
                         var minutesUntilShipReturns = (DateTimeOffset.Now - nextShipDue).Humanize(2);
 
                         var lastBackupTime = (DateTimeOffset.Now - DateTimeOffset.FromUnixTimeSeconds(backup.LastBackupTime)).Humanize(2).ShortenTime();

--- a/EGG9000.Bot/Automated/ShipReturnDM.cs
+++ b/EGG9000.Bot/Automated/ShipReturnDM.cs
@@ -183,10 +183,10 @@ namespace EGG9000.Bot.Automated {
         }
 
         private static bool NeedsFuel(CustomBackup backup) {
-            bool needsFuel = true;
+            var needsFuel = true;
             var currentShip = backup.SpaceMissions.FirstOrDefault(x => x.Status == MissionInfo.Types.Status.Fueling);
             if(currentShip != null) {
-                var fuelTargets = Ei.MissionInfo.GetFuelTargets(currentShip.Ship, currentShip.Duration);
+                var fuelTargets = MissionInfo.GetFuelTargets(currentShip.Ship, currentShip.Duration);
                 needsFuel = fuelTargets.Any(ft => ft.Value > (currentShip.Fuels.FirstOrDefault(f => f.Egg == ft.Key)?.Amount ?? 0));
             }
             return needsFuel;

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Hosting;
 using EGG9000.Common.JsonData.EiAfxData;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
+using EGG9000.Common.Database.Entities;
 
 namespace EGG9000.Bot.Commands.DiscordEnums {
     public class AutoCompleteHandlers {
@@ -200,6 +201,16 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                     .ToList()
                     .Select(x => new AutocompleteResult(PlayerGradeDetails.GetText((PlayerGrade)x), (uint)x));
 
+                await arg.RespondAsync(
+                    result
+                );
+            }
+        }
+
+        public class GradeAutoComplete() : AutoCompleteHandler {
+            public async Task Run(SocketAutocompleteInteraction arg) {
+                var result = Enumerable.Range(1, 5).Reverse().ToList()
+                    .Select(x => new AutocompleteResult(PlayerGradeDetails.GetText((PlayerGrade)x), (uint)x));
                 await arg.RespondAsync(
                     result
                 );

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -411,7 +411,7 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task AddCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client,
             [SlashParam(AutocompleteHandler = typeof(StaffContractAutoComplete))] string contract, 
-            [SlashParam] string coopname, [SlashParam(AutocompleteHandler = typeof(GradeAutoComplete))] uint grade
+            [SlashParam] string coopname, [SlashParam(AutocompleteHandler = typeof(GradeAutoComplete))] uint grade,
             [SlashParam(Description = "Is the coop any-grade?",Required = false)] bool anygrade = false) {
 
             if(grade < 0 || grade > 5) {

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -325,7 +325,7 @@ namespace EGG9000.Bot.Commands {
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.Id == Guid.Parse(userid));
             var account = dbuser.EggIncAccounts.OrderByDescending(x => x.Backup?.EarningsBonus).ToList()[int.Parse(useraccount.Split("|")[1])];
 
-            var newCoopResponse = await FindPotentialCoopForUser(account, contract, guildRef, _client, db);
+            var newCoopResponse = await FindPotentialCoopForUser(account, contract, guildRef, _client, db, priority);
 
             switch(newCoopResponse.Response) {
                 case PotentialCoopCode.NonUltra:
@@ -406,37 +406,30 @@ namespace EGG9000.Bot.Commands {
         //    await command.Channel.SendMessageAsync($"{coopsBreakdown.PotentialCoops.SelectMany(x => x.CoopParticipants).Count()} prefarmers added");
         //}
 
+        //GradeAutoComplete
 
         [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.FarmHand)]
-        public static async Task AddCoop(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketChannel contractchannel, [SlashParam] string coopname, [SlashParam] string grade) {
-            var guildContract = db.GuildContracts.Include(x => x.Contract).FirstOrDefault(x => x.DiscordChannelId == contractchannel.Id);
+        public static async Task AddCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client,
+            [SlashParam(AutocompleteHandler = typeof(StaffContractAutoComplete))] string contract, 
+            [SlashParam] string coopname,
+            [SlashParam(AutocompleteHandler = typeof(GradeAutoComplete))] uint grade) {
+
+            var dbContract = db.Contracts.FirstOrDefault(c => c.ID == contract);
+            if(contract is null) {
+                await command.RespondAsync(content: "", embed: EmbedError("Contract not found - please use dropdown menu."));
+                return;
+            }
+
+            var guildContract = db.GuildContracts.Include(x => x.Contract).FirstOrDefault(x => x.Contract.ID == dbContract.ID);
             if(guildContract == null) {
                 await command.RespondAsync(content: "", embed: EmbedError("Unable to find contract details, have you tagged a contract channel?"));
                 return;
             }
 
-            int league = 0;
-            switch(grade.ToLower().Trim()) {
-                case "aaa":
-                    league = 5;
-                    break;
-                case "aa":
-                    league = 4;
-                    break;
-                case "a":
-                    league = 3;
-                    break;
-                case "b":
-                    league = 2;
-                    break;
-                case "c":
-                    league = 1;
-                    break;
-            }
+            var contractChannel = (await _client.GetChannelAsync(guildContract.DiscordChannelId) as SocketTextChannel);
 
             var status = await ContractsAPI.GetCoopStatus(guildContract.ContractID, coopname.ToLower());
             if(status != null && status.Success) {
-
                 var coop = new Coop {
                     ContractID = guildContract.ContractID,
                     Created = DateTimeOffset.Now,
@@ -444,15 +437,15 @@ namespace EGG9000.Bot.Commands {
                     Name = coopname,
                     MaxUsers = guildContract.Contract.MaxUsers,
                     Status = CoopStatusEnum.WaitingOnAssigned,
-                    League = (uint)league,
+                    League = grade,
                     CoopEnds = DateTimeOffset.Now.AddSeconds(status.SecondsRemaining)
                 };
                 db.Coops.Add(coop);
                 await db.SaveChangesAsync();
-                await command.RespondAsync($"Co-op Added: {coopname} for {((SocketTextChannel)contractchannel).Mention}");
+                await command.RespondAsync(content: "", embed: EmbedSuccess($"Co-op `{coopname}` added for {contractChannel.Mention}"));
                 return;
             } else {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find co-op details, double check co-op name ({coopname}) and correct contract channel ({((SocketTextChannel)contractchannel).Mention})."));
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find co-op details, double check co-op name (`{coopname}`) and correct contract channel ({contractChannel.Mention})."));
                 return;
             }
         }
@@ -631,7 +624,7 @@ namespace EGG9000.Bot.Commands {
 
 
         [SlashCommand(Description = "Remove user from co-op (only works if the bot doesn't see them as joined)", AdminOnly = StaffOnlyLevel.FarmHand)]
-        public static async Task RemoveFromCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, [SlashParam(AutocompleteHandler = typeof(RemoveFromCoopAutoComplete))] string useraccount) {
+        public static async Task RemoveFromCoop(FauxCommand command, ApplicationDbContext db, [SlashParam(AutocompleteHandler = typeof(RemoveFromCoopAutoComplete))] string useraccount) {
             await command.DeferAsync();
             var targetCoop = await db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.DiscordChannelId == command.Channel.Id);
             if(targetCoop == null) {
@@ -656,7 +649,7 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Delete a contract channel (Please use this instead of deleting the channel in discord)", AdminOnly = StaffOnlyLevel.Admin)]
-        public static async Task DeleteContract(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client) {
+        public static async Task DeleteContract(FauxCommand command, ApplicationDbContext db) {
             var guildContract = db.GuildContracts.Include(x => x.Contract).FirstOrDefault(x => x.DiscordChannelId == command.Channel.Id);
             if(guildContract == null) {
                 await command.RespondAsync(content: "", embed: EmbedError("Unable to find contract, use only in contract channels."));
@@ -676,7 +669,11 @@ namespace EGG9000.Bot.Commands {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find user"); });
                 return;
             }
-            var contract = await db.Contracts.FirstAsync(x => x.ID == contractid);
+            var contract = await db.Contracts.FirstOrDefaultAsync(x => x.ID == contractid);
+            if(contract is null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to find contract from input. Please select a choice from the list"); });
+                return;
+            }
             var guildContract = await db.GuildContracts.FirstAsync(gc => gc.GuildID == command.GuildId && gc.Contract == contract);
 
             var subscriptionAccountsCount = user.EggIncAccounts.Where(x => x.HasActiveSubscription()).Count();

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -299,7 +299,9 @@ namespace EGG9000.Bot.Commands {
                 var users = await db.DBUsers.Where(x => userids.Contains(x.Id)).ToListAsync();
                 var usersWithBackups = users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Account = y, Backup = y.Backup, User = x })).ToList();
                 var details = new CoopDetails(coop, contract, (uint)account.GetGrade(), usersWithBackups, _client, coop.LastStatusUpdate);
-                if(coop.DeletedChannel || _client.GetGuild(coop.GuildId).GetChannel(coop.DiscordChannelId) == null) continue;
+                var coopChannel = await _client.GetChannelAsync(coop.DiscordChannelId);
+                if(coopChannel == null) coopChannel = _client.GetGuild(coop.OverflowGuildId).GetChannel(coop.DiscordChannelId);
+                if(coop.DeletedChannel || coopChannel == null) continue;
                 if(details.HasSpots) {
                     newCoop = coop;
                     break;

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -407,7 +407,7 @@ namespace EGG9000.Bot.Commands {
         //}
 
 
-        [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task AddCoop(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketChannel contractchannel, [SlashParam] string coopname, [SlashParam] string grade) {
             var guildContract = db.GuildContracts.Include(x => x.Contract).FirstOrDefault(x => x.DiscordChannelId == contractchannel.Id);
             if(guildContract == null) {

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -411,8 +411,13 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task AddCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client,
             [SlashParam(AutocompleteHandler = typeof(StaffContractAutoComplete))] string contract, 
-            [SlashParam] string coopname,
-            [SlashParam(AutocompleteHandler = typeof(GradeAutoComplete))] uint grade) {
+            [SlashParam] string coopname, [SlashParam(AutocompleteHandler = typeof(GradeAutoComplete))] uint grade
+            [SlashParam(Description = "Is the coop any-grade?",Required = false)] bool anygrade = false) {
+
+            if(grade < 0 || grade > 5) {
+                await command.RespondAsync(content: "", embed: EmbedError($"Specified grade value (`{grade}`) outside of bounds (1-5)."));
+                return;
+            }
 
             var dbContract = db.Contracts.FirstOrDefault(c => c.ID == contract);
             if(contract is null) {
@@ -438,6 +443,7 @@ namespace EGG9000.Bot.Commands {
                     MaxUsers = guildContract.Contract.MaxUsers,
                     Status = CoopStatusEnum.WaitingOnAssigned,
                     League = grade,
+                    AnyLeague = anygrade,
                     CoopEnds = DateTimeOffset.Now.AddSeconds(status.SecondsRemaining)
                 };
                 db.Coops.Add(coop);

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -33,7 +33,7 @@ namespace EGG9000.Bot.Commands {
             try { account = dbuser.EggIncAccounts[int.Parse(useraccount.Split("|")[1])]; } catch(Exception) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Please select an account from the list, instead of typing an input."); }); return; }
             if(account is null) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"User account for {userid} could not be found"); }); return; }
 
-            await _viewInventory(command, dbuser, account, showinchannel);
+            await _viewInventory(command, db, dbuser, account, showinchannel);
         }
 
         [SlashCommand(Description = "View your inventory")]

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -16,6 +16,8 @@ using static EGG9000.Common.Helpers.ArtifactHelpers;
 using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 using Discord;
 using System.Text.RegularExpressions;
+using EGG9000.Bot.EggIncAPI;
+using Ei;
 
 namespace EGG9000.Bot.Commands {
     public static class ArtifactCommands {
@@ -61,10 +63,21 @@ namespace EGG9000.Bot.Commands {
             try { account = dbuser.EggIncAccounts[int.Parse(useraccount.Split("|")[1])]; } catch(Exception) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Please select an account from the list, instead of typing an input."); }); return; }
             if(account is null) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"User account for {userid} could not be found"); }); return; }
 
-            await _viewInventory(command, dbuser, account);
+            await _viewInventory(command, db, dbuser, account);
         }
 
-        public static async Task _viewInventory(FauxCommand command, DBUser user, EggIncAccount account, bool showInChannel = true) {
+        public static async Task _viewInventory(FauxCommand command, ApplicationDbContext db, DBUser user, EggIncAccount account, bool showInChannel = true) {
+            //Pull and save a fresh backup
+            var backup = new CustomBackup((await ContractsAPI.FirstContact(account.Id)).Backup, account.Backup ?? null);
+            account.Backup.ArtifactHall = backup.ArtifactHall;
+            user.UpdateAccounts();
+            await db.SaveChangesAsync();
+
+            if(account.Backup is null || account.Backup.ArtifactHall is null) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Backup came back as empty from the Egg, Inc. API."); });
+                return;
+            }
+
             var (B64, Config) = InventoryB64(account);
             if(string.IsNullOrEmpty(B64)) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("User inventory could not be converted."); }); return; }
 

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -120,8 +120,8 @@ namespace EGG9000.Bot.Commands {
             } else if(dbUser.EggIncAccounts.Any(x => x.Id == eggincid)) {
                 dbUser.RemoveID(eggincid);
             } else {
-                Embed[] embedArrayErr = { EmbedError($"Unable to find the EggIncId `{eggincid}` registered with <@{userid}>") };
-                embedArrayErr = embedArrayErr.Concat(AccountsString(db, dbUser, apiLink, false).Result.Select(b => b.Build()).ToArray()).ToArray();
+                Embed[] embedArrayErr = [EmbedError($"Unable to find the EggIncId `{eggincid}` registered with <@{userid}>")];
+                embedArrayErr = [.. embedArrayErr, .. AccountsString(db, dbUser, apiLink, false).Result.Select(b => b.Build()).ToArray()];
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embeds = embedArrayErr; });
                 return;
             }

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -27,6 +27,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using static EGG9000.Common.Helpers.Prefarm;
 
 namespace EGG9000.Common.Services {
 
@@ -155,6 +156,7 @@ namespace EGG9000.Common.Services {
             }
 
             if(dbuser != null && dbuser.GuildId == user.Guild.Id) {
+                await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, new List<LeaderboardUser>());
                 var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!" }, _logger);
                 await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
                 return;
@@ -162,7 +164,9 @@ namespace EGG9000.Common.Services {
                 var previouslyHere = await db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.GuildId == user.Guild.Id);
                 if(previouslyHere) {
                     dbuser.GuildId = user.Guild.Id;
+                    dbuser.UpdateAccounts();
                     await db.SaveChangesAsync();
+                    await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, new List<LeaderboardUser>());
                     var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!" }, _logger);
                     await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
                     return;

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -145,8 +145,14 @@ namespace EGG9000.Common.Services {
                 return;
             }
 
+            
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
-            if(dbuser is not null && dbuser.TempDisabled) await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(user.Guild.Id), GuildChannelType.BannedUserThread, new() { Text = $"{user.Mention} just joined and is disabled." }, _logger);
+            if(dbuser is not null && dbuser.TempDisabled) {
+                var welChannel = await _discord.GetChannelAsync(GuildChannelType.Welcome, user.Guild);
+                var disabledMsg = $"Welcome to the server {user.Mention}! Looks like you are currently disabled, please wait for someone from staff to get you re-enabled.";
+                await welChannel.SendMessageAsync(disabledMsg);
+                await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(user.Guild.Id), GuildChannelType.BannedUserThread, new() { Text = $"{user.Mention} just joined and is disabled." }, _logger);
+            }
 
             if(dbuser != null && dbuser.GuildId == user.Guild.Id) {
                 var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!" }, _logger);
@@ -157,6 +163,8 @@ namespace EGG9000.Common.Services {
                 if(previouslyHere) {
                     dbuser.GuildId = user.Guild.Id;
                     await db.SaveChangesAsync();
+                    var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!" }, _logger);
+                    await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
                     return;
                 }
             }
@@ -164,7 +172,6 @@ namespace EGG9000.Common.Services {
 #if DEV9002
             return;
 #endif
-
             var welcomeChannel = await _discord.GetChannelAsync(GuildChannelType.Welcome, user.Guild);
             var rulesChannel = await _discord.GetChannelAsync(GuildChannelType.Rules, user.Guild);
             var msg = $"Welcome to the server {user.Mention}! Please read {rulesChannel.Mention} and then use the </accept:1095116354329268368> command when you are ready.";

--- a/EGG9000.Common/Contracts/OrganizeCoops.cs
+++ b/EGG9000.Common/Contracts/OrganizeCoops.cs
@@ -44,8 +44,6 @@ namespace EGG9000.Common.Contracts {
 
             FilterAccounts(accounts, excluded, x => CheckOnPreviousComplete(x, contract, accounts.Where(a => a.User == x.User && a.Account.Id != x.Account.Id).ToList()), "Previously completed");
           
-
-          
             FilterAccounts(accounts, excluded, x => x.Account.OnBreakUntil < DateTimeOffset.Now, "On break");
 
             FilterAccounts(accounts, excluded, x => !x.Account.Backup.Farms.Any(y => y.ContractId == contract.ID && y.FarmType == Ei.FarmType.Contract), "Already In Co-op");
@@ -158,7 +156,7 @@ namespace EGG9000.Common.Contracts {
                 ua.Account.Id != x.Account.Id &&
                 MatchGrade(ua.Account, x.Account, contract) &&
                 MatchGroup(ua.Account, x.Account, contract) &&
-                CheckOnPreviousComplete(ua, contract, new List<UserByAccount>())
+                CheckOnPreviousComplete(ua, contract, [])
             )) return true;
 
             if(contract.HadTwoRewards) {
@@ -169,13 +167,19 @@ namespace EGG9000.Common.Contracts {
                     return true;
                 }
             }
+
+            if(contract.Details.Leggacy && x.Account.RedoLeggacySelection == RedoLeggacyOption.No 
+                && (
+                    x.Account.Backup.Farms.Any(f => f.Completed && f.ContractId == contract.ID) ||
+                    x.Account.Backup.ArchivedFarms.Any(f => f.Completed && f.ContractId == contract.ID)
+                ))
+                return false;
+
             return (!x.Account.Backup.Farms.Any(f => f.ContractId == contract.ID && f.Completed) && !x.Account.Backup.ArchivedFarms.Any(f => f.ContractId == contract.ID && f.Completed));
         }
 
         private static List<PotentialCoop> _SortUsersIntoDay1Coops(IEnumerable<UserByAccount> Accounts, int BoardingGroup, Ei.Contract.Types.PlayerGrade Grade, Ei.Contract contract, List<int> includeBG, bool dontMergeDown, bool AllowGuilds, int overrideNumber = 0, ulong roleid = 0) {
-            IEnumerable<UserByAccount> matchingAccounts = Accounts.Where(x =>
-                    x.Account.GetGrade() == Grade  || contract.CcOnly 
-                );
+            var matchingAccounts = Accounts.Where(x => x.Account.GetGrade() == Grade || contract.CcOnly );
 
             if(roleid > 0) {
                 matchingAccounts = matchingAccounts.Where(x => x.RoleId == roleid);

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -41,6 +41,7 @@ namespace EGG9000.Common.Database.Entities {
         public bool DeletedChannel { get; set; }
         public uint FindChannelErrors { get; set; } = 0;
         public ulong Group { get; set; }
+        public bool AddedFromBackup { get; set; } = false;
 
         public CoopStatusEnum Status { get; set; }
         //public int UnableToFind { get; set; }

--- a/EGG9000.Common/Database/Entities/EventCustomization.cs
+++ b/EGG9000.Common/Database/Entities/EventCustomization.cs
@@ -29,10 +29,10 @@ namespace EGG9000.Common.Database.Entities
             {
                 return JsonConvert.DeserializeObject<EventCustomizationSettings>(_settings ?? "{}");
             }
-
+            set {
+                _settings = JsonConvert.SerializeObject(value);
+            }
         }
-
-
     }
 
     public class EventField
@@ -51,5 +51,13 @@ namespace EGG9000.Common.Database.Entities
         public ulong GuildID { get; set; }
         public decimal MinValue { get; set; }
         public ulong RoleID { get; set; }
+        public string RoleIdString {
+            get {
+                return RoleID.ToString();
+            }
+            set {
+                RoleID = ulong.Parse(value);
+            }
+        }
     }
 }

--- a/EGG9000.Common/Database/Entities/Guild.cs
+++ b/EGG9000.Common/Database/Entities/Guild.cs
@@ -48,7 +48,9 @@ namespace EGG9000.Common.Database.Entities {
         //public ulong? FailedCategory { get; set; }
         public string CoopCategories { get; set; }
         public string FinishedCategories { get; set; }
-        
+
+        public bool AddOutsideCoops { get; set; } = true;
+
         public string _coopSettingsJson { get; set; }
         [NotMapped]
         private List<ServerCoopSetting> _coopSettings { get; set; }

--- a/EGG9000.Common/Helpers/Discord/ChannelHelper.cs
+++ b/EGG9000.Common/Helpers/Discord/ChannelHelper.cs
@@ -42,6 +42,8 @@ namespace EGG9000.Bot.Common.Helpers {
             public ISticker[] Stickers { get; set; } = null;
             public Embed[] Embeds { get; set; } = null;
             public MessageFlags Flags { get; set; } = MessageFlags.None;
+            public FileAttachment File { get; set; }
+            public bool SendFile { get; set; } = false;
         }
 
         public static async Task<Discord.Rest.RestUserMessage> DetermineAndSend(ApplicationDbContext db, DiscordSocketClient _client, Guild dbGuild, SocketGuild discordGuild, GuildChannelType channelType, CustomDiscordMessage message, ILogger logger = null) {
@@ -53,11 +55,19 @@ namespace EGG9000.Bot.Common.Helpers {
             if(channel is null ) return null;
 
             if(channel.GetType() == typeof(SocketThreadChannel)) {
-                return await ((SocketThreadChannel)channel).SendMessageAsync(message.Text, message.IsTTS, message.Embed, message.Options, message.AllowedMentions, message.MessageReference, message.Components, message.Stickers, message.Embeds, message.Flags);
+                if(message.SendFile) {
+                    return await ((SocketThreadChannel)channel).SendFileAsync(message.File, message.Text, message.IsTTS, message.Embed, message.Options, message.AllowedMentions, message.MessageReference, message.Components, message.Stickers, message.Embeds, message.Flags);
+                } else {
+                    return await ((SocketThreadChannel)channel).SendMessageAsync(message.Text, message.IsTTS, message.Embed, message.Options, message.AllowedMentions, message.MessageReference, message.Components, message.Stickers, message.Embeds, message.Flags);
+                }
             } else if(channel.GetType() == typeof(SocketTextChannel)) {
-                return await ((SocketTextChannel)channel).SendMessageAsync(message.Text, message.IsTTS, message.Embed, message.Options, message.AllowedMentions, message.MessageReference, message.Components, message.Stickers, message.Embeds, message.Flags);
+                if(message.SendFile) {
+                    return await ((SocketTextChannel)channel).SendFileAsync(message.File, message.Text, message.IsTTS, message.Embed, message.Options, message.AllowedMentions, message.MessageReference, message.Components, message.Stickers, message.Embeds, message.Flags);
+                } else {
+                    return await ((SocketTextChannel)channel).SendMessageAsync(message.Text, message.IsTTS, message.Embed, message.Options, message.AllowedMentions, message.MessageReference, message.Components, message.Stickers, message.Embeds, message.Flags);
+                }
             } else {
-                if(logger is not null) logger.LogWarning("DetermineAndSend called, expected type of SocketTextChannel or SocketThreadChannel. Instead found type of " + channel.GetType());
+                if(logger is not null) logger.LogWarning("DetermineAndSend called, expected type of SocketTextChannel or SocketThreadChannel. Instead found type of {type}", channel.GetType());
                 return null;
             }
         }

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -259,6 +259,12 @@ namespace EGG9000.Bot.Helpers {
                         break;
                 }
 
+                //Hocho
+                if(discordUser.Id == 321314664397144074) {
+                    messages = [
+                        $"Congratulations on this eggmazing achievement {discordUser.Mention}, I remember everything from your eggventure. From joining at 8.7o%, to racing Ashmyne to be our first Xenna, to wiping the floor with everyone and being our first Wecca. Now, we celebrate you reaching Vendafarmer! May you continue to inspire our farmers to reach new EB heights."
+                    ];
+                }
 
 
                 var random = new Random();
@@ -453,7 +459,7 @@ namespace EGG9000.Bot.Helpers {
         private static async Task CheckASCRole(DiscordHostedService _client, SocketGuild Guild, IGuildUser DiscordUser, DBUser user) {
             var ascRole = await _client.GetRoleAsync(GuildChannelType.ASCRole, Guild);
             if(ascRole is not null) {
-                var needsRole = user.EggIncAccounts.Where(x => x.Backup is not null && x.Backup.ShipsSent is not null).Any(x => MissionHelpers.HasMaxedShips(x.Backup));
+                var needsRole = user.EggIncAccounts.Where(x => x.Backup is not null && x.Backup.ShipsSent is not null).Any(x => x.Backup.HasMaxedShips());
                 var hasRole = DiscordUser.RoleIds.Any(x => x == ascRole.Id);
 
                 if(!hasRole && needsRole) {

--- a/EGG9000.Common/Helpers/EggIncBoosts.cs
+++ b/EGG9000.Common/Helpers/EggIncBoosts.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using static EGG9000.Common.Helpers.EggIncBoostTypeEnum;
+
 namespace EGG9000.Common.Helpers {
     public class EggIncBoosts {
         public static EggIncBoost FromId(string id) {
@@ -10,43 +12,41 @@ namespace EGG9000.Common.Helpers {
         }
 
         public static List<EggIncBoost> GetBoosts() {
-            return new List<EggIncBoost> {
-                new EggIncBoost { Id = "quantum_bulb", Type = EggIncBoostTypeEnum.UnlimitedHatchery, Name = "Quantum Bulb", Emoji = "<:Quantum_bulb:724397149118267424>", Time = TimeSpan.FromMinutes(10), Value = 0, CostGoldenEggs = 10, CostTokens = 0 },
-                new EggIncBoost { Id = "jimbos_blue", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Excellent Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(60), Value = 2, CostGoldenEggs = 50, CostTokens = 1 },
-                    new EggIncBoost { Id = "jimbos_blue_v2", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Excellent Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(60), Value = 2, CostGoldenEggs = 50, CostTokens = 1 },
-                new EggIncBoost { Id = "jimbos_blue_big", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Excellent Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(480), Value = 2, CostTokens = 1 },
-                new EggIncBoost { Id = "jimbos_purple", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Premium Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 250, CostTokens = 2 },
-                    new EggIncBoost { Id = "jimbos_purple_v2", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Premium Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 250, CostTokens = 2 },
-                new EggIncBoost { Id = "jimbos_purple_big", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Premium Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(120), Value = 10, CostGoldenEggs = 750, CostTokens = 3 },
-                new EggIncBoost { Id = "jimbos_orange", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Best Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(10), Value = 50, CostGoldenEggs = 2500, CostTokens = 3 },
-                new EggIncBoost { Id = "jimbos_orange_big", Type = EggIncBoostTypeEnum.Earnings, Name = "Jimbo's Best Bird Feed", Emoji = "<:Jimbos_60min_Bird:751625095230914662>", Time = TimeSpan.FromMinutes(60), Value = 50, CostGoldenEggs = 7500, CostTokens = 5 },
-                new EggIncBoost { Id = "tachyon_prism_blue", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 100, CostTokens = 1 },
-                    new EggIncBoost { Id = "tachyon_prism_blue_v2", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 100, CostTokens = 1 },
-                new EggIncBoost { Id = "tachyon_prism_blue_big", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Large Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(240), Value = 10, CostGoldenEggs = 600, CostTokens = 3 },
-                new EggIncBoost { Id = "tachyon_prism_purple", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Powerful Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(20), Value = 100, CostGoldenEggs = 750, CostTokens = 3 },
-                    new EggIncBoost { Id = "tachyon_prism_purple_v2", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Powerful Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(20), Value = 100, CostGoldenEggs = 750, CostTokens = 3 },
-                new EggIncBoost { Id = "tachyon_prism_purple_big", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Epic Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(120), Value = 100, CostGoldenEggs = 4000, CostTokens = 5 },
-                new EggIncBoost { Id = "tachyon_prism_orange", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Legendary Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(10), Value = 1000, CostGoldenEggs = 15000, CostTokens = 8 },
-                new EggIncBoost { Id = "tachyon_prism_orange_big", Type = EggIncBoostTypeEnum.InternalHatchery, Name = "Supreme Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(60), Value = 1000, CostGoldenEggs = 25000, CostTokens = 20 },
-                new EggIncBoost { Id = "boost_beacon_blue", Type = EggIncBoostTypeEnum.BoostBeacon, Name = "Boost Beacon", Emoji = "<:Legendary_boost:748221091809591307>", Time = TimeSpan.FromMinutes(30), Value = 2, CostGoldenEggs = 1000, CostTokens = 5 },
-                new EggIncBoost { Id = "boost_beacon_purple", Type = EggIncBoostTypeEnum.BoostBeacon, Name = "Epic Boost Beacon", Emoji = "<:Epic_Boost_Beacon:748220232971059291>", Time = TimeSpan.FromMinutes(10), Value = 10, CostGoldenEggs = 5000, CostTokens = 10 },
-                new EggIncBoost { Id = "boost_beacon_blue_big", Type = EggIncBoostTypeEnum.BoostBeacon, Name = "Large Boost Beacon", Emoji = "<:Boost_Beacon5x:761737943152459778>", Time = TimeSpan.FromMinutes(60), Value = 5, CostGoldenEggs = 75000, CostTokens = 15 },
-                new EggIncBoost { Id = "boost_beacon_orange", Type = EggIncBoostTypeEnum.BoostBeacon, Name = "Legendary Boost Beacon", Emoji = "<:Legendary_boost:748221091809591307>", Time = TimeSpan.FromMinutes(10), Value = 50, CostGoldenEggs = 30000, CostTokens = 50 },
-                new EggIncBoost { Id = "soul_beacon_blue", Type = EggIncBoostTypeEnum.SoulEggs, Name = "Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(60), Value = 5, CostGoldenEggs = 250  },
-                    new EggIncBoost { Id = "soul_beacon_blue_v2", Type = EggIncBoostTypeEnum.SoulEggs, Name = "Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(60), Value = 5, CostGoldenEggs = 250  },
-                new EggIncBoost { Id = "soul_beacon_purple", Type = EggIncBoostTypeEnum.SoulEggs, Name = "Epic Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(30), Value = 50, CostGoldenEggs = 2500 },
-                    new EggIncBoost { Id = "soul_beacon_purple_v2", Type = EggIncBoostTypeEnum.SoulEggs, Name = "Epic Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(30), Value = 50, CostGoldenEggs = 2500 },
-                new EggIncBoost { Id = "soul_beacon_orange", Type = EggIncBoostTypeEnum.SoulEggs, Name = "Legendary Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(10), Value = 500, CostGoldenEggs = 15000  },
-                new EggIncBoost { Id = "subsidy_application", Type = EggIncBoostTypeEnum.FarmValue, Name = "Subsidy Application", Emoji = "<:B_money_printer:730145142467723367>", Time = TimeSpan.FromMinutes(0), Value = 10, CostGoldenEggs = 150, CostTokens = 1 },
-                new EggIncBoost { Id = "blank_check", Type = EggIncBoostTypeEnum.FarmValue, Name = "Blank Check", Emoji = "<:B_money_printer:730145142467723367>", Time = TimeSpan.FromMinutes(0), Value = 100, CostGoldenEggs = 500, CostTokens = 2 },
-                new EggIncBoost { Id = "money_printer", Type = EggIncBoostTypeEnum.FarmValue, Name = "Money Printer", Emoji = "<:B_money_printer:730145142467723367>", Time = TimeSpan.FromMinutes(0), Value = 500, CostGoldenEggs = 2000, CostTokens = 3 },
-                new EggIncBoost { Id = "soul_mirror_blue", Type = EggIncBoostTypeEnum.SoulMirror, Name = "Soul Mirror", Emoji = "<:Soul_Mirror:798884954670891059>", Time = TimeSpan.FromMinutes(10), Value = 0, CostGoldenEggs = 100, CostTokens = 5 },
-                new EggIncBoost { Id = "soul_mirror_purple", Type = EggIncBoostTypeEnum.SoulMirror, Name = "Epic Soul Mirror", Emoji = "<:Soul_Mirror:798884954670891059>", Time = TimeSpan.FromMinutes(60), Value = 0, CostGoldenEggs = 500, CostTokens = 25 },
-                new EggIncBoost { Id = "soul_mirror_orange", Type = EggIncBoostTypeEnum.SoulMirror, Name = "Legendary Soul Mirror", Emoji = "<:Soul_Mirror:798884954670891059>", Time = TimeSpan.FromMinutes(1440), Value = 0, CostGoldenEggs = 2000, CostTokens = 50 },
-                new EggIncBoost { Id = "dilithium_bulb", Type = EggIncBoostTypeEnum.UnlimitedHatchery, Name = "Dilithium Warming Bulb", Emoji = "<:dili_bulb:1116601590003023882>", Time = TimeSpan.FromMinutes(10), Value = 0, CostGoldenEggs = 1000, CostTokens = 0 }
-
-                
-            };
+            return [
+                new () { Id = "quantum_bulb", Type = UnlimitedHatchery, Name = "Quantum Bulb", Emoji = "<:Quantum_bulb:724397149118267424>", Time = TimeSpan.FromMinutes(10), Value = 0, CostGoldenEggs = 10, CostTokens = 0 },
+                new () { Id = "jimbos_blue", Type = Earnings, Name = "Jimbo's Excellent Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(60), Value = 2, CostGoldenEggs = 50, CostTokens = 1 },
+                new () { Id = "jimbos_blue_v2", Type = Earnings, Name = "Jimbo's Excellent Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(60), Value = 2, CostGoldenEggs = 50, CostTokens = 1 },
+                new () { Id = "jimbos_blue_big", Type = Earnings, Name = "Jimbo's Excellent Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(480), Value = 2, CostTokens = 1 },
+                new () { Id = "jimbos_purple", Type = Earnings, Name = "Jimbo's Premium Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 250, CostTokens = 2 },
+                new () { Id = "jimbos_purple_v2", Type = Earnings, Name = "Jimbo's Premium Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 250, CostTokens = 2 },
+                new () { Id = "jimbos_purple_big", Type = Earnings, Name = "Jimbo's Premium Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(120), Value = 10, CostGoldenEggs = 750, CostTokens = 3 },
+                new () { Id = "jimbos_orange", Type = Earnings, Name = "Jimbo's Best Bird Feed", Emoji = "<:Jimbos_10min_Bird:751626448644734986>", Time = TimeSpan.FromMinutes(10), Value = 50, CostGoldenEggs = 2500, CostTokens = 3 },
+                new () { Id = "jimbos_orange_big", Type = Earnings, Name = "Jimbo's Best Bird Feed", Emoji = "<:Jimbos_60min_Bird:751625095230914662>", Time = TimeSpan.FromMinutes(120), Value = 50, CostGoldenEggs = 7500, CostTokens = 5 },
+                new () { Id = "tachyon_prism_blue", Type = InternalHatchery, Name = "Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 100, CostTokens = 1 },
+                new () { Id = "tachyon_prism_blue_v2", Type = InternalHatchery, Name = "Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(30), Value = 10, CostGoldenEggs = 100, CostTokens = 1 },
+                new () { Id = "tachyon_prism_blue_big", Type = InternalHatchery, Name = "Large Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(240), Value = 10, CostGoldenEggs = 600, CostTokens = 3 },
+                new () { Id = "tachyon_prism_purple", Type = InternalHatchery, Name = "Powerful Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(20), Value = 100, CostGoldenEggs = 750, CostTokens = 3 },
+                new () { Id = "tachyon_prism_purple_v2", Type = InternalHatchery, Name = "Powerful Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(20), Value = 100, CostGoldenEggs = 750, CostTokens = 3 },
+                new () { Id = "tachyon_prism_purple_big", Type = InternalHatchery, Name = "Epic Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(120), Value = 100, CostGoldenEggs = 4000, CostTokens = 5 },
+                new () { Id = "tachyon_prism_orange", Type = InternalHatchery, Name = "Legendary Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(10), Value = 1000, CostGoldenEggs = 15000, CostTokens = 8 },
+                new () { Id = "tachyon_prism_orange_big", Type = InternalHatchery, Name = "Supreme Tachyon Prism", Emoji = "<:Legendary_tachyon_prism:724391780598153236>", Time = TimeSpan.FromMinutes(60), Value = 1000, CostGoldenEggs = 25000, CostTokens = 20 },
+                new () { Id = "boost_beacon_blue", Type = BoostBeacon, Name = "Boost Beacon", Emoji = "<:Legendary_boost:748221091809591307>", Time = TimeSpan.FromMinutes(30), Value = 2, CostGoldenEggs = 1000, CostTokens = 5 },
+                new () { Id = "boost_beacon_purple", Type = BoostBeacon, Name = "Epic Boost Beacon", Emoji = "<:Epic_Boost_Beacon:748220232971059291>", Time = TimeSpan.FromMinutes(10), Value = 10, CostGoldenEggs = 5000, CostTokens = 10 },
+                new () { Id = "boost_beacon_blue_big", Type = BoostBeacon, Name = "Large Boost Beacon", Emoji = "<:Boost_Beacon5x:761737943152459778>", Time = TimeSpan.FromMinutes(60), Value = 5, CostGoldenEggs = 75000, CostTokens = 15 },
+                new () { Id = "boost_beacon_orange", Type = BoostBeacon, Name = "Legendary Boost Beacon", Emoji = "<:Legendary_boost:748221091809591307>", Time = TimeSpan.FromMinutes(10), Value = 50, CostGoldenEggs = 30000, CostTokens = 50 },
+                new () { Id = "soul_beacon_blue", Type = SoulEggs, Name = "Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(60), Value = 5, CostGoldenEggs = 250  },
+                new () { Id = "soul_beacon_blue_v2", Type = SoulEggs, Name = "Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(60), Value = 5, CostGoldenEggs = 250  },
+                new () { Id = "soul_beacon_purple", Type = SoulEggs, Name = "Epic Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(30), Value = 50, CostGoldenEggs = 2500 },
+                new () { Id = "soul_beacon_purple_v2", Type = SoulEggs, Name = "Epic Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(30), Value = 50, CostGoldenEggs = 2500 },
+                new () { Id = "soul_beacon_orange", Type = SoulEggs, Name = "Legendary Soul Beacon", Emoji = "<:Soul_beacon500x:724391496240988192>", Time = TimeSpan.FromMinutes(10), Value = 500, CostGoldenEggs = 15000  },
+                new () { Id = "subsidy_application", Type = FarmValue, Name = "Subsidy Application", Emoji = "<:B_money_printer:730145142467723367>", Time = TimeSpan.FromMinutes(0), Value = 10, CostGoldenEggs = 150, CostTokens = 1 },
+                new () { Id = "blank_check", Type = FarmValue, Name = "Blank Check", Emoji = "<:B_money_printer:730145142467723367>", Time = TimeSpan.FromMinutes(0), Value = 100, CostGoldenEggs = 500, CostTokens = 2 },
+                new () { Id = "money_printer", Type = FarmValue, Name = "Money Printer", Emoji = "<:B_money_printer:730145142467723367>", Time = TimeSpan.FromMinutes(0), Value = 500, CostGoldenEggs = 2000, CostTokens = 3 },
+                new () { Id = "soul_mirror_blue", Type = SoulMirror, Name = "Soul Mirror", Emoji = "<:Soul_Mirror:798884954670891059>", Time = TimeSpan.FromMinutes(10), Value = 0, CostGoldenEggs = 100, CostTokens = 5 },
+                new () { Id = "soul_mirror_purple", Type = SoulMirror, Name = "Epic Soul Mirror", Emoji = "<:Soul_Mirror:798884954670891059>", Time = TimeSpan.FromMinutes(60), Value = 0, CostGoldenEggs = 500, CostTokens = 25 },
+                new () { Id = "soul_mirror_orange", Type = SoulMirror, Name = "Legendary Soul Mirror", Emoji = "<:Soul_Mirror:798884954670891059>", Time = TimeSpan.FromMinutes(1440), Value = 0, CostGoldenEggs = 2000, CostTokens = 50 },
+                new () { Id = "dilithium_bulb", Type = UnlimitedHatchery, Name = "Dilithium Warming Bulb", Emoji = "<:dili_bulb:1116601590003023882>", Time = TimeSpan.FromMinutes(10), Value = 0, CostGoldenEggs = 1000, CostTokens = 0 }   
+            ];
         }
 
     }

--- a/EGG9000.Common/Helpers/MissionHelpers.cs
+++ b/EGG9000.Common/Helpers/MissionHelpers.cs
@@ -11,7 +11,11 @@ using static Ei.MissionInfo.Types;
 namespace EGG9000.Common.Helpers {
     public static class MissionHelpers {
 
-        public static readonly Dictionary<Spaceship, uint> MaxShipLevels = Root.Get().missionParameters.ToDictionary(mp => mp.shipEnum, mp => (uint)mp.levelMissionRequirements.Count);
+        public static readonly Dictionary<Spaceship, uint> MaxShipLevels 
+            = Root.Get().missionParameters.ToDictionary(
+                mp => mp.shipEnum, 
+                mp => (uint)mp.levelMissionRequirements.Count
+            );
 
         public static readonly Dictionary<Spaceship, Dictionary<DurationType, List<int>>> NominalShipCapacities
             = Root.Get().missionParameters.ToDictionary(
@@ -32,147 +36,6 @@ namespace EGG9000.Common.Helpers {
                     dur => dur.seconds / 60
                 )
             );
-
-        /*private static readonly Dictionary<Spaceship, Dictionary<DurationType, List<int>>> NominalShipCapacities = new() {
-            { Spaceship.ChickenOne, new() {
-                    { DurationType.Tutorial, new(){ 4 } },
-                    { DurationType.Short, new(){ 4 } },
-                    { DurationType.Long, new(){ 5 } },
-                    { DurationType.Epic, new(){ 6 } },
-                }
-            },
-            { Spaceship.ChickenNine, new() {
-                    { DurationType.Short, new(){ 7, 8, 9 } },
-                    { DurationType.Long, new(){ 8, 9, 10 } },
-                    { DurationType.Epic, new(){ 9, 10, 11 } },
-                }
-            },
-            { Spaceship.ChickenHeavy, new() {
-                    { DurationType.Short, new(){ 12, 13, 14, 15 } },
-                    { DurationType.Long, new(){ 14, 16, 18, 20 } },
-                    { DurationType.Epic, new(){ 15, 17, 19, 21 } },
-                }
-            },
-            { Spaceship.Bcr, new() {
-                    { DurationType.Short, new(){ 18, 20, 22, 24, 26 } },
-                    { DurationType.Long, new(){ 20, 22, 24, 26, 28 } },
-                    { DurationType.Epic, new(){ 22, 25, 29, 31, 34 } },
-                }
-            },
-            { Spaceship.MilleniumChicken, new() {
-                    { DurationType.Short, new(){ 10, 11, 12, 13, 14 }},
-                    { DurationType.Long, new(){ 12, 14, 16, 18, 20 } },
-                    { DurationType.Epic, new(){ 14, 16, 18, 20, 22 } },
-                }
-            },
-            { Spaceship.CorellihenCorvette, new() {
-                    { DurationType.Short, new(){ 18, 20, 22, 24, 26 } },
-                    { DurationType.Long, new(){ 21, 23, 25, 27, 29 } },
-                    { DurationType.Epic, new(){ 24, 27, 30, 33, 36 } },
-                }
-            },
-            { Spaceship.Galeggtica, new() {
-                    { DurationType.Short, new(){ 27, 30, 33, 36, 39, 42 } },
-                    { DurationType.Long, new(){ 30, 33, 36, 39, 42, 45 } },
-                    { DurationType.Epic, new(){ 35, 39, 43, 47, 51, 55 }},
-                }
-            },
-            { Spaceship.Chickfiant, new() {
-                    { DurationType.Short, new(){ 20, 22, 24, 26, 28, 30 } },
-                    { DurationType.Long, new(){ 24, 26, 28, 30, 32, 34 } },
-                    { DurationType.Epic, new(){ 28, 31, 34, 37, 40, 43 } },
-                }
-            },
-            { Spaceship.Voyegger, new() {
-                    { DurationType.Short, new(){ 30, 33, 36, 39, 42, 45, 48 } },
-                    { DurationType.Long, new(){ 35, 39, 43, 47, 51, 55, 59 } },
-                    { DurationType.Epic, new(){ 40, 44, 48, 52, 56, 60, 64 } },
-                }
-            },
-            { Spaceship.Henerprise, new() {
-                    { DurationType.Short, new(){ 45, 50, 55, 60, 65, 70, 75, 80, 85 } },
-                    { DurationType.Long, new(){ 50, 56, 62, 68, 74, 80, 86, 92, 98 } },
-                    { DurationType.Epic, new(){ 56, 63, 70, 77, 84, 91, 98, 105, 112 } },
-                }
-            },
-            { Spaceship.Atreggies, new() {
-                  { DurationType.Short, new() { 60, 67, 74, 81, 88, 95, 102, 109} },
-                  { DurationType.Long, new() { 78, 86, 94, 102, 110, 118, 126, 134} },
-                  { DurationType.Epic, new() { 86, 96, 106, 116, 126, 136, 146, 156 } },
-              }
-            }
-             
-        };*/
-
-        /*private static readonly Dictionary<Spaceship, Dictionary<DurationType, int>> ShipBaseTimesMinutes = new() {
-            { Spaceship.ChickenOne, new() {
-                    { DurationType.Tutorial, 1 },
-                    { DurationType.Short, 20 },
-                    { DurationType.Long, 60 },
-                    { DurationType.Epic, 2 * 60 },
-                }
-            },
-            { Spaceship.ChickenNine, new() {
-                    { DurationType.Short, 30 },
-                    { DurationType.Long, 60 },
-                    { DurationType.Epic, 3 * 60 },
-                }
-            },
-            { Spaceship.ChickenHeavy, new() {
-                    { DurationType.Short, 45 },
-                    { DurationType.Long, 90 },
-                    { DurationType.Epic, 4 * 60 },
-                }
-            },
-            { Spaceship.Bcr, new() {
-                    { DurationType.Short, 90 },
-                    { DurationType.Long, 4 * 60 },
-                    { DurationType.Epic, 8 * 60 },
-                }
-            },
-            { Spaceship.MilleniumChicken, new() {
-                    { DurationType.Short, 3 * 60 },
-                    { DurationType.Long, 6 * 60 },
-                    { DurationType.Epic, 12 * 60 },
-                }
-            },
-            { Spaceship.CorellihenCorvette, new() {
-                    { DurationType.Short, 4 * 60 },
-                    { DurationType.Long, 12 * 60 },
-                    { DurationType.Epic, 24 * 60 },
-                }
-            },
-            { Spaceship.Galeggtica, new() {
-                    { DurationType.Short, 6 * 60 },
-                    { DurationType.Long, 16 * 60 },
-                    { DurationType.Epic, (24 + 6) * 60 },
-                }
-            },
-            { Spaceship.Chickfiant, new() {
-                    { DurationType.Short, 8 * 60 },
-                    { DurationType.Long, 24 * 60 },
-                    { DurationType.Epic, 48 * 60 },
-                }
-            },
-            { Spaceship.Voyegger, new() {
-                    { DurationType.Short, 12 * 60 },
-                    { DurationType.Long, 36 * 60 },
-                    { DurationType.Epic, 72 * 60 },
-                }
-            },
-            { Spaceship.Henerprise, new() {
-                    { DurationType.Short, 24 * 60 },
-                    { DurationType.Long, 48 * 60 },
-                    { DurationType.Epic, 96 * 60 },
-                }
-            },
-            { Spaceship.Atreggies, new() {
-                    { DurationType.Short, 48 * 60 },
-                    { DurationType.Long, 72 * 60 },
-                    { DurationType.Epic, 96 * 60 },
-                }
-            },
-        };*/
 
         public static int GetNominalCapacity(this CustomBackup backup, SpaceMission mission) {
             if(mission is null || !NominalShipCapacities.ContainsKey(mission.Ship)) return 0;

--- a/EGG9000.Common/Helpers/MissionHelpers.cs
+++ b/EGG9000.Common/Helpers/MissionHelpers.cs
@@ -11,21 +11,29 @@ using static Ei.MissionInfo.Types;
 namespace EGG9000.Common.Helpers {
     public static class MissionHelpers {
 
-        public static readonly Dictionary<Spaceship, uint> MaxShipLevels = new() {
-            { Spaceship.ChickenOne, 0 },
-            { Spaceship.ChickenNine, 2 },
-            { Spaceship.ChickenHeavy, 3 },
-            { Spaceship.Bcr, 4 },
-            { Spaceship.MilleniumChicken, 4 },
-            { Spaceship.CorellihenCorvette, 4 },
-            { Spaceship.Galeggtica, 5 },
-            { Spaceship.Chickfiant, 5 },
-            { Spaceship.Voyegger, 6 },
-            { Spaceship.Henerprise, 8 },
-            { Spaceship.Atreggies, 8 },
-        };
+        public static readonly Dictionary<Spaceship, uint> MaxShipLevels = Root.Get().missionParameters.ToDictionary(mp => mp.shipEnum, mp => (uint)mp.levelMissionRequirements.Count);
 
-        private static readonly Dictionary<Spaceship, Dictionary<DurationType, List<int>>> NominalShipCapacities = new() {
+        public static readonly Dictionary<Spaceship, Dictionary<DurationType, List<int>>> NominalShipCapacities
+            = Root.Get().missionParameters.ToDictionary(
+                mp => mp.shipEnum,
+                mp => mp.durations.ToDictionary(
+                    dur => dur.durationTypeEnum,
+                    dur => Enumerable.Range(0, mp.levelMissionRequirements.Count + 1)
+                                     .Select(i => dur.capacity + i * dur.levelCapacityBump)
+                                     .ToList()
+                )
+            );
+
+        private static readonly Dictionary<Spaceship, Dictionary<DurationType, int>> ShipBaseTimesMinutes
+            = Root.Get().missionParameters.ToDictionary(
+                mp => mp.shipEnum,
+                mp => mp.durations.ToDictionary(
+                    dur => dur.durationTypeEnum,
+                    dur => dur.seconds / 60
+                )
+            );
+
+        /*private static readonly Dictionary<Spaceship, Dictionary<DurationType, List<int>>> NominalShipCapacities = new() {
             { Spaceship.ChickenOne, new() {
                     { DurationType.Tutorial, new(){ 4 } },
                     { DurationType.Short, new(){ 4 } },
@@ -94,9 +102,9 @@ namespace EGG9000.Common.Helpers {
               }
             }
              
-        };
+        };*/
 
-        private static readonly Dictionary<Spaceship, Dictionary<DurationType, int>> ShipBaseTimesMinutes = new() {
+        /*private static readonly Dictionary<Spaceship, Dictionary<DurationType, int>> ShipBaseTimesMinutes = new() {
             { Spaceship.ChickenOne, new() {
                     { DurationType.Tutorial, 1 },
                     { DurationType.Short, 20 },
@@ -164,7 +172,7 @@ namespace EGG9000.Common.Helpers {
                     { DurationType.Epic, 96 * 60 },
                 }
             },
-        };
+        };*/
 
         public static int GetNominalCapacity(this CustomBackup backup, SpaceMission mission) {
             if(mission is null || !NominalShipCapacities.ContainsKey(mission.Ship)) return 0;

--- a/EGG9000.Common/Helpers/MissionHelpers.cs
+++ b/EGG9000.Common/Helpers/MissionHelpers.cs
@@ -37,6 +37,12 @@ namespace EGG9000.Common.Helpers {
                 )
             );
 
+        private static readonly Dictionary<Spaceship, List<int>> LevelRequirements
+            = Root.Get().missionParameters.ToDictionary(
+                mp => mp.shipEnum,
+                mp => mp.levelMissionRequirements
+            );
+
         public static int GetNominalCapacity(this CustomBackup backup, SpaceMission mission) {
             if(mission is null || !NominalShipCapacities.ContainsKey(mission.Ship)) return 0;
             var nominalCaps = NominalShipCapacities[mission.Ship][mission.Duration];
@@ -50,7 +56,7 @@ namespace EGG9000.Common.Helpers {
             if(erScalar < 0 || ship < Spaceship.MilleniumChicken) erScalar = 0;
             var shipTimes = ShipBaseTimesMinutes[ship];
             return shipTimes.ContainsKey(duration) ?
-                MinutesToString(backup, (int)(ShipBaseTimesMinutes[ship][duration] * ((double)number / 3) * (double)(1 - (.01 * erScalar)))) //Div by 3 for 3 ship slots
+                MinutesToString((int)(ShipBaseTimesMinutes[ship][duration] * ((double)number / 3) * (double)(1 - (.01 * erScalar)))) //Div by 3 for 3 ship slots
                 : "";
         }
 
@@ -64,69 +70,28 @@ namespace EGG9000.Common.Helpers {
                 : 0;
         }
 
-        public static string MinutesToString(this CustomBackup backup, int minutes) {
-            if(minutes < 60) return minutes + "m";
-            if(minutes < 1440) { // Less than a day
-                var hours = minutes / 60;
-                var remainingMinutes = minutes % 60;
-                return remainingMinutes == 0 ? hours + "h" : hours + "h" + remainingMinutes + "m";
-            }
-            if(minutes < 525600) { // Less than a year (assuming 365 days in a year)
-                var days = minutes / 1440;
-                var remainingMinutes = minutes % 1440;
-                if(remainingMinutes == 0) return days + "d";
-                var hours = remainingMinutes / 60;
-                var remainingMinutesInHourSc = remainingMinutes % 60;
-                return days + "d" + hours + "h" + remainingMinutesInHourSc + "m";
-            }
-            var years = minutes / 525600;
-            var remainingMinutesInYear = minutes % 525600;
-            if(remainingMinutesInYear == 0) return years + "y";
-            var daysInYear = remainingMinutesInYear / 1440;
-            var remainingMinutesInDay = remainingMinutesInYear % 1440;
-            var hoursInDay = remainingMinutesInDay / 60;
-            var remainingMinutesInHour = remainingMinutesInDay % 60;
-            var result = years + "y";
-            if(daysInYear > 0)
-                result += daysInYear + "d";
-            if(hoursInDay > 0)
-                result += hoursInDay + "h";
-            if(remainingMinutesInHour > 0)
-                result += remainingMinutesInHour + "m";
-            return result;
-        }
+        public static string MinutesToString(int minutes) {
+            var timeSpan = TimeSpan.FromMinutes(minutes);
 
-        public static List<MissionInfo> GetLaunchedMissions(ArtifactsDB artifactsDB) {
-            return (artifactsDB.MissionArchive.ToList() ?? new List<MissionInfo>())
-                .Concat(artifactsDB.MissionInfos.ToList() ?? new List<MissionInfo>())
-                .Where(m => m.Status != Status.Exploring)
-                .OrderByDescending(m => m.StartTimeDerived).ToList();
-        }
+            if(timeSpan.TotalMinutes < 60) return $"{timeSpan.Minutes}m";
 
-        public static Dictionary<Spaceship, uint> GetShipLevels(ArtifactsDB artifactsDB) {
-            var newDic = new Dictionary<Spaceship, uint>();
-            GetLaunchedMissions(artifactsDB).GroupBy(m => m.Ship).Select(group => group.OrderByDescending(ship => ship.Level).First()).ToList().ForEach(l => {
-                newDic.Add(l.Ship, l.Level);
-            });
-            return newDic;
+            if(timeSpan.TotalMinutes < 1440)
+                return $"{timeSpan.Hours}h{(timeSpan.Minutes > 0 ? $"{timeSpan.Minutes}m" : "")}";
+
+            if(timeSpan.TotalMinutes < 525600)
+                return $"{timeSpan.Days}d{timeSpan.Hours}h{(timeSpan.Minutes > 0 ? $"{timeSpan.Minutes}m" : "")}";
+
+            return $"{(int)(timeSpan.TotalDays / 365)}y{timeSpan.Days % 365}d{timeSpan.Hours}h{(timeSpan.Minutes > 0 ? $"{timeSpan.Minutes}m" : "")}";
         }
 
         public static int GetShipLevel(this CustomBackup backup, Spaceship ship) {
-            if(backup.ShipsSent == null)
-                return 0;
+            if(backup.ShipsSent == null) return 0;
 
             //If they don't have the ship unlocked
             if(!backup.ShipsSent.Any(x => x.ship == ship)) return 0;
 
-            var points = backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Short).count +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Long).count * 1.4 +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Epic).count * 1.8;
-
-            var levelMissionRequirements = Root.Get().missionParameters.First(x => ship.ToString().Equals(x.ship.Replace("_", ""), StringComparison.CurrentCultureIgnoreCase)).levelMissionRequirements;
-
-            for(var i = levelMissionRequirements.Count; i > 0; i--) {
-                var sum = levelMissionRequirements.Take(i).Sum();
-                if(points >= sum) {
+            for(var i = LevelRequirements[ship].Count; i > 0; i--) {
+                if(backup.ShipsSent.Where(x => x.ship == ship).ToList().Sum(s => s.count * ((int)s.type < 3 ? (1 + ((int)s.type * .4)) : 0)) >= LevelRequirements[ship].Take(i).Sum()) {
                     return i;
                 }
             }
@@ -141,7 +106,7 @@ namespace EGG9000.Common.Helpers {
                 Spaceship.ChickenHeavy => "Chicken Heavy",
                 Spaceship.Bcr => "BCR",
                 Spaceship.MilleniumChicken => "Quintillion Chicken",
-                Spaceship.CorellihenCorvette => "Cornish-Hen Corbette",
+                Spaceship.CorellihenCorvette => "Cornish-Hen Corvette",
                 Spaceship.Galeggtica => "Galleggtica",
                 Spaceship.Chickfiant => "Defihent",
                 Spaceship.Voyegger => "Voyegger",
@@ -152,98 +117,72 @@ namespace EGG9000.Common.Helpers {
         }
 
         public static Dictionary<DurationType, int> LaunchShipsToNext(this CustomBackup backup, Spaceship ship) {
-            if(backup.ShipsSent is null) return new();
+            if(backup.ShipsSent is null) return [];
 
-            var points = (!backup.ShipsSent.Any(x => x.ship == ship)) ? 0 : backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Short).count +
-            backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Long).count * 1.4 +
-            backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Epic).count * 1.8;
-
-            var levelMissionRequirements = Root.Get().missionParameters.First(x => ship.ToString().Equals(x.ship.Replace("_", ""), StringComparison.CurrentCultureIgnoreCase)).levelMissionRequirements;
+            var points = backup.ShipsSent.Where(x => x.ship == ship).ToList().Sum(s => s.count * ((int)s.type < 3 ? (1 + ((int)s.type * .4)) : 0));
+            var levelMissionRequirements = LevelRequirements[ship];
 
             for(var i = levelMissionRequirements.Count; i > 0; i--) {
                 if(points >= levelMissionRequirements.Take(i).Sum()) {
                     return ShipsFromPoints(levelMissionRequirements.Take(i + 1).Sum() - points);
                 }
             }
-            if(levelMissionRequirements.Count == 0) return new();
-            if(points == 0) return ShipsFromPoints(levelMissionRequirements[0]);
+            if(levelMissionRequirements.Count == 0) return [];
+            if(points < levelMissionRequirements[0]) return ShipsFromPoints(levelMissionRequirements[0] - points);
             else return ShipsFromPoints(0);
         }
 
         public static Dictionary<DurationType, int> LaunchShipsToMax(this CustomBackup backup, Spaceship ship) {
-            if(backup.ShipsSent is null) return new();
-
-            var points = (!backup.ShipsSent.Any(x => x.ship == ship)) ? 0 : backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Short).count +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Long).count * 1.4 +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Epic).count * 1.8;
-
-            var levelMissionRequirements = Root.Get().missionParameters.First(x => ship.ToString().Equals(x.ship.Replace("_", ""), StringComparison.CurrentCultureIgnoreCase)).levelMissionRequirements;
-            return ShipsFromPoints(levelMissionRequirements.Sum() - points);
+            if(backup.ShipsSent is null) return [];
+            var points = backup.ShipsSent.Where(x => x.ship == ship).ToList().Sum(s => s.count * ((int)s.type < 3 ? (1 + ((int)s.type * .4)) : 0));
+            return ShipsFromPoints(LevelRequirements[ship].Sum() - points);
         }
 
         public static Dictionary<DurationType, int> ShipsFromPoints(double neededPoints) {
-            Dictionary<DurationType, int> newDic = new();
-            if(neededPoints == 0) return newDic;
-
-            newDic.Add(DurationType.Short, (int)Math.Ceiling(neededPoints / 1));
-            newDic.Add(DurationType.Long, (int)Math.Ceiling(neededPoints / 1.4));
-            newDic.Add(DurationType.Epic, (int)Math.Ceiling(neededPoints / 1.8));
-
-            return newDic;
+            return Enum.GetValues<DurationType>().ToDictionary(
+               d => d,
+               d => (int)Math.Ceiling(neededPoints / (1 + ((int)d * 0.4)))
+            );
         }
 
         public static double GetShipProgressNextLevel(this CustomBackup backup, Spaceship ship) {
-            if(backup.ShipsSent == null)
-                return 0;
-
-            //No stars, always maxed
+            if(backup.ShipsSent == null) return 0;
             if(ship == Spaceship.ChickenOne) return 1;
 
-            var points = (!backup.ShipsSent.Any(x => x.ship == ship)) ? 0 : backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Short).count  +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Long).count * 1.4 +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Epic).count * 1.8 ;
+            var points = backup.ShipsSent.Where(x => x.ship == ship).ToList().Sum(s => s.count * ((int)s.type < 3 ? (1 + ((int)s.type * .4)) : 0));
 
-            var levelMissionRequirements = Root.Get().missionParameters.First(x => ship.ToString().Equals(x.ship.Replace("_", ""), StringComparison.CurrentCultureIgnoreCase)).levelMissionRequirements;
+            var levelMissionRequirements = Root.Get().missionParameters.First(x => x.shipEnum == ship).levelMissionRequirements;
 
             for(var i = levelMissionRequirements.Count; i > 0; i--) {
                 var sum = levelMissionRequirements.Take(i).Sum();
                 if(points >= sum) {
                     if(levelMissionRequirements.Count > i) {
-                        double numLaunchedCurrentLevel = points - sum;
+                        var numLaunchedCurrentLevel = points - sum;
                         double numForNextLevel = levelMissionRequirements[i];
                         return numLaunchedCurrentLevel / numForNextLevel;
                     } else {
                         return 1;
                     }
-                    
                 }
             }
             return 0;
         }
 
         public static double GetShipProgressTotal(this CustomBackup backup, Spaceship ship) {
-            if(backup.ShipsSent == null)
-                return 0;
+            if(backup.ShipsSent == null) return 0;
+            var points = backup.ShipsSent.Where(x => x.ship == ship).ToList().Sum(s => s.count * ((int)s.type < 3 ? (1 + ((int)s.type * .4)) : 0));
+            double sum = LevelRequirements[ship].Sum();
 
-            var points = (!backup.ShipsSent.Any(x => x.ship == ship)) ? 0 : backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Short).count +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Long).count * 1.4 +
-                backup.ShipsSent.FirstOrDefault(x => x.ship == ship && x.type == DurationType.Epic).count * 1.8;
-
-            var levelMissionRequirements = Root.Get().missionParameters.First(x => ship.ToString().Equals(x.ship.Replace("_", ""), StringComparison.CurrentCultureIgnoreCase)).levelMissionRequirements;
-
-            var sum = levelMissionRequirements.Sum();
+            if(ship == Spaceship.Atreggies) {
+                Console.WriteLine("Points: " + points);
+                Console.WriteLine("Sum: " + sum);
+            }
 
             return (points == 0 ? 0 : (points / sum > 1 ? 1 : points / sum));
         }
 
-        public static bool HasMaxedShips(CustomBackup backup) {
-            return MaxShipLevels.All(x => {
-                var currentStars = backup.GetShipLevel(x.Key);
-                if(currentStars == x.Value) {
-                    return true;
-                }
-                return false;
-            });
+        public static bool HasMaxedShips(this CustomBackup backup) {
+            return MaxShipLevels.All(x => backup.GetShipLevel(x.Key) == x.Value);
         }
     }
 }

--- a/EGG9000.Common/Helpers/MissionHelpers.cs
+++ b/EGG9000.Common/Helpers/MissionHelpers.cs
@@ -165,6 +165,7 @@ namespace EGG9000.Common.Helpers {
                     }
                 }
             }
+            if(points > 0 && points < levelMissionRequirements[0]) return points / levelMissionRequirements[0];
             return 0;
         }
 

--- a/EGG9000.Common/JsonData/eiafx-config.cs
+++ b/EGG9000.Common/JsonData/eiafx-config.cs
@@ -1,12 +1,13 @@
-﻿using Newtonsoft.Json;
+﻿using Ei;
+using Newtonsoft.Json;
 
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
+
+using static Ei.MissionInfo.Types;
 
 namespace EGG9000.Common.JsonData.EiAfxConfig {
 
@@ -32,6 +33,14 @@ namespace EGG9000.Common.JsonData.EiAfxConfig {
         public int capacity { get; set; }
         public int levelCapacityBump { get; set; }
         public double levelQualityBump { get; set; }
+
+        public DurationType durationTypeEnum {
+            get {
+                if(Enum.TryParse<DurationType>(durationType, ignoreCase: true, out var parsedEnum)) return parsedEnum;
+
+                return DurationType.Tutorial;
+            }
+        }
     }
 
     public class MissionParameter {
@@ -39,6 +48,16 @@ namespace EGG9000.Common.JsonData.EiAfxConfig {
         public List<Duration> durations { get; set; }
         public List<int> levelMissionRequirements { get; set; }
         public int capacityDEPRECATED { get; set; }
+
+        public Spaceship shipEnum { 
+            get {
+                if(Enum.TryParse<Spaceship>(ship, ignoreCase: true, out var parsedEnum)) return parsedEnum;
+
+                if(Enum.TryParse<Spaceship>(ship.Replace("_", ""), ignoreCase: true, out var parsedEnum2)) return parsedEnum2;
+
+                return Spaceship.ChickenOne;
+            }
+        }
     }
 
     public class Root {
@@ -71,7 +90,5 @@ namespace EGG9000.Common.JsonData.EiAfxConfig {
         public string rarity { get; set; }
         public string egg { get; set; }
     }
-
-
 
 }

--- a/EGG9000.Common/Migrations/20240309230547_AddOutsideCoops.Designer.cs
+++ b/EGG9000.Common/Migrations/20240309230547_AddOutsideCoops.Designer.cs
@@ -4,6 +4,7 @@ using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240309230547_AddOutsideCoops")]
+    partial class AddOutsideCoops
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EGG9000.Common/Migrations/20240309230547_AddOutsideCoops.cs
+++ b/EGG9000.Common/Migrations/20240309230547_AddOutsideCoops.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    public partial class AddOutsideCoops : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AddOutsideCoops",
+                table: "Guilds",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "AddedFromBackup",
+                table: "Coops",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AddOutsideCoops",
+                table: "Guilds");
+
+            migrationBuilder.DropColumn(
+                name: "AddedFromBackup",
+                table: "Coops");
+        }
+    }
+}

--- a/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -23,1364 +23,1364 @@ namespace EGG9000.Common.Migrations
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.AutomationLog", b =>
-                {
-                    b.Property<Guid>("id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTimeOffset?>("EndTime")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("EndTime")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("Skipped")
-                        .HasColumnType("bit");
+                b.Property<bool>("Skipped")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset>("StartTime")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("StartTime")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("Type")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Type")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("id");
+                b.HasKey("id");
 
-                    b.ToTable("AutomationLogs");
-                });
+                b.ToTable("AutomationLogs");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b =>
-                {
-                    b.Property<string>("ID")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("ID")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Created")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset>("GoodUntil")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("GoodUntil")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("HadTwoRewards")
-                        .HasColumnType("bit");
+                b.Property<bool>("HadTwoRewards")
+                    .HasColumnType("bit");
 
-                    b.Property<int>("MaxUsers")
-                        .HasColumnType("int");
+                b.Property<int>("MaxUsers")
+                    .HasColumnType("int");
 
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<int>("P11")
-                        .HasColumnType("int");
+                b.Property<int>("P11")
+                    .HasColumnType("int");
 
-                    b.Property<int>("P2")
-                        .HasColumnType("int");
+                b.Property<int>("P2")
+                    .HasColumnType("int");
 
-                    b.Property<int>("P4")
-                        .HasColumnType("int");
+                b.Property<int>("P4")
+                    .HasColumnType("int");
 
-                    b.Property<double>("P6")
-                        .HasColumnType("float");
+                b.Property<double>("P6")
+                    .HasColumnType("float");
 
-                    b.Property<double>("P7")
-                        .HasColumnType("float");
+                b.Property<double>("P7")
+                    .HasColumnType("float");
 
-                    b.Property<string>("Rewards")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Rewards")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("_response")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("_response")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("cc_only")
-                        .HasColumnType("bit");
+                b.Property<bool>("cc_only")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("coop_allowed")
-                        .HasColumnType("bit");
+                b.Property<bool>("coop_allowed")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("debug")
-                        .HasColumnType("bit");
+                b.Property<bool>("debug")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("egg")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("egg")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("goals")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("goals")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<double>("length_seconds")
-                        .HasColumnType("float");
+                b.Property<double>("length_seconds")
+                    .HasColumnType("float");
 
-                    b.Property<int>("max_boosts")
-                        .HasColumnType("int");
+                b.Property<int>("max_boosts")
+                    .HasColumnType("int");
 
-                    b.Property<double>("max_soul_eggs")
-                        .HasColumnType("float");
+                b.Property<double>("max_soul_eggs")
+                    .HasColumnType("float");
 
-                    b.Property<int>("min_client_version")
-                        .HasColumnType("int");
+                b.Property<int>("min_client_version")
+                    .HasColumnType("int");
 
-                    b.HasKey("ID");
+                b.HasKey("ID");
 
-                    b.ToTable("Contracts");
-                });
+                b.ToTable("Contracts");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("AddedFromBackup")
-                        .HasColumnType("bit");
+                b.Property<bool>("AddedFromBackup")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("AnyLeague")
-                        .HasColumnType("bit");
+                b.Property<bool>("AnyLeague")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("ContractID")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("ContractID")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<DateTimeOffset?>("CoopCompleted")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("CoopCompleted")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("CoopEnds")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("CoopEnds")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Created")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("CreatorID")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("CreatorID")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<int?>("CurrentUsers")
-                        .HasColumnType("int");
+                b.Property<int?>("CurrentUsers")
+                    .HasColumnType("int");
 
-                    b.Property<bool>("DeletedChannel")
-                        .HasColumnType("bit");
+                b.Property<bool>("DeletedChannel")
+                    .HasColumnType("bit");
 
-                    b.Property<decimal>("DiscordChannelId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("DiscordChannelId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<long>("FindChannelErrors")
-                        .HasColumnType("bigint");
+                b.Property<long>("FindChannelErrors")
+                    .HasColumnType("bigint");
 
-                    b.Property<bool>("Finished")
-                        .HasColumnType("bit");
+                b.Property<bool>("Finished")
+                    .HasColumnType("bit");
 
-                    b.Property<decimal>("Group")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("Group")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<decimal>("GuildId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("GuildId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<int>("JoinUsers")
-                        .HasColumnType("int");
+                b.Property<int>("JoinUsers")
+                    .HasColumnType("int");
 
-                    b.Property<DateTimeOffset?>("LastUpdateToChannel")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("LastUpdateToChannel")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<long>("League")
-                        .HasColumnType("bigint");
+                b.Property<long>("League")
+                    .HasColumnType("bigint");
 
-                    b.Property<int?>("MaxUsers")
-                        .HasColumnType("int");
+                b.Property<int?>("MaxUsers")
+                    .HasColumnType("int");
 
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<decimal>("OverflowGuildId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("OverflowGuildId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<DateTimeOffset?>("ProjectedFinish")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("ProjectedFinish")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("ProjectedToFinish")
-                        .HasColumnType("bit");
+                b.Property<bool>("ProjectedToFinish")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("PseudoExpired")
-                        .HasColumnType("bit");
+                b.Property<bool>("PseudoExpired")
+                    .HasColumnType("bit");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("int");
+                b.Property<int>("Status")
+                    .HasColumnType("int");
 
-                    b.Property<string>("UpdateMessagesId")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("UpdateMessagesId")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset?>("WarningForDeleteChannel")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("WarningForDeleteChannel")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<byte[]>("_StatusCompressed")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_StatusCompressed")
+                    .HasColumnType("varbinary(max)");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("ContractID");
+                b.HasIndex("ContractID");
 
-                    b.ToTable("Coops");
-                });
+                b.ToTable("Coops");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("AcceptedRules")
-                        .HasColumnType("bit");
+                b.Property<bool>("AcceptedRules")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("Banned")
-                        .HasColumnType("bit");
+                b.Property<bool>("Banned")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset>("CreateOn")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("CreateOn")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("CustomCoopName")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("CustomCoopName")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("DMOnShipReturn")
-                        .HasColumnType("bit");
+                b.Property<bool>("DMOnShipReturn")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("DMSBlocked")
-                        .HasColumnType("bit");
+                b.Property<bool>("DMSBlocked")
+                    .HasColumnType("bit");
 
-                    b.Property<decimal>("DiscordId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("DiscordId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<string>("DiscordUsername")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("DiscordUsername")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("EIDs")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("EIDs")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset?>("ExpireCustomCoopName")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("ExpireCustomCoopName")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<int>("GuildCoops")
-                        .HasColumnType("int");
+                b.Property<int>("GuildCoops")
+                    .HasColumnType("int");
 
-                    b.Property<decimal>("GuildId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("GuildId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<decimal?>("LastGuild")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal?>("LastGuild")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<DateTimeOffset>("LastSleepingNotification")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("LastSleepingNotification")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("NextBreakExpire")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("NextBreakExpire")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("NextShipReturnDMDue")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("NextShipReturnDMDue")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("Notes")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Notes")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset?>("OnBreakSince")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("OnBreakSince")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("Registered")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("Registered")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("ServersBannedFrom")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ServersBannedFrom")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("ShipReturnDMAfterFuel")
-                        .HasColumnType("bit");
+                b.Property<bool>("ShipReturnDMAfterFuel")
+                    .HasColumnType("bit");
 
-                    b.Property<int>("ShipReturnMinutes")
-                        .HasColumnType("int");
+                b.Property<int>("ShipReturnMinutes")
+                    .HasColumnType("int");
 
-                    b.Property<int>("ShipReturnStillFuelingMinutes")
-                        .HasColumnType("int");
+                b.Property<int>("ShipReturnStillFuelingMinutes")
+                    .HasColumnType("int");
 
-                    b.Property<bool>("SkipNoArtifacts")
-                        .HasColumnType("bit");
+                b.Property<bool>("SkipNoArtifacts")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("SkipNoPE")
-                        .HasColumnType("bit");
+                b.Property<bool>("SkipNoPE")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("SkipNoPiggyDouble")
-                        .HasColumnType("bit");
+                b.Property<bool>("SkipNoPiggyDouble")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("TempDisabled")
-                        .HasColumnType("bit");
+                b.Property<bool>("TempDisabled")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("Usernames")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Usernames")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<byte[]>("_CustomBackups")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_CustomBackups")
+                    .HasColumnType("varbinary(max)");
 
-                    b.Property<byte[]>("_contractRegistrationByte")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_contractRegistrationByte")
+                    .HasColumnType("varbinary(max)");
 
-                    b.Property<byte[]>("_coopSettingByte")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_coopSettingByte")
+                    .HasColumnType("varbinary(max)");
 
-                    b.Property<string>("_eggIncIds")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("_eggIncIds")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<byte[]>("_shipDMsByte")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_shipDMsByte")
+                    .HasColumnType("varbinary(max)");
 
-                    b.Property<bool>("showEB")
-                        .HasColumnType("bit");
+                b.Property<bool>("showEB")
+                    .HasColumnType("bit");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("DiscordId");
+                b.HasIndex("DiscordId");
 
-                    b.ToTable("Users");
-                });
+                b.ToTable("Users");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("AdminUserId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("AdminUserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("ContractID")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ContractID")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Details")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Details")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("Permanent")
-                        .HasColumnType("bit");
+                b.Property<bool>("Permanent")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("Reason")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Reason")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("UserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTimeOffset>("When")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("When")
+                    .HasColumnType("datetimeoffset");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("AdminUserId");
+                b.HasIndex("AdminUserId");
 
-                    b.HasIndex("UserId");
+                b.HasIndex("UserId");
 
-                    b.ToTable("Demerit");
-                });
+                b.ToTable("Demerit");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<float>("Amount")
-                        .HasColumnType("real");
+                b.Property<float>("Amount")
+                    .HasColumnType("real");
 
-                    b.Property<string>("Type")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Type")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("UserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTimeOffset>("When")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("When")
+                    .HasColumnType("datetimeoffset");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("UserId");
+                b.HasIndex("UserId");
 
-                    b.ToTable("Donations");
-                });
+                b.ToTable("Donations");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Event", b =>
-                {
-                    b.Property<Guid>("id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("CcOnly")
-                        .HasColumnType("bit");
+                b.Property<bool>("CcOnly")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("Ended")
-                        .HasColumnType("bit");
+                b.Property<bool>("Ended")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset>("Ends")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Ends")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("Identifier")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Identifier")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("MessageIds")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("MessageIds")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<double>("Multiplier")
-                        .HasColumnType("float");
+                b.Property<double>("Multiplier")
+                    .HasColumnType("float");
 
-                    b.Property<string>("Subtitle")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Subtitle")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Type")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Type")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("id");
+                b.HasKey("id");
 
-                    b.ToTable("Events");
-                });
+                b.ToTable("Events");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.EventCustomization", b =>
-                {
-                    b.Property<string>("Type")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("Type")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("Color")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Color")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Description")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Emoji")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Emoji")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Fields")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Fields")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<int>("Priority")
-                        .HasColumnType("int");
+                b.Property<int>("Priority")
+                    .HasColumnType("int");
 
-                    b.Property<string>("ThumbnailURL")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ThumbnailURL")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("_settings")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("_settings")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("Type");
+                b.HasKey("Type");
 
-                    b.ToTable("EventCustomizations");
-                });
+                b.ToTable("EventCustomizations");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.ExpiringShell", b =>
-                {
-                    b.Property<Guid>("id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("Archived")
-                        .HasColumnType("bit");
+                b.Property<bool>("Archived")
+                    .HasColumnType("bit");
 
-                    b.Property<int>("AssetType")
-                        .HasColumnType("int");
+                b.Property<int>("AssetType")
+                    .HasColumnType("int");
 
-                    b.Property<DateTimeOffset>("Expires")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Expires")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("Identifier")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Identifier")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Json")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Json")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("MessageIds")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("MessageIds")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<long>("Price")
-                        .HasColumnType("bigint");
+                b.Property<long>("Price")
+                    .HasColumnType("bigint");
 
-                    b.HasKey("id");
+                b.HasKey("id");
 
-                    b.ToTable("ExpiringShells");
-                });
+                b.ToTable("ExpiringShells");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardCoop", b =>
-                {
-                    b.Property<Guid>("id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("CheckFailed")
-                        .HasColumnType("bit");
+                b.Property<bool>("CheckFailed")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("Checked")
-                        .HasColumnType("bit");
+                b.Property<bool>("Checked")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("ContractID")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ContractID")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<int>("DegreeOfSeperation")
-                        .HasColumnType("int");
+                b.Property<int>("DegreeOfSeperation")
+                    .HasColumnType("int");
 
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("id");
+                b.HasKey("id");
 
-                    b.ToTable("GlobalLeaderboardCoops");
-                });
+                b.ToTable("GlobalLeaderboardCoops");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardUser", b =>
-                {
-                    b.Property<Guid>("id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<int>("DegreeOfSeperation")
-                        .HasColumnType("int");
+                b.Property<int>("DegreeOfSeperation")
+                    .HasColumnType("int");
 
-                    b.Property<string>("EggIncId")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("EggIncId")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset>("LastBackup")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("LastBackup")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("LastUpdate")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("LastUpdate")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("NeedsUpdate")
-                        .HasColumnType("bit");
+                b.Property<bool>("NeedsUpdate")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("UpdateFailed")
-                        .HasColumnType("bit");
+                b.Property<bool>("UpdateFailed")
+                    .HasColumnType("bit");
 
-                    b.Property<double>("earnings_bonus")
-                        .HasColumnType("float");
+                b.Property<double>("earnings_bonus")
+                    .HasColumnType("float");
 
-                    b.Property<decimal>("eggs_of_prophecy")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("eggs_of_prophecy")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<double>("lifetime_cash_earned")
-                        .HasColumnType("float");
+                b.Property<double>("lifetime_cash_earned")
+                    .HasColumnType("float");
 
-                    b.Property<double>("soul_eggs")
-                        .HasColumnType("float");
+                b.Property<double>("soul_eggs")
+                    .HasColumnType("float");
 
-                    b.Property<string>("user_id")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("user_id")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("user_name")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("user_name")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("id");
+                b.HasKey("id");
 
-                    b.ToTable("GlobalLeaderboardUsers");
-                });
+                b.ToTable("GlobalLeaderboardUsers");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Guild", b =>
-                {
-                    b.Property<decimal>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("decimal(20,0)");
+            {
+                b.Property<decimal>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("decimal(20,0)");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<decimal>("Id"), 1L, 1);
+                SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<decimal>("Id"), 1L, 1);
 
-                    b.Property<string>("ActiveElites")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ActiveElites")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("ActiveStandards")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ActiveStandards")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("AddOutsideCoops")
-                        .HasColumnType("bit");
+                b.Property<bool>("AddOutsideCoops")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("AllowGuilds")
-                        .HasColumnType("bit");
+                b.Property<bool>("AllowGuilds")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("CoopCategories")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("CoopCategories")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("CoopNamePrefix")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("CoopNamePrefix")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("DisableBG")
-                        .HasColumnType("bit");
+                b.Property<bool>("DisableBG")
+                    .HasColumnType("bit");
 
-                    b.Property<decimal>("DiscordSeverId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("DiscordSeverId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<string>("FinishedCategories")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("FinishedCategories")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("GroupRoles")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("GroupRoles")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("InactiveElites")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("InactiveElites")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("InactiveStandards")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("InactiveStandards")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("LeaderboardImage")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("LeaderboardImage")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("OverflowServersJson")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("OverflowServersJson")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("PublicScoreGrid")
-                        .HasColumnType("bit");
+                b.Property<bool>("PublicScoreGrid")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("RemoveFindCoopSpot")
-                        .HasColumnType("bit");
+                b.Property<bool>("RemoveFindCoopSpot")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("RolesToSync")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("RolesToSync")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("StaffCoopsMessageDetails")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("StaffCoopsMessageDetails")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("_channelDetailsJson")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("_channelDetailsJson")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("_coopSettingsJson")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("_coopSettingsJson")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("_eventCustomizationsJson")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("_eventCustomizationsJson")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.ToTable("Guilds");
-                });
+                b.ToTable("Guilds");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b =>
-                {
-                    b.Property<string>("ContractID")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("ContractID")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<decimal>("GuildID")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("GuildID")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<long>("League")
-                        .HasColumnType("bigint");
+                b.Property<long>("League")
+                    .HasColumnType("bigint");
 
-                    b.Property<int>("BoardingGroup")
-                        .HasColumnType("int");
+                b.Property<int>("BoardingGroup")
+                    .HasColumnType("int");
 
-                    b.Property<bool>("CcOnly")
-                        .HasColumnType("bit");
+                b.Property<bool>("CcOnly")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Created")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("DeletedChannel")
-                        .HasColumnType("bit");
+                b.Property<bool>("DeletedChannel")
+                    .HasColumnType("bit");
 
-                    b.Property<decimal>("DiscordChannelId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("DiscordChannelId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<bool>("HasScores")
-                        .HasColumnType("bit");
+                b.Property<bool>("HasScores")
+                    .HasColumnType("bit");
 
-                    b.Property<int>("NumberOfCoops")
-                        .HasColumnType("int");
+                b.Property<int>("NumberOfCoops")
+                    .HasColumnType("int");
 
-                    b.Property<string>("OutsideCoops")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("OutsideCoops")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Skip")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Skip")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Starters")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Starters")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<int>("Status")
-                        .HasColumnType("int");
+                b.Property<int>("Status")
+                    .HasColumnType("int");
 
-                    b.Property<DateTimeOffset?>("WarningForDeleteChannel")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("WarningForDeleteChannel")
+                    .HasColumnType("datetimeoffset");
 
-                    b.HasKey("ContractID", "GuildID", "League");
+                b.HasKey("ContractID", "GuildID", "League");
 
-                    b.ToTable("GuildContracts");
-                });
+                b.ToTable("GuildContracts");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("AdminUserId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("AdminUserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("Reason")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Reason")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("UserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTimeOffset>("When")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("When")
+                    .HasColumnType("datetimeoffset");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("AdminUserId");
+                b.HasIndex("AdminUserId");
 
-                    b.HasIndex("UserId");
+                b.HasIndex("UserId");
 
-                    b.ToTable("Merit");
-                });
+                b.ToTable("Merit");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.TemporaryRole", b =>
-                {
-                    b.Property<decimal>("UserId")
-                        .HasColumnType("decimal(20,0)");
+            {
+                b.Property<decimal>("UserId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<decimal>("RoleId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("RoleId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Created")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset>("Expires")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Expires")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<decimal>("GuildId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("GuildId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<bool>("IsRemoved")
-                        .HasColumnType("bit");
+                b.Property<bool>("IsRemoved")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("Reason")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Reason")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("UserId", "RoleId", "Created");
+                b.HasKey("UserId", "RoleId", "Created");
 
-                    b.ToTable("TemporaryRoles");
-                });
+                b.ToTable("TemporaryRoles");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b =>
-                {
-                    b.Property<Guid>("ID")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("ID")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<decimal>("ChannelId")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("ChannelId")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<string>("ContractId")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("ContractId")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<decimal>("GuildID")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("GuildID")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<bool>("IsLeggacy")
-                        .HasColumnType("bit");
+                b.Property<bool>("IsLeggacy")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset>("TargetDate")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("TargetDate")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<byte[]>("_userRegs")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_userRegs")
+                    .HasColumnType("varbinary(max)");
 
-                    b.HasKey("ID");
+                b.HasKey("ID");
 
-                    b.HasIndex("ContractId");
+                b.HasIndex("ContractId");
 
-                    b.ToTable("UpcomingContracts");
-                });
+                b.ToTable("UpcomingContracts");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("CoopId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("CoopId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTimeOffset>("CreatedOn")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("CreatedOn")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("EggIncId")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("EggIncId")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("EggIncName")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("EggIncName")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<double>("Rate")
-                        .HasColumnType("float");
+                b.Property<double>("Rate")
+                    .HasColumnType("float");
 
-                    b.Property<DateTimeOffset?>("SleepingWarning")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("SleepingWarning")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<double>("Total")
-                        .HasColumnType("float");
+                b.Property<double>("Total")
+                    .HasColumnType("float");
 
-                    b.Property<Guid?>("UserId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid?>("UserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("CoopId");
+                b.HasIndex("CoopId");
 
-                    b.HasIndex("UserId");
+                b.HasIndex("UserId");
 
-                    b.ToTable("UserCoopStatuses");
-                });
+                b.ToTable("UserCoopStatuses");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b =>
-                {
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("UserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<Guid>("CoopId")
-                        .HasColumnType("uniqueidentifier");
+                b.Property<Guid>("CoopId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("EggIncId")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("EggIncId")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<bool>("AddedToChannel")
-                        .HasColumnType("bit");
+                b.Property<bool>("AddedToChannel")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("CoopFullWarning")
-                        .HasColumnType("bit");
+                b.Property<bool>("CoopFullWarning")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset>("CreatedOn")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("CreatedOn")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("EquipedTachyonDeflector")
-                        .HasColumnType("bit");
+                b.Property<bool>("EquipedTachyonDeflector")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("FixedUserName")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("FixedUserName")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<decimal>("Group")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("Group")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<bool>("GussetCheatDetected")
-                        .HasColumnType("bit");
+                b.Property<bool>("GussetCheatDetected")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("HasTachyonDeflector")
-                        .HasColumnType("bit");
+                b.Property<bool>("HasTachyonDeflector")
+                    .HasColumnType("bit");
 
-                    b.Property<int>("HoursSleeping")
-                        .HasColumnType("int");
+                b.Property<int>("HoursSleeping")
+                    .HasColumnType("int");
 
-                    b.Property<bool>("JoinWarning12h")
-                        .HasColumnType("bit");
+                b.Property<bool>("JoinWarning12h")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("JoinWarning24TillFinish")
-                        .HasColumnType("bit");
+                b.Property<bool>("JoinWarning24TillFinish")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("JoinWarning24h")
-                        .HasColumnType("bit");
+                b.Property<bool>("JoinWarning24h")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("JoinedCoop")
-                        .HasColumnType("bit");
+                b.Property<bool>("JoinedCoop")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset?>("LastStatusTime")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("LastStatusTime")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<bool>("NoDemerit")
-                        .HasColumnType("bit");
+                b.Property<bool>("NoDemerit")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("OutsideCoop")
-                        .HasColumnType("bit");
+                b.Property<bool>("OutsideCoop")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("PingOnFinished")
-                        .HasColumnType("bit");
+                b.Property<bool>("PingOnFinished")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("PingOnFull")
-                        .HasColumnType("bit");
+                b.Property<bool>("PingOnFull")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("PingOnHighestEB")
-                        .HasColumnType("bit");
+                b.Property<bool>("PingOnHighestEB")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("RefEggIncId")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("RefEggIncId")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<float?>("RunningScore")
-                        .HasColumnType("real");
+                b.Property<float?>("RunningScore")
+                    .HasColumnType("real");
 
-                    b.Property<float?>("Score")
-                        .HasColumnType("real");
+                b.Property<float?>("Score")
+                    .HasColumnType("real");
 
-                    b.Property<float?>("SiloTimeHours")
-                        .HasColumnType("real");
+                b.Property<float?>("SiloTimeHours")
+                    .HasColumnType("real");
 
-                    b.Property<decimal>("SleepingDiscordMessageID")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("SleepingDiscordMessageID")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<DateTimeOffset?>("SleepingWarningTime")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("SleepingWarningTime")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<double?>("SoulPower")
-                        .HasColumnType("float");
+                b.Property<double?>("SoulPower")
+                    .HasColumnType("float");
 
-                    b.Property<bool>("Starter")
-                        .HasColumnType("bit");
+                b.Property<bool>("Starter")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("Status")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Status")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("TimeCheatReported")
-                        .HasColumnType("bit");
+                b.Property<bool>("TimeCheatReported")
+                    .HasColumnType("bit");
 
-                    b.Property<float>("TotalHoursSleeping")
-                        .HasColumnType("real");
+                b.Property<float>("TotalHoursSleeping")
+                    .HasColumnType("real");
 
-                    b.Property<bool>("WaitingOnStarter")
-                        .HasColumnType("bit");
+                b.Property<bool>("WaitingOnStarter")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("WasAssigned")
-                        .HasColumnType("bit");
+                b.Property<bool>("WasAssigned")
+                    .HasColumnType("bit");
 
-                    b.Property<byte[]>("_coopSettingByte")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_coopSettingByte")
+                    .HasColumnType("varbinary(max)");
 
-                    b.Property<byte[]>("_lastStatusByte")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_lastStatusByte")
+                    .HasColumnType("varbinary(max)");
 
-                    b.Property<byte[]>("_sleepTrackingByte")
-                        .HasColumnType("varbinary(max)");
+                b.Property<byte[]>("_sleepTrackingByte")
+                    .HasColumnType("varbinary(max)");
 
-                    b.HasKey("UserId", "CoopId", "EggIncId");
+                b.HasKey("UserId", "CoopId", "EggIncId");
 
-                    b.HasIndex("CoopId");
+                b.HasIndex("CoopId");
 
-                    b.HasIndex("CreatedOn", "JoinedCoop");
+                b.HasIndex("CreatedOn", "JoinedCoop");
 
-                    b.ToTable("UserCoopXrefs");
-                });
+                b.ToTable("UserCoopXrefs");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCsHistoryEntry", b =>
-                {
-                    b.Property<string>("CoopIdentifier")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("CoopIdentifier")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("ContractIdentifier")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("ContractIdentifier")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("EggIncId")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("EggIncId")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<DateTimeOffset>("Created")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset>("Created")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<double>("Cxp")
-                        .HasColumnType("float");
+                b.Property<double>("Cxp")
+                    .HasColumnType("float");
 
-                    b.HasKey("CoopIdentifier", "ContractIdentifier", "EggIncId");
+                b.HasKey("CoopIdentifier", "ContractIdentifier", "EggIncId");
 
-                    b.ToTable("UserCsHistoryEntries");
-                });
+                b.ToTable("UserCsHistoryEntries");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UserSnapShot", b =>
-                {
-                    b.Property<Guid>("UserId")
-                        .HasColumnType("uniqueidentifier");
+            {
+                b.Property<Guid>("UserId")
+                    .HasColumnType("uniqueidentifier");
 
-                    b.Property<DateTime>("Date")
-                        .HasColumnType("Date");
+                b.Property<DateTime>("Date")
+                    .HasColumnType("Date");
 
-                    b.Property<string>("EggIncID")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("EggIncID")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<double>("EarningsBonus")
-                        .HasColumnType("float");
+                b.Property<double>("EarningsBonus")
+                    .HasColumnType("float");
 
-                    b.Property<decimal>("EggsOfProphecy")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("EggsOfProphecy")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<decimal>("Prestiges")
-                        .HasColumnType("decimal(20,0)");
+                b.Property<decimal>("Prestiges")
+                    .HasColumnType("decimal(20,0)");
 
-                    b.Property<double>("SoulEggs")
-                        .HasColumnType("float");
+                b.Property<double>("SoulEggs")
+                    .HasColumnType("float");
 
-                    b.HasKey("UserId", "Date", "EggIncID");
+                b.HasKey("UserId", "Date", "EggIncID");
 
-                    b.ToTable("UserSnapShots");
-                });
+                b.ToTable("UserSnapShots");
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("Id")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("ConcurrencyStamp")
-                        .IsConcurrencyToken()
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ConcurrencyStamp")
+                    .IsConcurrencyToken()
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Name")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                b.Property<string>("Name")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
 
-                    b.Property<string>("NormalizedName")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                b.Property<string>("NormalizedName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("NormalizedName")
-                        .IsUnique()
-                        .HasDatabaseName("RoleNameIndex")
-                        .HasFilter("[NormalizedName] IS NOT NULL");
+                b.HasIndex("NormalizedName")
+                    .IsUnique()
+                    .HasDatabaseName("RoleNameIndex")
+                    .HasFilter("[NormalizedName] IS NOT NULL");
 
-                    b.ToTable("AspNetRoles", (string)null);
-                });
+                b.ToTable("AspNetRoles", (string)null);
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
-                    b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ClaimType")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ClaimValue")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("RoleId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("RoleId")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(450)");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("RoleId");
+                b.HasIndex("RoleId");
 
-                    b.ToTable("AspNetRoleClaims", (string)null);
-                });
+                b.ToTable("AspNetRoleClaims", (string)null);
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
-                {
-                    b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("Id")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<int>("AccessFailedCount")
-                        .HasColumnType("int");
+                b.Property<int>("AccessFailedCount")
+                    .HasColumnType("int");
 
-                    b.Property<string>("ConcurrencyStamp")
-                        .IsConcurrencyToken()
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ConcurrencyStamp")
+                    .IsConcurrencyToken()
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("Email")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                b.Property<string>("Email")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
 
-                    b.Property<bool>("EmailConfirmed")
-                        .HasColumnType("bit");
+                b.Property<bool>("EmailConfirmed")
+                    .HasColumnType("bit");
 
-                    b.Property<bool>("LockoutEnabled")
-                        .HasColumnType("bit");
+                b.Property<bool>("LockoutEnabled")
+                    .HasColumnType("bit");
 
-                    b.Property<DateTimeOffset?>("LockoutEnd")
-                        .HasColumnType("datetimeoffset");
+                b.Property<DateTimeOffset?>("LockoutEnd")
+                    .HasColumnType("datetimeoffset");
 
-                    b.Property<string>("NormalizedEmail")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                b.Property<string>("NormalizedEmail")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
 
-                    b.Property<string>("NormalizedUserName")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                b.Property<string>("NormalizedUserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
 
-                    b.Property<string>("PasswordHash")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("PasswordHash")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("PhoneNumber")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("PhoneNumber")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("PhoneNumberConfirmed")
-                        .HasColumnType("bit");
+                b.Property<bool>("PhoneNumberConfirmed")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("SecurityStamp")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("SecurityStamp")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<bool>("TwoFactorEnabled")
-                        .HasColumnType("bit");
+                b.Property<bool>("TwoFactorEnabled")
+                    .HasColumnType("bit");
 
-                    b.Property<string>("UserName")
-                        .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                b.Property<string>("UserName")
+                    .HasMaxLength(256)
+                    .HasColumnType("nvarchar(256)");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("NormalizedEmail")
-                        .HasDatabaseName("EmailIndex");
+                b.HasIndex("NormalizedEmail")
+                    .HasDatabaseName("EmailIndex");
 
-                    b.HasIndex("NormalizedUserName")
-                        .IsUnique()
-                        .HasDatabaseName("UserNameIndex")
-                        .HasFilter("[NormalizedUserName] IS NOT NULL");
+                b.HasIndex("NormalizedUserName")
+                    .IsUnique()
+                    .HasDatabaseName("UserNameIndex")
+                    .HasFilter("[NormalizedUserName] IS NOT NULL");
 
-                    b.ToTable("AspNetUsers", (string)null);
-                });
+                b.ToTable("AspNetUsers", (string)null);
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int");
 
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
-                    b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ClaimType")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ClaimValue")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("UserId")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(450)");
 
-                    b.HasKey("Id");
+                b.HasKey("Id");
 
-                    b.HasIndex("UserId");
+                b.HasIndex("UserId");
 
-                    b.ToTable("AspNetUserClaims", (string)null);
-                });
+                b.ToTable("AspNetUserClaims", (string)null);
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
-                {
-                    b.Property<string>("LoginProvider")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("LoginProvider")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("ProviderKey")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("ProviderKey")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("ProviderDisplayName")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("ProviderDisplayName")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("UserId")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(450)");
 
-                    b.HasKey("LoginProvider", "ProviderKey");
+                b.HasKey("LoginProvider", "ProviderKey");
 
-                    b.HasIndex("UserId");
+                b.HasIndex("UserId");
 
-                    b.ToTable("AspNetUserLogins", (string)null);
-                });
+                b.ToTable("AspNetUserLogins", (string)null);
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
-                {
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("UserId")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("RoleId")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("RoleId")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.HasKey("UserId", "RoleId");
+                b.HasKey("UserId", "RoleId");
 
-                    b.HasIndex("RoleId");
+                b.HasIndex("RoleId");
 
-                    b.ToTable("AspNetUserRoles", (string)null);
-                });
+                b.ToTable("AspNetUserRoles", (string)null);
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-                {
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
+            {
+                b.Property<string>("UserId")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("LoginProvider")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("LoginProvider")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("Name")
-                        .HasColumnType("nvarchar(450)");
+                b.Property<string>("Name")
+                    .HasColumnType("nvarchar(450)");
 
-                    b.Property<string>("Value")
-                        .HasColumnType("nvarchar(max)");
+                b.Property<string>("Value")
+                    .HasColumnType("nvarchar(max)");
 
-                    b.HasKey("UserId", "LoginProvider", "Name");
+                b.HasKey("UserId", "LoginProvider", "Name");
 
-                    b.ToTable("AspNetUserTokens", (string)null);
-                });
+                b.ToTable("AspNetUserTokens", (string)null);
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
-                        .WithMany("Coops")
-                        .HasForeignKey("ContractID");
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
+                    .WithMany("Coops")
+                    .HasForeignKey("ContractID");
 
-                    b.Navigation("Contract");
-                });
+                b.Navigation("Contract");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
-                        .WithMany("DemeritsGiven")
-                        .HasForeignKey("AdminUserId")
-                        .IsRequired();
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
+                    .WithMany("DemeritsGiven")
+                    .HasForeignKey("AdminUserId")
+                    .IsRequired();
 
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                        .WithMany("Demerits")
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                    .WithMany("Demerits")
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.Navigation("AdminUser");
+                b.Navigation("AdminUser");
 
-                    b.Navigation("User");
-                });
+                b.Navigation("User");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.Navigation("User");
-                });
+                b.Navigation("User");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
-                        .WithMany("GuildContracts")
-                        .HasForeignKey("ContractID")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
+                    .WithMany("GuildContracts")
+                    .HasForeignKey("ContractID")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.Navigation("Contract");
-                });
+                b.Navigation("Contract");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
-                        .WithMany("MeritsGiven")
-                        .HasForeignKey("AdminUserId")
-                        .IsRequired();
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
+                    .WithMany("MeritsGiven")
+                    .HasForeignKey("AdminUserId")
+                    .IsRequired();
 
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                        .WithMany("Merits")
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.ClientCascade)
-                        .IsRequired();
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                    .WithMany("Merits")
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.ClientCascade)
+                    .IsRequired();
 
-                    b.Navigation("AdminUser");
+                b.Navigation("AdminUser");
 
-                    b.Navigation("User");
-                });
+                b.Navigation("User");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
-                        .WithMany()
-                        .HasForeignKey("ContractId");
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
+                    .WithMany()
+                    .HasForeignKey("ContractId");
 
-                    b.Navigation("Contract");
-                });
+                b.Navigation("Contract");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
-                        .WithMany()
-                        .HasForeignKey("CoopId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
+                    .WithMany()
+                    .HasForeignKey("CoopId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                        .WithMany()
-                        .HasForeignKey("UserId");
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                    .WithMany()
+                    .HasForeignKey("UserId");
 
-                    b.Navigation("Coop");
+                b.Navigation("Coop");
 
-                    b.Navigation("User");
-                });
+                b.Navigation("User");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b =>
-                {
-                    b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
-                        .WithMany("UserCoopsXrefs")
-                        .HasForeignKey("CoopId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+            {
+                b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
+                    .WithMany("UserCoopsXrefs")
+                    .HasForeignKey("CoopId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                        .WithMany("UserCoopXrefs")
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                    .WithMany("UserCoopXrefs")
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.Navigation("Coop");
+                b.Navigation("Coop");
 
-                    b.Navigation("User");
-                });
+                b.Navigation("User");
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
-                {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
-                        .WithMany()
-                        .HasForeignKey("RoleId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+            {
+                b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    .WithMany()
+                    .HasForeignKey("RoleId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
-                {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+            {
+                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
-                {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+            {
+                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
-                {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
-                        .WithMany()
-                        .HasForeignKey("RoleId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
+            {
+                b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    .WithMany()
+                    .HasForeignKey("RoleId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
 
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-                {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                        .WithMany()
-                        .HasForeignKey("UserId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
+            {
+                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    .WithMany()
+                    .HasForeignKey("UserId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b =>
-                {
-                    b.Navigation("Coops");
+            {
+                b.Navigation("Coops");
 
-                    b.Navigation("GuildContracts");
-                });
+                b.Navigation("GuildContracts");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
-                {
-                    b.Navigation("UserCoopsXrefs");
-                });
+            {
+                b.Navigation("UserCoopsXrefs");
+            });
 
             modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b =>
-                {
-                    b.Navigation("Demerits");
+            {
+                b.Navigation("Demerits");
 
-                    b.Navigation("DemeritsGiven");
+                b.Navigation("DemeritsGiven");
 
-                    b.Navigation("Merits");
+                b.Navigation("Merits");
 
-                    b.Navigation("MeritsGiven");
+                b.Navigation("MeritsGiven");
 
-                    b.Navigation("UserCoopXrefs");
-                });
+                b.Navigation("UserCoopXrefs");
+            });
 #pragma warning restore 612, 618
         }
     }

--- a/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -8,10 +8,13 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace EGG9000.Common.Migrations {
+namespace EGG9000.Common.Migrations
+{
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot {
-        protected override void BuildModel(ModelBuilder modelBuilder) {
+    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "6.0.6")
@@ -19,1322 +22,1365 @@ namespace EGG9000.Common.Migrations {
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.AutomationLog", b => {
-                b.Property<Guid>("id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.AutomationLog", b =>
+                {
+                    b.Property<Guid>("id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<DateTimeOffset?>("EndTime")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("EndTime")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("Skipped")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Skipped")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset>("StartTime")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("StartTime")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("Type")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Type")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("id");
+                    b.HasKey("id");
 
-                b.ToTable("AutomationLogs");
-            });
+                    b.ToTable("AutomationLogs");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b => {
-                b.Property<string>("ID")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b =>
+                {
+                    b.Property<string>("ID")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<DateTimeOffset>("Created")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("Description")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<DateTimeOffset>("GoodUntil")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("GoodUntil")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("HadTwoRewards")
-                    .HasColumnType("bit");
+                    b.Property<bool>("HadTwoRewards")
+                        .HasColumnType("bit");
 
-                b.Property<int>("MaxUsers")
-                    .HasColumnType("int");
+                    b.Property<int>("MaxUsers")
+                        .HasColumnType("int");
 
-                b.Property<string>("Name")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<int>("P11")
-                    .HasColumnType("int");
+                    b.Property<int>("P11")
+                        .HasColumnType("int");
 
-                b.Property<int>("P2")
-                    .HasColumnType("int");
+                    b.Property<int>("P2")
+                        .HasColumnType("int");
 
-                b.Property<int>("P4")
-                    .HasColumnType("int");
+                    b.Property<int>("P4")
+                        .HasColumnType("int");
 
-                b.Property<double>("P6")
-                    .HasColumnType("float");
+                    b.Property<double>("P6")
+                        .HasColumnType("float");
 
-                b.Property<double>("P7")
-                    .HasColumnType("float");
+                    b.Property<double>("P7")
+                        .HasColumnType("float");
 
-                b.Property<string>("Rewards")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Rewards")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("_response")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("_response")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("cc_only")
-                    .HasColumnType("bit");
+                    b.Property<bool>("cc_only")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("coop_allowed")
-                    .HasColumnType("bit");
+                    b.Property<bool>("coop_allowed")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("debug")
-                    .HasColumnType("bit");
+                    b.Property<bool>("debug")
+                        .HasColumnType("bit");
 
-                b.Property<string>("egg")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("egg")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("goals")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("goals")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<double>("length_seconds")
-                    .HasColumnType("float");
+                    b.Property<double>("length_seconds")
+                        .HasColumnType("float");
 
-                b.Property<int>("max_boosts")
-                    .HasColumnType("int");
+                    b.Property<int>("max_boosts")
+                        .HasColumnType("int");
 
-                b.Property<double>("max_soul_eggs")
-                    .HasColumnType("float");
+                    b.Property<double>("max_soul_eggs")
+                        .HasColumnType("float");
 
-                b.Property<int>("min_client_version")
-                    .HasColumnType("int");
+                    b.Property<int>("min_client_version")
+                        .HasColumnType("int");
 
-                b.HasKey("ID");
+                    b.HasKey("ID");
 
-                b.ToTable("Contracts");
-            });
+                    b.ToTable("Contracts");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b => {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<bool>("AddedFromBackup")
-                    .HasColumnType("bit");
+                    b.Property<bool>("AddedFromBackup")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("AnyLeague")
-                    .HasColumnType("bit");
+                    b.Property<bool>("AnyLeague")
+                        .HasColumnType("bit");
 
-                b.Property<string>("ContractID")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("ContractID")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<DateTimeOffset?>("CoopCompleted")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("CoopCompleted")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset?>("CoopEnds")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("CoopEnds")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset>("Created")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("CreatorID")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("CreatorID")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<int?>("CurrentUsers")
-                    .HasColumnType("int");
+                    b.Property<int?>("CurrentUsers")
+                        .HasColumnType("int");
 
-                b.Property<bool>("DeletedChannel")
-                    .HasColumnType("bit");
+                    b.Property<bool>("DeletedChannel")
+                        .HasColumnType("bit");
 
-                b.Property<decimal>("DiscordChannelId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("DiscordChannelId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<long>("FindChannelErrors")
-                    .HasColumnType("bigint");
+                    b.Property<long>("FindChannelErrors")
+                        .HasColumnType("bigint");
 
-                b.Property<bool>("Finished")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Finished")
+                        .HasColumnType("bit");
 
-                b.Property<decimal>("Group")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("Group")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<decimal>("GuildId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("GuildId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<int>("JoinUsers")
-                    .HasColumnType("int");
+                    b.Property<int>("JoinUsers")
+                        .HasColumnType("int");
 
-                b.Property<DateTimeOffset?>("LastUpdateToChannel")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("LastUpdateToChannel")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<long>("League")
-                    .HasColumnType("bigint");
+                    b.Property<long>("League")
+                        .HasColumnType("bigint");
 
-                b.Property<int?>("MaxUsers")
-                    .HasColumnType("int");
+                    b.Property<int?>("MaxUsers")
+                        .HasColumnType("int");
 
-                b.Property<string>("Name")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<decimal>("OverflowGuildId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("OverflowGuildId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<DateTimeOffset?>("ProjectedFinish")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("ProjectedFinish")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("ProjectedToFinish")
-                    .HasColumnType("bit");
+                    b.Property<bool>("ProjectedToFinish")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("PseudoExpired")
-                    .HasColumnType("bit");
+                    b.Property<bool>("PseudoExpired")
+                        .HasColumnType("bit");
 
-                b.Property<int>("Status")
-                    .HasColumnType("int");
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
 
-                b.Property<string>("UpdateMessagesId")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("UpdateMessagesId")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<DateTimeOffset?>("WarningForDeleteChannel")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("WarningForDeleteChannel")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<byte[]>("_StatusCompressed")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_StatusCompressed")
+                        .HasColumnType("varbinary(max)");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("ContractID");
+                    b.HasIndex("ContractID");
 
-                b.ToTable("Coops");
-            });
+                    b.ToTable("Coops");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b => {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<bool>("AcceptedRules")
-                    .HasColumnType("bit");
+                    b.Property<bool>("AcceptedRules")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("Banned")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Banned")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset>("CreateOn")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("CreateOn")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("CustomCoopName")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("CustomCoopName")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("DMOnShipReturn")
-                    .HasColumnType("bit");
+                    b.Property<bool>("DMOnShipReturn")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("DMSBlocked")
-                    .HasColumnType("bit");
+                    b.Property<bool>("DMSBlocked")
+                        .HasColumnType("bit");
 
-                b.Property<decimal>("DiscordId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("DiscordId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<string>("DiscordUsername")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("DiscordUsername")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("EIDs")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("EIDs")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<DateTimeOffset?>("ExpireCustomCoopName")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("ExpireCustomCoopName")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<int>("GuildCoops")
-                    .HasColumnType("int");
+                    b.Property<int>("GuildCoops")
+                        .HasColumnType("int");
 
-                b.Property<decimal>("GuildId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("GuildId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<decimal?>("LastGuild")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal?>("LastGuild")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<DateTimeOffset>("LastSleepingNotification")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("LastSleepingNotification")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset?>("NextBreakExpire")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("NextBreakExpire")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset?>("NextShipReturnDMDue")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("NextShipReturnDMDue")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("Notes")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Notes")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<DateTimeOffset?>("OnBreakSince")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("OnBreakSince")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset?>("Registered")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("Registered")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("ServersBannedFrom")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ServersBannedFrom")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("ShipReturnDMAfterFuel")
-                    .HasColumnType("bit");
+                    b.Property<bool>("ShipReturnDMAfterFuel")
+                        .HasColumnType("bit");
 
-                b.Property<int>("ShipReturnMinutes")
-                    .HasColumnType("int");
+                    b.Property<int>("ShipReturnMinutes")
+                        .HasColumnType("int");
 
-                b.Property<int>("ShipReturnStillFuelingMinutes")
-                    .HasColumnType("int");
+                    b.Property<int>("ShipReturnStillFuelingMinutes")
+                        .HasColumnType("int");
 
-                b.Property<bool>("SkipNoArtifacts")
-                    .HasColumnType("bit");
+                    b.Property<bool>("SkipNoArtifacts")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("SkipNoPE")
-                    .HasColumnType("bit");
+                    b.Property<bool>("SkipNoPE")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("SkipNoPiggyDouble")
-                    .HasColumnType("bit");
+                    b.Property<bool>("SkipNoPiggyDouble")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("TempDisabled")
-                    .HasColumnType("bit");
+                    b.Property<bool>("TempDisabled")
+                        .HasColumnType("bit");
 
-                b.Property<string>("Usernames")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Usernames")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<byte[]>("_CustomBackups")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_CustomBackups")
+                        .HasColumnType("varbinary(max)");
 
-                b.Property<byte[]>("_contractRegistrationByte")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_contractRegistrationByte")
+                        .HasColumnType("varbinary(max)");
 
-                b.Property<byte[]>("_coopSettingByte")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_coopSettingByte")
+                        .HasColumnType("varbinary(max)");
 
-                b.Property<string>("_eggIncIds")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("_eggIncIds")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<byte[]>("_shipDMsByte")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_shipDMsByte")
+                        .HasColumnType("varbinary(max)");
 
-                b.Property<bool>("showEB")
-                    .HasColumnType("bit");
+                    b.Property<bool>("showEB")
+                        .HasColumnType("bit");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("DiscordId");
+                    b.HasIndex("DiscordId");
 
-                b.ToTable("Users");
-            });
+                    b.ToTable("Users");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b => {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<Guid>("AdminUserId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("AdminUserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<string>("ContractID")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ContractID")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Details")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Details")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("Permanent")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Permanent")
+                        .HasColumnType("bit");
 
-                b.Property<string>("Reason")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Reason")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<Guid>("UserId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<DateTimeOffset>("When")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("When")
+                        .HasColumnType("datetimeoffset");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("AdminUserId");
+                    b.HasIndex("AdminUserId");
 
-                b.HasIndex("UserId");
+                    b.HasIndex("UserId");
 
-                b.ToTable("Demerit");
-            });
+                    b.ToTable("Demerit");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b => {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<float>("Amount")
-                    .HasColumnType("real");
+                    b.Property<float>("Amount")
+                        .HasColumnType("real");
 
-                b.Property<string>("Type")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Type")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<Guid>("UserId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<DateTimeOffset>("When")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("When")
+                        .HasColumnType("datetimeoffset");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("UserId");
+                    b.HasIndex("UserId");
 
-                b.ToTable("Donations");
-            });
+                    b.ToTable("Donations");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Event", b => {
-                b.Property<Guid>("id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Event", b =>
+                {
+                    b.Property<Guid>("id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<bool>("CcOnly")
-                    .HasColumnType("bit");
+                    b.Property<bool>("CcOnly")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("Ended")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Ended")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset>("Ends")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Ends")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("Identifier")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Identifier")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("MessageIds")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("MessageIds")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<double>("Multiplier")
-                    .HasColumnType("float");
+                    b.Property<double>("Multiplier")
+                        .HasColumnType("float");
 
-                b.Property<string>("Subtitle")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Subtitle")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Type")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Type")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("id");
+                    b.HasKey("id");
 
-                b.ToTable("Events");
-            });
+                    b.ToTable("Events");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.EventCustomization", b => {
-                b.Property<string>("Type")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.EventCustomization", b =>
+                {
+                    b.Property<string>("Type")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("Color")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Color")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Description")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Emoji")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Emoji")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Fields")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Fields")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<int>("Priority")
-                    .HasColumnType("int");
+                    b.Property<int>("Priority")
+                        .HasColumnType("int");
 
-                b.Property<string>("ThumbnailURL")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ThumbnailURL")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("_settings")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("_settings")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("Type");
+                    b.HasKey("Type");
 
-                b.ToTable("EventCustomizations");
-            });
+                    b.ToTable("EventCustomizations");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.ExpiringShell", b => {
-                b.Property<Guid>("id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.ExpiringShell", b =>
+                {
+                    b.Property<Guid>("id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<bool>("Archived")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Archived")
+                        .HasColumnType("bit");
 
-                b.Property<int>("AssetType")
-                    .HasColumnType("int");
+                    b.Property<int>("AssetType")
+                        .HasColumnType("int");
 
-                b.Property<DateTimeOffset>("Expires")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Expires")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("Identifier")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Identifier")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Json")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Json")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("MessageIds")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("MessageIds")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Name")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<long>("Price")
-                    .HasColumnType("bigint");
+                    b.Property<long>("Price")
+                        .HasColumnType("bigint");
 
-                b.HasKey("id");
+                    b.HasKey("id");
 
-                b.ToTable("ExpiringShells");
-            });
+                    b.ToTable("ExpiringShells");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardCoop", b => {
-                b.Property<Guid>("id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardCoop", b =>
+                {
+                    b.Property<Guid>("id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<bool>("CheckFailed")
-                    .HasColumnType("bit");
+                    b.Property<bool>("CheckFailed")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("Checked")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Checked")
+                        .HasColumnType("bit");
 
-                b.Property<string>("ContractID")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ContractID")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<int>("DegreeOfSeperation")
-                    .HasColumnType("int");
+                    b.Property<int>("DegreeOfSeperation")
+                        .HasColumnType("int");
 
-                b.Property<string>("Name")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("id");
+                    b.HasKey("id");
 
-                b.ToTable("GlobalLeaderboardCoops");
-            });
+                    b.ToTable("GlobalLeaderboardCoops");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardUser", b => {
-                b.Property<Guid>("id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardUser", b =>
+                {
+                    b.Property<Guid>("id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<int>("DegreeOfSeperation")
-                    .HasColumnType("int");
+                    b.Property<int>("DegreeOfSeperation")
+                        .HasColumnType("int");
 
-                b.Property<string>("EggIncId")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("EggIncId")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<DateTimeOffset>("LastBackup")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("LastBackup")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset?>("LastUpdate")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("LastUpdate")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("NeedsUpdate")
-                    .HasColumnType("bit");
+                    b.Property<bool>("NeedsUpdate")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("UpdateFailed")
-                    .HasColumnType("bit");
+                    b.Property<bool>("UpdateFailed")
+                        .HasColumnType("bit");
 
-                b.Property<double>("earnings_bonus")
-                    .HasColumnType("float");
+                    b.Property<double>("earnings_bonus")
+                        .HasColumnType("float");
 
-                b.Property<decimal>("eggs_of_prophecy")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("eggs_of_prophecy")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<double>("lifetime_cash_earned")
-                    .HasColumnType("float");
+                    b.Property<double>("lifetime_cash_earned")
+                        .HasColumnType("float");
 
-                b.Property<double>("soul_eggs")
-                    .HasColumnType("float");
+                    b.Property<double>("soul_eggs")
+                        .HasColumnType("float");
 
-                b.Property<string>("user_id")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("user_id")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("user_name")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("user_name")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("id");
+                    b.HasKey("id");
 
-                b.ToTable("GlobalLeaderboardUsers");
-            });
+                    b.ToTable("GlobalLeaderboardUsers");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Guild", b => {
-                b.Property<decimal>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("decimal(20,0)");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Guild", b =>
+                {
+                    b.Property<decimal>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("decimal(20,0)");
 
-                SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<decimal>("Id"), 1L, 1);
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<decimal>("Id"), 1L, 1);
 
-                b.Property<string>("ActiveElites")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ActiveElites")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("ActiveStandards")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ActiveStandards")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("AddOutsideCoops")
-                    .HasColumnType("bit");
+                    b.Property<bool>("AddOutsideCoops")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("AllowGuilds")
-                    .HasColumnType("bit");
+                    b.Property<bool>("AllowGuilds")
+                        .HasColumnType("bit");
 
-                b.Property<string>("CoopCategories")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("CoopCategories")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("CoopNamePrefix")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("CoopNamePrefix")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("DisableBG")
-                    .HasColumnType("bit");
+                    b.Property<bool>("DisableBG")
+                        .HasColumnType("bit");
 
-                b.Property<decimal>("DiscordSeverId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("DiscordSeverId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<string>("FinishedCategories")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("FinishedCategories")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("GroupRoles")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("GroupRoles")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("InactiveElites")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("InactiveElites")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("InactiveStandards")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("InactiveStandards")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("LeaderboardImage")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("LeaderboardImage")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Name")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("OverflowServersJson")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("OverflowServersJson")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("PublicScoreGrid")
-                    .HasColumnType("bit");
+                    b.Property<bool>("PublicScoreGrid")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("RemoveFindCoopSpot")
-                    .HasColumnType("bit");
+                    b.Property<bool>("RemoveFindCoopSpot")
+                        .HasColumnType("bit");
 
-                b.Property<string>("RolesToSync")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("RolesToSync")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("StaffCoopsMessageDetails")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("StaffCoopsMessageDetails")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("_channelDetailsJson")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("_channelDetailsJson")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("_coopSettingsJson")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("_coopSettingsJson")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("_eventCustomizationsJson")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("_eventCustomizationsJson")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.ToTable("Guilds");
-            });
+                    b.ToTable("Guilds");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b => {
-                b.Property<string>("ContractID")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b =>
+                {
+                    b.Property<string>("ContractID")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<decimal>("GuildID")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("GuildID")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<long>("League")
-                    .HasColumnType("bigint");
+                    b.Property<long>("League")
+                        .HasColumnType("bigint");
 
-                b.Property<int>("BoardingGroup")
-                    .HasColumnType("int");
+                    b.Property<int>("BoardingGroup")
+                        .HasColumnType("int");
 
-                b.Property<bool>("CcOnly")
-                    .HasColumnType("bit");
+                    b.Property<bool>("CcOnly")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset>("Created")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("DeletedChannel")
-                    .HasColumnType("bit");
+                    b.Property<bool>("DeletedChannel")
+                        .HasColumnType("bit");
 
-                b.Property<decimal>("DiscordChannelId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("DiscordChannelId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<bool>("HasScores")
-                    .HasColumnType("bit");
+                    b.Property<bool>("HasScores")
+                        .HasColumnType("bit");
 
-                b.Property<int>("NumberOfCoops")
-                    .HasColumnType("int");
+                    b.Property<int>("NumberOfCoops")
+                        .HasColumnType("int");
 
-                b.Property<string>("OutsideCoops")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("OutsideCoops")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Skip")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Skip")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Starters")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Starters")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<int>("Status")
-                    .HasColumnType("int");
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
 
-                b.Property<DateTimeOffset?>("WarningForDeleteChannel")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("WarningForDeleteChannel")
+                        .HasColumnType("datetimeoffset");
 
-                b.HasKey("ContractID", "GuildID", "League");
+                    b.HasKey("ContractID", "GuildID", "League");
 
-                b.ToTable("GuildContracts");
-            });
+                    b.ToTable("GuildContracts");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b => {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<Guid>("AdminUserId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("AdminUserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<string>("Reason")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Reason")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<Guid>("UserId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<DateTimeOffset>("When")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("When")
+                        .HasColumnType("datetimeoffset");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("AdminUserId");
+                    b.HasIndex("AdminUserId");
 
-                b.HasIndex("UserId");
+                    b.HasIndex("UserId");
 
-                b.ToTable("Merit");
-            });
+                    b.ToTable("Merit");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.TemporaryRole", b => {
-                b.Property<decimal>("UserId")
-                    .HasColumnType("decimal(20,0)");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.TemporaryRole", b =>
+                {
+                    b.Property<decimal>("UserId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<decimal>("RoleId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("RoleId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<DateTimeOffset>("Created")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<DateTimeOffset>("Expires")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Expires")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<decimal>("GuildId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("GuildId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<bool>("IsRemoved")
-                    .HasColumnType("bit");
+                    b.Property<bool>("IsRemoved")
+                        .HasColumnType("bit");
 
-                b.Property<string>("Reason")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Reason")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("UserId", "RoleId", "Created");
+                    b.HasKey("UserId", "RoleId", "Created");
 
-                b.ToTable("TemporaryRoles");
-            });
+                    b.ToTable("TemporaryRoles");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b => {
-                b.Property<Guid>("ID")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b =>
+                {
+                    b.Property<Guid>("ID")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<decimal>("ChannelId")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("ChannelId")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<string>("ContractId")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("ContractId")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<decimal>("GuildID")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("GuildID")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<bool>("IsLeggacy")
-                    .HasColumnType("bit");
+                    b.Property<bool>("IsLeggacy")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset>("TargetDate")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("TargetDate")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<byte[]>("_userRegs")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_userRegs")
+                        .HasColumnType("varbinary(max)");
 
-                b.HasKey("ID");
+                    b.HasKey("ID");
 
-                b.HasIndex("ContractId");
+                    b.HasIndex("ContractId");
 
-                b.ToTable("UpcomingContracts");
-            });
+                    b.ToTable("UpcomingContracts");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b => {
-                b.Property<Guid>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<Guid>("CoopId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("CoopId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<DateTimeOffset>("CreatedOn")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("CreatedOn")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("EggIncId")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("EggIncId")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("EggIncName")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("EggIncName")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<double>("Rate")
-                    .HasColumnType("float");
+                    b.Property<double>("Rate")
+                        .HasColumnType("float");
 
-                b.Property<DateTimeOffset?>("SleepingWarning")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("SleepingWarning")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<double>("Total")
-                    .HasColumnType("float");
+                    b.Property<double>("Total")
+                        .HasColumnType("float");
 
-                b.Property<Guid?>("UserId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid?>("UserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("CoopId");
+                    b.HasIndex("CoopId");
 
-                b.HasIndex("UserId");
+                    b.HasIndex("UserId");
 
-                b.ToTable("UserCoopStatuses");
-            });
+                    b.ToTable("UserCoopStatuses");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b => {
-                b.Property<Guid>("UserId")
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<Guid>("CoopId")
-                    .HasColumnType("uniqueidentifier");
+                    b.Property<Guid>("CoopId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<string>("EggIncId")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("EggIncId")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<bool>("AddedToChannel")
-                    .HasColumnType("bit");
+                    b.Property<bool>("AddedToChannel")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("CoopFullWarning")
-                    .HasColumnType("bit");
+                    b.Property<bool>("CoopFullWarning")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset>("CreatedOn")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("CreatedOn")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("EquipedTachyonDeflector")
-                    .HasColumnType("bit");
+                    b.Property<bool>("EquipedTachyonDeflector")
+                        .HasColumnType("bit");
 
-                b.Property<string>("FixedUserName")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("FixedUserName")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<decimal>("Group")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("Group")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<bool>("GussetCheatDetected")
-                    .HasColumnType("bit");
+                    b.Property<bool>("GussetCheatDetected")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("HasTachyonDeflector")
-                    .HasColumnType("bit");
+                    b.Property<bool>("HasTachyonDeflector")
+                        .HasColumnType("bit");
 
-                b.Property<int>("HoursSleeping")
-                    .HasColumnType("int");
+                    b.Property<int>("HoursSleeping")
+                        .HasColumnType("int");
 
-                b.Property<bool>("JoinWarning12h")
-                    .HasColumnType("bit");
+                    b.Property<bool>("JoinWarning12h")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("JoinWarning24TillFinish")
-                    .HasColumnType("bit");
+                    b.Property<bool>("JoinWarning24TillFinish")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("JoinWarning24h")
-                    .HasColumnType("bit");
+                    b.Property<bool>("JoinWarning24h")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("JoinedCoop")
-                    .HasColumnType("bit");
+                    b.Property<bool>("JoinedCoop")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset?>("LastStatusTime")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("LastStatusTime")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<bool>("NoDemerit")
-                    .HasColumnType("bit");
+                    b.Property<bool>("NoDemerit")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("OutsideCoop")
-                    .HasColumnType("bit");
+                    b.Property<bool>("OutsideCoop")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("PingOnFinished")
-                    .HasColumnType("bit");
+                    b.Property<bool>("PingOnFinished")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("PingOnFull")
-                    .HasColumnType("bit");
+                    b.Property<bool>("PingOnFull")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("PingOnHighestEB")
-                    .HasColumnType("bit");
+                    b.Property<bool>("PingOnHighestEB")
+                        .HasColumnType("bit");
 
-                b.Property<string>("RefEggIncId")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("RefEggIncId")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<float?>("RunningScore")
-                    .HasColumnType("real");
+                    b.Property<float?>("RunningScore")
+                        .HasColumnType("real");
 
-                b.Property<float?>("Score")
-                    .HasColumnType("real");
+                    b.Property<float?>("Score")
+                        .HasColumnType("real");
 
-                b.Property<float?>("SiloTimeHours")
-                    .HasColumnType("real");
+                    b.Property<float?>("SiloTimeHours")
+                        .HasColumnType("real");
 
-                b.Property<decimal>("SleepingDiscordMessageID")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("SleepingDiscordMessageID")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<DateTimeOffset?>("SleepingWarningTime")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("SleepingWarningTime")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<double?>("SoulPower")
-                    .HasColumnType("float");
+                    b.Property<double?>("SoulPower")
+                        .HasColumnType("float");
 
-                b.Property<bool>("Starter")
-                    .HasColumnType("bit");
+                    b.Property<bool>("Starter")
+                        .HasColumnType("bit");
 
-                b.Property<string>("Status")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Status")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("TimeCheatReported")
-                    .HasColumnType("bit");
+                    b.Property<bool>("TimeCheatReported")
+                        .HasColumnType("bit");
 
-                b.Property<float>("TotalHoursSleeping")
-                    .HasColumnType("real");
+                    b.Property<float>("TotalHoursSleeping")
+                        .HasColumnType("real");
 
-                b.Property<bool>("WaitingOnStarter")
-                    .HasColumnType("bit");
+                    b.Property<bool>("WaitingOnStarter")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("WasAssigned")
-                    .HasColumnType("bit");
+                    b.Property<bool>("WasAssigned")
+                        .HasColumnType("bit");
 
-                b.Property<byte[]>("_coopSettingByte")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_coopSettingByte")
+                        .HasColumnType("varbinary(max)");
 
-                b.Property<byte[]>("_lastStatusByte")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_lastStatusByte")
+                        .HasColumnType("varbinary(max)");
 
-                b.Property<byte[]>("_sleepTrackingByte")
-                    .HasColumnType("varbinary(max)");
+                    b.Property<byte[]>("_sleepTrackingByte")
+                        .HasColumnType("varbinary(max)");
 
-                b.HasKey("UserId", "CoopId", "EggIncId");
+                    b.HasKey("UserId", "CoopId", "EggIncId");
 
-                b.HasIndex("CoopId");
+                    b.HasIndex("CoopId");
 
-                b.HasIndex("CreatedOn", "JoinedCoop");
+                    b.HasIndex("CreatedOn", "JoinedCoop");
 
-                b.ToTable("UserCoopXrefs");
-            });
+                    b.ToTable("UserCoopXrefs");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCsHistoryEntry", b => {
-                b.Property<string>("CoopIdentifier")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCsHistoryEntry", b =>
+                {
+                    b.Property<string>("CoopIdentifier")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("ContractIdentifier")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("ContractIdentifier")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("EggIncId")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("EggIncId")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<DateTimeOffset>("Created")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<double>("Cxp")
-                    .HasColumnType("float");
+                    b.Property<double>("Cxp")
+                        .HasColumnType("float");
 
-                b.HasKey("CoopIdentifier", "ContractIdentifier", "EggIncId");
+                    b.HasKey("CoopIdentifier", "ContractIdentifier", "EggIncId");
 
-                b.ToTable("UserCsHistoryEntries");
-            });
+                    b.ToTable("UserCsHistoryEntries");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserSnapShot", b => {
-                b.Property<Guid>("UserId")
-                    .HasColumnType("uniqueidentifier");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserSnapShot", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
 
-                b.Property<DateTime>("Date")
-                    .HasColumnType("Date");
+                    b.Property<DateTime>("Date")
+                        .HasColumnType("Date");
 
-                b.Property<string>("EggIncID")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("EggIncID")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<double>("EarningsBonus")
-                    .HasColumnType("float");
+                    b.Property<double>("EarningsBonus")
+                        .HasColumnType("float");
 
-                b.Property<decimal>("EggsOfProphecy")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("EggsOfProphecy")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<decimal>("Prestiges")
-                    .HasColumnType("decimal(20,0)");
+                    b.Property<decimal>("Prestiges")
+                        .HasColumnType("decimal(20,0)");
 
-                b.Property<double>("SoulEggs")
-                    .HasColumnType("float");
+                    b.Property<double>("SoulEggs")
+                        .HasColumnType("float");
 
-                b.HasKey("UserId", "Date", "EggIncID");
+                    b.HasKey("UserId", "Date", "EggIncID");
 
-                b.ToTable("UserSnapShots");
-            });
+                    b.ToTable("UserSnapShots");
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b => {
-                b.Property<string>("Id")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
+                {
+                    b.Property<string>("Id")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("ConcurrencyStamp")
-                    .IsConcurrencyToken()
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken()
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Name")
-                    .HasMaxLength(256)
-                    .HasColumnType("nvarchar(256)");
+                    b.Property<string>("Name")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
-                b.Property<string>("NormalizedName")
-                    .HasMaxLength(256)
-                    .HasColumnType("nvarchar(256)");
+                    b.Property<string>("NormalizedName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("NormalizedName")
-                    .IsUnique()
-                    .HasDatabaseName("RoleNameIndex")
-                    .HasFilter("[NormalizedName] IS NOT NULL");
+                    b.HasIndex("NormalizedName")
+                        .IsUnique()
+                        .HasDatabaseName("RoleNameIndex")
+                        .HasFilter("[NormalizedName] IS NOT NULL");
 
-                b.ToTable("AspNetRoles", (string)null);
-            });
+                    b.ToTable("AspNetRoles", (string)null);
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b => {
-                b.Property<int>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("int");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
 
-                SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
-                b.Property<string>("ClaimType")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ClaimType")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("ClaimValue")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ClaimValue")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("RoleId")
-                    .IsRequired()
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("RoleId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("RoleId");
+                    b.HasIndex("RoleId");
 
-                b.ToTable("AspNetRoleClaims", (string)null);
-            });
+                    b.ToTable("AspNetRoleClaims", (string)null);
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b => {
-                b.Property<string>("Id")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
+                {
+                    b.Property<string>("Id")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<int>("AccessFailedCount")
-                    .HasColumnType("int");
+                    b.Property<int>("AccessFailedCount")
+                        .HasColumnType("int");
 
-                b.Property<string>("ConcurrencyStamp")
-                    .IsConcurrencyToken()
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken()
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("Email")
-                    .HasMaxLength(256)
-                    .HasColumnType("nvarchar(256)");
+                    b.Property<string>("Email")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
-                b.Property<bool>("EmailConfirmed")
-                    .HasColumnType("bit");
+                    b.Property<bool>("EmailConfirmed")
+                        .HasColumnType("bit");
 
-                b.Property<bool>("LockoutEnabled")
-                    .HasColumnType("bit");
+                    b.Property<bool>("LockoutEnabled")
+                        .HasColumnType("bit");
 
-                b.Property<DateTimeOffset?>("LockoutEnd")
-                    .HasColumnType("datetimeoffset");
+                    b.Property<DateTimeOffset?>("LockoutEnd")
+                        .HasColumnType("datetimeoffset");
 
-                b.Property<string>("NormalizedEmail")
-                    .HasMaxLength(256)
-                    .HasColumnType("nvarchar(256)");
+                    b.Property<string>("NormalizedEmail")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
-                b.Property<string>("NormalizedUserName")
-                    .HasMaxLength(256)
-                    .HasColumnType("nvarchar(256)");
+                    b.Property<string>("NormalizedUserName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
-                b.Property<string>("PasswordHash")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("PasswordHash")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("PhoneNumber")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("PhoneNumber")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("PhoneNumberConfirmed")
-                    .HasColumnType("bit");
+                    b.Property<bool>("PhoneNumberConfirmed")
+                        .HasColumnType("bit");
 
-                b.Property<string>("SecurityStamp")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("SecurityStamp")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<bool>("TwoFactorEnabled")
-                    .HasColumnType("bit");
+                    b.Property<bool>("TwoFactorEnabled")
+                        .HasColumnType("bit");
 
-                b.Property<string>("UserName")
-                    .HasMaxLength(256)
-                    .HasColumnType("nvarchar(256)");
+                    b.Property<string>("UserName")
+                        .HasMaxLength(256)
+                        .HasColumnType("nvarchar(256)");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("NormalizedEmail")
-                    .HasDatabaseName("EmailIndex");
+                    b.HasIndex("NormalizedEmail")
+                        .HasDatabaseName("EmailIndex");
 
-                b.HasIndex("NormalizedUserName")
-                    .IsUnique()
-                    .HasDatabaseName("UserNameIndex")
-                    .HasFilter("[NormalizedUserName] IS NOT NULL");
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasDatabaseName("UserNameIndex")
+                        .HasFilter("[NormalizedUserName] IS NOT NULL");
 
-                b.ToTable("AspNetUsers", (string)null);
-            });
+                    b.ToTable("AspNetUsers", (string)null);
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b => {
-                b.Property<int>("Id")
-                    .ValueGeneratedOnAdd()
-                    .HasColumnType("int");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
 
-                SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
-                b.Property<string>("ClaimType")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ClaimType")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("ClaimValue")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ClaimValue")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("UserId")
-                    .IsRequired()
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
 
-                b.HasKey("Id");
+                    b.HasKey("Id");
 
-                b.HasIndex("UserId");
+                    b.HasIndex("UserId");
 
-                b.ToTable("AspNetUserClaims", (string)null);
-            });
+                    b.ToTable("AspNetUserClaims", (string)null);
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b => {
-                b.Property<string>("LoginProvider")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("ProviderKey")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("ProviderKey")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("ProviderDisplayName")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("ProviderDisplayName")
+                        .HasColumnType("nvarchar(max)");
 
-                b.Property<string>("UserId")
-                    .IsRequired()
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
 
-                b.HasKey("LoginProvider", "ProviderKey");
+                    b.HasKey("LoginProvider", "ProviderKey");
 
-                b.HasIndex("UserId");
+                    b.HasIndex("UserId");
 
-                b.ToTable("AspNetUserLogins", (string)null);
-            });
+                    b.ToTable("AspNetUserLogins", (string)null);
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b => {
-                b.Property<string>("UserId")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("RoleId")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("RoleId")
+                        .HasColumnType("nvarchar(450)");
 
-                b.HasKey("UserId", "RoleId");
+                    b.HasKey("UserId", "RoleId");
 
-                b.HasIndex("RoleId");
+                    b.HasIndex("RoleId");
 
-                b.ToTable("AspNetUserRoles", (string)null);
-            });
+                    b.ToTable("AspNetUserRoles", (string)null);
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b => {
-                b.Property<string>("UserId")
-                    .HasColumnType("nvarchar(450)");
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+                {
+                    b.Property<string>("UserId")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("LoginProvider")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("LoginProvider")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("Name")
-                    .HasColumnType("nvarchar(450)");
+                    b.Property<string>("Name")
+                        .HasColumnType("nvarchar(450)");
 
-                b.Property<string>("Value")
-                    .HasColumnType("nvarchar(max)");
+                    b.Property<string>("Value")
+                        .HasColumnType("nvarchar(max)");
 
-                b.HasKey("UserId", "LoginProvider", "Name");
+                    b.HasKey("UserId", "LoginProvider", "Name");
 
-                b.ToTable("AspNetUserTokens", (string)null);
-            });
+                    b.ToTable("AspNetUserTokens", (string)null);
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
-                    .WithMany("Coops")
-                    .HasForeignKey("ContractID");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
+                        .WithMany("Coops")
+                        .HasForeignKey("ContractID");
 
-                b.Navigation("Contract");
-            });
+                    b.Navigation("Contract");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
-                    .WithMany("DemeritsGiven")
-                    .HasForeignKey("AdminUserId")
-                    .IsRequired();
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
+                        .WithMany("DemeritsGiven")
+                        .HasForeignKey("AdminUserId")
+                        .IsRequired();
 
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                    .WithMany("Demerits")
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                        .WithMany("Demerits")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.Navigation("AdminUser");
+                    b.Navigation("AdminUser");
 
-                b.Navigation("User");
-            });
+                    b.Navigation("User");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                    .WithMany()
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.Navigation("User");
-            });
+                    b.Navigation("User");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
-                    .WithMany("GuildContracts")
-                    .HasForeignKey("ContractID")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
+                        .WithMany("GuildContracts")
+                        .HasForeignKey("ContractID")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.Navigation("Contract");
-            });
+                    b.Navigation("Contract");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
-                    .WithMany("MeritsGiven")
-                    .HasForeignKey("AdminUserId")
-                    .IsRequired();
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
+                        .WithMany("MeritsGiven")
+                        .HasForeignKey("AdminUserId")
+                        .IsRequired();
 
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                    .WithMany("Merits")
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.ClientCascade)
-                    .IsRequired();
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                        .WithMany("Merits")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.ClientCascade)
+                        .IsRequired();
 
-                b.Navigation("AdminUser");
+                    b.Navigation("AdminUser");
 
-                b.Navigation("User");
-            });
+                    b.Navigation("User");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
-                    .WithMany()
-                    .HasForeignKey("ContractId");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
+                        .WithMany()
+                        .HasForeignKey("ContractId");
 
-                b.Navigation("Contract");
-            });
+                    b.Navigation("Contract");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
-                    .WithMany()
-                    .HasForeignKey("CoopId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
+                        .WithMany()
+                        .HasForeignKey("CoopId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                    .WithMany()
-                    .HasForeignKey("UserId");
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId");
 
-                b.Navigation("Coop");
+                    b.Navigation("Coop");
 
-                b.Navigation("User");
-            });
+                    b.Navigation("User");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b => {
-                b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
-                    .WithMany("UserCoopsXrefs")
-                    .HasForeignKey("CoopId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b =>
+                {
+                    b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
+                        .WithMany("UserCoopsXrefs")
+                        .HasForeignKey("CoopId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
-                    .WithMany("UserCoopXrefs")
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+                    b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
+                        .WithMany("UserCoopXrefs")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.Navigation("Coop");
+                    b.Navigation("Coop");
 
-                b.Navigation("User");
-            });
+                    b.Navigation("User");
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b => {
-                b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
-                    .WithMany()
-                    .HasForeignKey("RoleId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
-            });
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                        .WithMany()
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b => {
-                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                    .WithMany()
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
-            });
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b => {
-                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                    .WithMany()
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
-            });
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b => {
-                b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
-                    .WithMany()
-                    .HasForeignKey("RoleId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                        .WithMany()
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
 
-                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                    .WithMany()
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
-            });
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b => {
-                b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
-                    .WithMany()
-                    .HasForeignKey("UserId")
-                    .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired();
-            });
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b => {
-                b.Navigation("Coops");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b =>
+                {
+                    b.Navigation("Coops");
 
-                b.Navigation("GuildContracts");
-            });
+                    b.Navigation("GuildContracts");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b => {
-                b.Navigation("UserCoopsXrefs");
-            });
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
+                {
+                    b.Navigation("UserCoopsXrefs");
+                });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b => {
-                b.Navigation("Demerits");
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b =>
+                {
+                    b.Navigation("Demerits");
 
-                b.Navigation("DemeritsGiven");
+                    b.Navigation("DemeritsGiven");
 
-                b.Navigation("Merits");
+                    b.Navigation("Merits");
 
-                b.Navigation("MeritsGiven");
+                    b.Navigation("MeritsGiven");
 
-                b.Navigation("UserCoopXrefs");
-            });
+                    b.Navigation("UserCoopXrefs");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -8,13 +8,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace EGG9000.Common.Migrations
-{
+namespace EGG9000.Common.Migrations {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
-    {
-        protected override void BuildModel(ModelBuilder modelBuilder)
-        {
+    partial class ApplicationDbContextModelSnapshot : ModelSnapshot {
+        protected override void BuildModel(ModelBuilder modelBuilder) {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "6.0.6")
@@ -22,8 +19,7 @@ namespace EGG9000.Common.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.AutomationLog", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.AutomationLog", b => {
                 b.Property<Guid>("id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -45,8 +41,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AutomationLogs");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b => {
                 b.Property<string>("ID")
                     .HasColumnType("nvarchar(450)");
 
@@ -121,8 +116,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Contracts");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b => {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -215,8 +209,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Coops");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b => {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -330,8 +323,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Users");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b => {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -366,8 +358,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Demerit");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b => {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -391,8 +382,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Donations");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Event", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Event", b => {
                 b.Property<Guid>("id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -426,8 +416,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Events");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.EventCustomization", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.EventCustomization", b => {
                 b.Property<string>("Type")
                     .HasColumnType("nvarchar(450)");
 
@@ -457,8 +446,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("EventCustomizations");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.ExpiringShell", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.ExpiringShell", b => {
                 b.Property<Guid>("id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -492,8 +480,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("ExpiringShells");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardCoop", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardCoop", b => {
                 b.Property<Guid>("id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -518,8 +505,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("GlobalLeaderboardCoops");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardUser", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GlobalLeaderboardUser", b => {
                 b.Property<Guid>("id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -565,8 +551,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("GlobalLeaderboardUsers");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Guild", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Guild", b => {
                 b.Property<decimal>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("decimal(20,0)");
@@ -644,8 +629,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Guilds");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b => {
                 b.Property<string>("ContractID")
                     .HasColumnType("nvarchar(450)");
 
@@ -696,8 +680,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("GuildContracts");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b => {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -723,8 +706,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("Merit");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.TemporaryRole", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.TemporaryRole", b => {
                 b.Property<decimal>("UserId")
                     .HasColumnType("decimal(20,0)");
 
@@ -751,8 +733,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("TemporaryRoles");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b => {
                 b.Property<Guid>("ID")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -782,8 +763,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("UpcomingContracts");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b => {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("uniqueidentifier");
@@ -821,8 +801,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("UserCoopStatuses");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b => {
                 b.Property<Guid>("UserId")
                     .HasColumnType("uniqueidentifier");
 
@@ -946,8 +925,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("UserCoopXrefs");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCsHistoryEntry", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCsHistoryEntry", b => {
                 b.Property<string>("CoopIdentifier")
                     .HasColumnType("nvarchar(450)");
 
@@ -968,8 +946,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("UserCsHistoryEntries");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserSnapShot", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserSnapShot", b => {
                 b.Property<Guid>("UserId")
                     .HasColumnType("uniqueidentifier");
 
@@ -996,8 +973,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("UserSnapShots");
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b => {
                 b.Property<string>("Id")
                     .HasColumnType("nvarchar(450)");
 
@@ -1023,8 +999,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetRoles", (string)null);
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b => {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("int");
@@ -1048,8 +1023,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetRoleClaims", (string)null);
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b => {
                 b.Property<string>("Id")
                     .HasColumnType("nvarchar(450)");
 
@@ -1113,8 +1087,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetUsers", (string)null);
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b => {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
                     .HasColumnType("int");
@@ -1138,8 +1111,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetUserClaims", (string)null);
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b => {
                 b.Property<string>("LoginProvider")
                     .HasColumnType("nvarchar(450)");
 
@@ -1160,8 +1132,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetUserLogins", (string)null);
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b => {
                 b.Property<string>("UserId")
                     .HasColumnType("nvarchar(450)");
 
@@ -1175,8 +1146,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetUserRoles", (string)null);
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b => {
                 b.Property<string>("UserId")
                     .HasColumnType("nvarchar(450)");
 
@@ -1194,8 +1164,7 @@ namespace EGG9000.Common.Migrations
                 b.ToTable("AspNetUserTokens", (string)null);
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
                     .WithMany("Coops")
                     .HasForeignKey("ContractID");
@@ -1203,8 +1172,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("Contract");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Demerit", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
                     .WithMany("DemeritsGiven")
                     .HasForeignKey("AdminUserId")
@@ -1221,8 +1189,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("User");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Donation", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.DBUser", "User")
                     .WithMany()
                     .HasForeignKey("UserId")
@@ -1232,8 +1199,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("User");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.GuildContract", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
                     .WithMany("GuildContracts")
                     .HasForeignKey("ContractID")
@@ -1243,8 +1209,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("Contract");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Merit", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.DBUser", "AdminUser")
                     .WithMany("MeritsGiven")
                     .HasForeignKey("AdminUserId")
@@ -1261,8 +1226,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("User");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UpcomingContract", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.Contract", "Contract")
                     .WithMany()
                     .HasForeignKey("ContractId");
@@ -1270,8 +1234,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("Contract");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopStatus", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
                     .WithMany()
                     .HasForeignKey("CoopId")
@@ -1287,8 +1250,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("User");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.UserCoopXref", b => {
                 b.HasOne("EGG9000.Common.Database.Entities.Coop", "Coop")
                     .WithMany("UserCoopsXrefs")
                     .HasForeignKey("CoopId")
@@ -1306,8 +1268,7 @@ namespace EGG9000.Common.Migrations
                 b.Navigation("User");
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b => {
                 b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
                     .WithMany()
                     .HasForeignKey("RoleId")
@@ -1315,8 +1276,7 @@ namespace EGG9000.Common.Migrations
                     .IsRequired();
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b => {
                 b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
                     .WithMany()
                     .HasForeignKey("UserId")
@@ -1324,8 +1284,7 @@ namespace EGG9000.Common.Migrations
                     .IsRequired();
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b => {
                 b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
                     .WithMany()
                     .HasForeignKey("UserId")
@@ -1333,8 +1292,7 @@ namespace EGG9000.Common.Migrations
                     .IsRequired();
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b => {
                 b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
                     .WithMany()
                     .HasForeignKey("RoleId")
@@ -1348,8 +1306,7 @@ namespace EGG9000.Common.Migrations
                     .IsRequired();
             });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-            {
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b => {
                 b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
                     .WithMany()
                     .HasForeignKey("UserId")
@@ -1357,20 +1314,17 @@ namespace EGG9000.Common.Migrations
                     .IsRequired();
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Contract", b => {
                 b.Navigation("Coops");
 
                 b.Navigation("GuildContracts");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.Coop", b => {
                 b.Navigation("UserCoopsXrefs");
             });
 
-            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b =>
-            {
+            modelBuilder.Entity("EGG9000.Common.Database.Entities.DBUser", b => {
                 b.Navigation("Demerits");
 
                 b.Navigation("DemeritsGiven");

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -9,6 +9,9 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Text;
 
+using static Ei.MissionInfo.Types;
+using static Ei.Contract.Types;
+
 namespace Ei {
     public partial class EggIncFirstContactResponse {
         public bool Success { get; set; }
@@ -28,79 +31,76 @@ namespace Ei {
                 if(_participants != null)
                     return _participants;
                 _participants = new List<Types.ContributionInfo>();
-                foreach(var p in this.Contributors) {
-                    p.TimeLeftSeconds = this.SecondsRemaining;
+                foreach(var p in Contributors) {
+                    p.TimeLeftSeconds = SecondsRemaining;
                     _participants.Add(p);
                 }
-
                 return _participants;
             }
         }
 
         public bool Finished() {
-            return this.AllGoalsAchieved;
+            return AllGoalsAchieved;
         }
 
         public bool Failed() {
-            return !this.AllGoalsAchieved && this.ClearedForExit;
+            return !AllGoalsAchieved && ClearedForExit;
         }
 
         public partial class Types {
             public partial class ContributionInfo {
                 public string GetID() { return UserId; }
-                public string TotalString { get { return ArgumentsHelper.NumberToString(this.ContributionAmount, false, -1); } }
+                public string TotalString { get { return ArgumentsHelper.NumberToString(ContributionAmount, false, -1); } }
                 public double TimeLeftSeconds { get; set; }
 
                 public TimeSpan LastActive { get; set; }
-                public string RateString { get { return ArgumentsHelper.NumberToString(this.ContributionRate * 60 * 60, false, -1) + "/h"; } }
+                public string RateString { get { return ArgumentsHelper.NumberToString(ContributionRate * 60 * 60, false, -1) + "/h"; } }
 
                 public double AmountWithOffline(double siloTimeMinutes, TimeSpan lastActive) {
                     if(TimeLeftSeconds < 0) {
                         var awayTime = Math.Min(lastActive.TotalSeconds, siloTimeMinutes * 60);
-                        return this.ContributionAmount + this.ContributionRate * (awayTime + TimeLeftSeconds);
+                        return ContributionAmount + ContributionRate * (awayTime + TimeLeftSeconds);
                     }
-                    return this.ContributionAmount + this.ContributionRate * Math.Min(lastActive.TotalSeconds, siloTimeMinutes * 60);
+                    return ContributionAmount + ContributionRate * Math.Min(lastActive.TotalSeconds, siloTimeMinutes * 60);
                 }
 
                 public double AmountWithOfflineIgnoreSilo() {
                     if(TimeLeftSeconds < 0) {
-                        return this.ContributionAmount;
+                        return ContributionAmount;
                     }
-                    return this.ContributionAmount + this.ContributionRate * LastActive.TotalSeconds;
+                    return ContributionAmount + ContributionRate * LastActive.TotalSeconds;
                 }
 
                 public double Projected {
                     get {
                         if(TimeLeftSeconds < 0) {
-                            return this.ContributionAmount + this.ContributionRate * Math.Min(TimeLeftSeconds, LastActive.TotalSeconds);
+                            return ContributionAmount + ContributionRate * Math.Min(TimeLeftSeconds, LastActive.TotalSeconds);
                         }
-                        return this.ContributionAmount + this.ContributionRate * TimeLeftSeconds + this.ContributionRate * LastActive.TotalSeconds;
+                        return ContributionAmount + ContributionRate * TimeLeftSeconds + ContributionRate * LastActive.TotalSeconds;
                     }
                 }
             }
         }
-
-
     }
 
     public partial class Contract {
 
-        public List<Ei.Contract.Types.Goal> GetGoals(int league) {
-            if(this.GradeSpecs.Count > 0)
-                return this.GradeSpecs[league - 1].Goals.ToList();
-            else return this.GoalSets[league].Goals.ToList();
+        public List<Goal> GetGoals(int league) {
+            if(GradeSpecs.Count > 0)
+                return [.. GradeSpecs[league - 1].Goals];
+            else return [.. GoalSets[league].Goals];
         }
-        public List<Ei.Contract.Types.Goal> GetGoals(Ei.LocalContract contract) {
-            if(contract.Grade != Types.PlayerGrade.GradeUnset)
-                return this.GradeSpecs[(int)contract.Grade - 1].Goals.ToList();
-            else if(this.GoalSets.Count > 0)
-                return this.GoalSets[(int)contract.League].Goals.ToList();
+        public List<Goal> GetGoals(LocalContract contract) {
+            if(contract.Grade != PlayerGrade.GradeUnset)
+                return [.. GradeSpecs[(int)contract.Grade - 1].Goals];
+            else if(GoalSets.Count > 0)
+                return [.. GoalSets[(int)contract.League].Goals];
             else
-                return this.Goals.ToList();
+                return [.. Goals];
         }
 
         public int GetPossiblePE() {
-            return (int)((this.GradeSpecs?.FirstOrDefault()?.Goals ?? this.GoalSets?.FirstOrDefault()?.Goals ?? this.Goals).FirstOrDefault(x => x.RewardType == Ei.RewardType.EggsOfProphecy)?.RewardAmount ?? 0);
+            return (int)((GradeSpecs?.FirstOrDefault()?.Goals ?? GoalSets?.FirstOrDefault()?.Goals ?? Goals).FirstOrDefault(x => x.RewardType == Ei.RewardType.EggsOfProphecy)?.RewardAmount ?? 0);
         }
     }
 
@@ -108,8 +108,8 @@ namespace Ei {
         public DateTimeOffset Started { get { return DateTimeOffset.FromUnixTimeSeconds((long)TimeAccepted); } }
         public bool Completed {
             get {
-                var targetGoals = Contract.GradeSpecs.Count > 0 && Grade != Contract.Types.PlayerGrade.GradeUnset ?
-                    Contract.GradeSpecs[(int)(this.Grade - 1)].Goals.Count :
+                var targetGoals = Contract.GradeSpecs.Count > 0 && Grade != PlayerGrade.GradeUnset ?
+                    Contract.GradeSpecs[(int)(Grade - 1)].Goals.Count :
                     (Contract.GoalSets.Any() ?
                     Contract.GoalSets[0].Goals.Count : Contract.Goals.Count);
                 return NumGoalsAchieved == targetGoals;
@@ -125,7 +125,7 @@ namespace Ei {
             }
             return UserId;
         }
-        //public FarmDetails GetFarmDetails(Types.Simulation farm) {
+        //public FarmDetails GetFarmDetails(Simulation farm) {
         //    var farmIndex = Farms.IndexOf(farm);
 
         //    var artifacts = new List<EggIncArtifactInstance>();
@@ -155,9 +155,9 @@ namespace Ei {
         //    public List<EggIncArtifactInstance> Artifacts { get; set; }
         //    public double CurrentMultiplier { get; set; }
         //    public double EarningsBonus { get; set; }
-        //    public Types.Simulation Farm { get; set; }
+        //    public Simulation Farm { get; set; }
         //    public Ei.LocalContract Contract { get; set; }
-        //    public Google.Protobuf.Collections.RepeatedField<Ei.Backup.Types.ResearchItem> EpicResearch { get; set; }
+        //    public Google.Protobuf.Collections.RepeatedField<Ei.Backup.ResearchItem> EpicResearch { get; set; }
         //    public Double EggLayingRate {
         //        get {
         //            return Research.GetEggLayingRatePerSec(Farm, EpicResearch.ToList()) * EggIncArtifacts.GetEggLayingRateMultiple(Artifacts);
@@ -207,158 +207,67 @@ namespace Ei {
             }
         }
     }
-    public partial class MissionInfo {
-        public static Dictionary<Egg, double> GetFuelTargets(Types.Spaceship Ship, Types.DurationType DurationType) {
-            Dictionary<Types.Spaceship, Dictionary<Types.DurationType, Dictionary<Egg, double>>> ShipFuelTargets = new Dictionary<Types.Spaceship, Dictionary<Types.DurationType, Dictionary<Egg, double>>>();
-            ShipFuelTargets.Add(Types.Spaceship.ChickenOne, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Tutorial, new Dictionary<Egg, double> { { Egg.RocketFuel, 1e5 } } },
-                    { Types.DurationType.Short, new Dictionary<Egg, double> { { Egg.RocketFuel, 2e6 } } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> { { Egg.RocketFuel, 3e6 } } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> { { Egg.RocketFuel, 10e6 } } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.ChickenNine, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> { { Egg.RocketFuel, 10e6 } } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> { { Egg.RocketFuel, 15e6 } } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> { { Egg.RocketFuel, 25e6 } } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.ChickenHeavy, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> { { Egg.RocketFuel, 100e6 } } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.RocketFuel, 50e6 },
-                        { Egg.Fusion, 5e6 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.RocketFuel, 75e6 },
-                        { Egg.Fusion, 25e6 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.Bcr, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.RocketFuel, 250e6 },
-                        { Egg.Fusion, 50e6 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.RocketFuel, 400e6 },
-                        { Egg.Fusion, 75e6 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Superfood, 5e6 },
-                        { Egg.RocketFuel, 300e6 },
-                        { Egg.Fusion, 100e6 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.MilleniumChicken, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 5e9 },
-                        { Egg.Graviton, 1e9 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 7e9 },
-                        { Egg.Graviton, 5e9 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Superfood, 10e6 },
-                        { Egg.Fusion, 10e9 },
-                        { Egg.Graviton, 15e9 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.CorellihenCorvette, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 15e9 },
-                        { Egg.Graviton, 2e9 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 20e9 },
-                        { Egg.Graviton, 3e9 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Superfood, 500e6 },
-                        { Egg.Fusion, 25e9 },
-                        { Egg.Graviton, 5e9 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.Galeggtica, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 50e9 },
-                        { Egg.Graviton, 10e9 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 75e9 },
-                        { Egg.Graviton, 25e9 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Fusion, 100e9 },
-                        { Egg.Graviton, 50e9 },
-                        { Egg.Antimatter, 1e9 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.Chickfiant, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 200e9 },
-                        { Egg.Antimatter, 50e9 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 250e9 },
-                        { Egg.Antimatter, 150e9 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Tachyon, 25e9 },
-                        { Egg.Dilithium, 250e9 },
-                        { Egg.Antimatter, 250e9 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.Voyegger, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 1e12 },
-                        { Egg.Antimatter, 1e12 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 1.5e12 },
-                        { Egg.Antimatter, 1.5e12 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Tachyon, 100e9 },
-                        { Egg.Dilithium, 2e12},
-                        { Egg.Antimatter, 2e12 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.Henerprise, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 2e12 },
-                        { Egg.Antimatter, 2e12 }
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 3e12 },
-                        { Egg.Antimatter, 3e12 },
-                        { Egg.DarkMatter, 3e12 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Tachyon, 1e12 },
-                        { Egg.Dilithium, 3e12},
-                        { Egg.Antimatter, 3e12 },
-                        { Egg.DarkMatter, 3e12 },
-                    } }
-                });
-            ShipFuelTargets.Add(Types.Spaceship.Atreggies, new Dictionary<Types.DurationType, Dictionary<Egg, double>> {
-                    { Types.DurationType.Short, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 4e12 },
-                        { Egg.Antimatter, 4e12 },
-                        { Egg.DarkMatter, 3e12 },
-                    } },
-                    { Types.DurationType.Long, new Dictionary<Egg, double> {
-                        { Egg.Dilithium, 6e12 },
-                        { Egg.Antimatter, 6e12 },
-                        { Egg.DarkMatter, 4e12 },
-                    } },
-                    { Types.DurationType.Epic, new Dictionary<Egg, double> {
-                        { Egg.Tachyon, 2e12 },
-                        { Egg.Dilithium, 6e12},
-                        { Egg.Antimatter, 6e12 },
-                        { Egg.DarkMatter, 6e12 },
-                    } }
-                });
 
-            return ShipFuelTargets[Ship][DurationType];
+    public partial class MissionInfo {
+        public static Dictionary<Egg, double> GetFuelTargets(Spaceship Ship, DurationType DurationType) {
+            return new Dictionary<Spaceship, Dictionary<DurationType, Dictionary<Egg, double>>> {
+                {Spaceship.ChickenOne, new() {
+                    { DurationType.Tutorial, new(){ { Egg.RocketFuel, 1e5 } }},
+                    { DurationType.Short, new(){ { Egg.RocketFuel, 2e6 } }},
+                    { DurationType.Long, new() { { Egg.RocketFuel, 3e6 } }},
+                    { DurationType.Epic, new() { { Egg.RocketFuel, 10e6 } }},
+                }},
+                {Spaceship.ChickenNine, new() {
+                    { DurationType.Short, new() { { Egg.RocketFuel, 10e6 } }},
+                    { DurationType.Long, new() { { Egg.RocketFuel, 15e6 } }},
+                    { DurationType.Epic, new() { { Egg.RocketFuel, 25e6 } }},
+                }},
+                {Spaceship.ChickenHeavy, new() {
+                    { DurationType.Short, new() { { Egg.RocketFuel, 100e6 } }},
+                    { DurationType.Long, new() { { Egg.RocketFuel, 50e6 }, { Egg.Fusion, 5e6 } }},
+                    { DurationType.Epic, new() { { Egg.RocketFuel, 75e6 }, { Egg.Fusion, 25e6 } }},
+                }},
+                {Spaceship.Bcr, new() {
+                    { DurationType.Short, new() { { Egg.RocketFuel, 250e6 }, { Egg.Fusion, 50e6 } }},
+                    { DurationType.Long, new() { { Egg.RocketFuel, 400e6 }, { Egg.Fusion, 75e6 } }},
+                    { DurationType.Epic, new() { { Egg.Superfood, 5e6 }, { Egg.RocketFuel, 300e6 }, { Egg.Fusion, 100e6 } }},
+                }},
+                {Spaceship.MilleniumChicken, new() {
+                    { DurationType.Short, new() { { Egg.Fusion, 5e9 }, { Egg.Graviton, 1e9 } }},
+                    { DurationType.Long, new() { { Egg.Fusion, 7e9 }, { Egg.Graviton, 5e9 } }},
+                    { DurationType.Epic, new() { { Egg.Superfood, 10e6 }, { Egg.Fusion, 10e9 }, { Egg.Graviton, 15e9 } }},
+                }},
+                {Spaceship.CorellihenCorvette, new() {
+                    { DurationType.Short, new() { { Egg.Fusion, 15e9 }, { Egg.Graviton, 2e9 } }},
+                    { DurationType.Long, new() { { Egg.Fusion, 20e9 }, { Egg.Graviton, 3e9 } }},
+                    { DurationType.Epic, new() { { Egg.Superfood, 500e6 }, { Egg.Fusion, 25e9 }, { Egg.Graviton, 5e9 } }},
+                }},
+                {Spaceship.Galeggtica, new() {
+                    { DurationType.Short, new() { { Egg.Fusion, 50e9 }, { Egg.Graviton, 10e9 } }},
+                    { DurationType.Long, new() { { Egg.Fusion, 75e9 }, { Egg.Graviton, 25e9 } }},
+                    { DurationType.Epic, new() { { Egg.Fusion, 100e9 }, { Egg.Graviton, 50e9 }, { Egg.Antimatter, 1e9 } }},
+                }},
+                {Spaceship.Chickfiant, new() {
+                    { DurationType.Short, new() { { Egg.Dilithium, 200e9 }, { Egg.Antimatter, 50e9 } }},
+                    { DurationType.Long, new() { { Egg.Dilithium, 250e9 }, { Egg.Antimatter, 150e9 } }},
+                    { DurationType.Epic, new() { { Egg.Tachyon, 25e9 }, { Egg.Dilithium, 250e9 }, { Egg.Antimatter, 250e9 } }},
+                }},
+                {Spaceship.Voyegger, new() {
+                    { DurationType.Short, new() { { Egg.Dilithium, 1e12 }, { Egg.Antimatter, 1e12 } }},
+                    { DurationType.Long, new() { { Egg.Dilithium, 1.5e12 }, { Egg.Antimatter, 1.5e12 } }},
+                    { DurationType.Epic, new() { { Egg.Tachyon, 100e9 }, { Egg.Dilithium, 2e12}, { Egg.Antimatter, 2e12 } }},
+                }},
+                {Spaceship.Henerprise, new() {
+                    { DurationType.Short, new() { { Egg.Dilithium, 2e12 }, { Egg.Antimatter, 2e12 } }},
+                    { DurationType.Long, new() { { Egg.Dilithium, 3e12 }, { Egg.Antimatter, 3e12 }, { Egg.DarkMatter, 3e12 } }},
+                    { DurationType.Epic, new() { { Egg.Tachyon, 1e12 }, { Egg.Dilithium, 3e12}, { Egg.Antimatter, 3e12 }, { Egg.DarkMatter, 3e12 } }},
+                }},
+                {Spaceship.Atreggies, new() {
+                    { DurationType.Short, new() { { Egg.Dilithium, 4e12 }, { Egg.Antimatter, 4e12 }, { Egg.DarkMatter, 3e12 } }},
+                    { DurationType.Long, new() { { Egg.Dilithium, 6e12 }, { Egg.Antimatter, 6e12 }, { Egg.DarkMatter, 4e12 } }},
+                    { DurationType.Epic, new() { { Egg.Tachyon, 2e12 }, { Egg.Dilithium, 6e12}, { Egg.Antimatter, 6e12 }, { Egg.DarkMatter, 6e12 } }},
+                }}
+            }[Ship][DurationType];
         }
     }
 }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -285,17 +285,62 @@ namespace EGG9000.Site.Controllers {
             public int FinishedCoops { get; set; }
         }
 
-        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin")]
+        private static readonly List<string> EventTypes = [
+            "prestige-boost", "piggy-boost", "earnings-boost", "gift-boost", "vehicle-sale", "drone-boost", "research-sale", "hab-sale", 
+            "epic-research-sale", "boost-sale", "crafting-sale", "boost-duration", "mission-fuel", "mission-capacity", "shell-sale", "piggy-cap-boost"
+        ];
+
+        public record EventCustomizationModel(
+            List<EventCustomization> Customizations,
+            ulong GuildDiscordID
+        );
+
+        [Authorize(Roles = "Admin,GuildAdmin")]
         public async Task<IActionResult> EventCustomization() {
             var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
             var guild = await _db.Guilds.AsQueryable().FirstAsync(x => x.DiscordSeverId == guildId);
+            //Used for 'default values'
+            var palaceGuild = await _db.Guilds.AsQueryable().FirstOrDefaultAsync(g => g.DiscordSeverId == 656455567858073601);
+            
+            var eventCustomizations = new List<EventCustomization>();
+            foreach(var type in EventTypes) {
+                var guildEventCustomization = guild.EventCustomzations.FirstOrDefault(ec => ec.Type == type);
+                if(guildEventCustomization == null && palaceGuild != null) { //Default to palace customizations
+                    Console.WriteLine("Grabbing from Palace");
+                    guildEventCustomization = palaceGuild.EventCustomzations.FirstOrDefault(ec => ec.Type == type);
+                }
+                guildEventCustomization ??= new() {
+                    Type = type,
+                };
+                eventCustomizations.Add(guildEventCustomization);
+            }
 
-            return View(await _db.EventCustomizations.AsQueryable().OrderByDescending(x => x.Priority).ToListAsync());
+            return View(eventCustomizations.OrderByDescending(x => x.Priority).ToList());
         }
 
-        [Authorize(Roles = "Admin")]
+        [Authorize(Roles = "Admin,GuildAdmin")]
         public async Task<IActionResult> SaveEventCustomization([FromBody] EventCustomization eventCustomization) {
-            _db.Entry(eventCustomization).State = EntityState.Modified;
+            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+            var guild = await _db.Guilds.AsQueryable().FirstAsync(x => x.DiscordSeverId == guildId);
+
+            var eventCustomizationToSave = guild.EventCustomzations.FirstOrDefault(ec => ec.Type == eventCustomization.Type);
+            
+            var tempNotifs = JsonConvert.DeserializeObject<EventCustomizationSettings>(eventCustomization._settings);
+            tempNotifs.Notifications.ForEach(n => n.GuildID = guild.DiscordSeverId);
+            eventCustomization._settings = JsonConvert.SerializeObject(tempNotifs);
+
+            if(eventCustomizationToSave is null) {
+                guild.EventCustomzations = [
+                    .. guild.EventCustomzations,
+                    eventCustomization
+                ];
+            } else {
+                var cloneList = new List<EventCustomization>(guild.EventCustomzations) {
+                    [guild.EventCustomzations.IndexOf(eventCustomizationToSave)] = eventCustomization
+                };
+                guild.EventCustomzations = cloneList;
+            }
+
             await _db.SaveChangesAsync();
             return Content("Success");
         }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -801,12 +801,12 @@ namespace EGG9000.Site.Controllers {
         }
 
         public async Task<IActionResult> SearchID([FromQuery] string id) {
-            var users = (await _db.DBUsers.AsQueryable().Select(x => new { x.Id, x.DiscordId, x.DiscordUsername, x._eggIncIds, x.EIDs }).ToListAsync())
-                .Select(x => new DBUser { Id = x.Id, DiscordId = x.DiscordId, DiscordUsername = x.DiscordUsername, _eggIncIds = x._eggIncIds, EIDs = x.EIDs });
+            var users = (await _db.DBUsers.AsQueryable().Select(x => new { x.Id, x.DiscordId, x.DiscordUsername, x._eggIncIds, x.EIDs, x.Usernames }).ToListAsync())
+                .Select(x => new DBUser { Id = x.Id, DiscordId = x.DiscordId, DiscordUsername = x.DiscordUsername, _eggIncIds = x._eggIncIds, EIDs = x.EIDs, Usernames = x.Usernames });
 
             if(id.Trim().All(x => x >= '0' && x <= '9')) {
                 return RedirectToAction("ViewUser", "MyFarms", new { discordId = id });
-            } else if(Regex.IsMatch(id.ToUpper(), "@EI\\d{16}") && users.Any(u => u.EIDs.Contains(id))) {
+            } else if(Regex.IsMatch(id.ToUpper(), "EI\\d{16}") && users.Any(u => u.EIDs.Contains(id))) {
                 return RedirectToAction("ViewUser", "MyFarms", new { discordId = (users.First(u => u.EIDs.Contains(id))).DiscordId });
             }
 
@@ -815,10 +815,13 @@ namespace EGG9000.Site.Controllers {
             //    return RedirectToAction("ViewUser", "MyFarms", new { discordId = matchingUser2.DiscordId });
             //}
 
+            Console.WriteLine("Usernames: \n" + string.Join("\n", users.Select(x => (x.Usernames ?? "").ToLower().Split(",")).ToList()));
+
             id = id.ToLower().Trim();
+            Console.WriteLine("Id: " +  id);
             var matchingUsers = users.Where(x => 
                 (x.DiscordUsername ?? "").ToLower().Contains(id) || 
-                x.Usernames.ToLower().Split(",").Contains(id)
+                (x.Usernames ?? "").ToLower().Split(",").Any(u => u.Contains(id))
             ).ToList();
 
             if(matchingUsers.Count == 1) {

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -264,8 +264,8 @@ namespace EGG9000.Site.Controllers {
                 Guilds = _discord.Guilds.Where(x => x.Id == guildId || guild.OverflowServers.Contains(x.Id)).OrderBy(x => x.Id).Select(x => new GuildDetails {
                     Name = x.Name,
                     ChannelCount = x.Channels.Where(x => x is not SocketThreadChannel).Count(),
-                    ActiveCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.Contains("coops") && !c.Category.Name.Contains("finished")),
-                    FinishedCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.Contains("coops") && c.Category.Name.Contains("finished")),
+                    ActiveCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.ToLower().Contains("coops") && !c.Category.Name.ToLower().Contains("finished")),
+                    FinishedCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.ToLower().Contains("coops") && c.Category.Name.ToLower().Contains("finished")),
                 }).ToList(),
                 ContractsToScore = contractsToScore
             });

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -263,7 +263,8 @@ namespace EGG9000.Site.Controllers {
                 Contracts = await _db.Contracts.AsQueryable().OrderByDescending(x => x.Created).Take(10).ToListAsync(),
                 Guilds = _discord.Guilds.Where(x => x.Id == guildId || guild.OverflowServers.Contains(x.Id)).OrderBy(x => x.Id).Select(x => new GuildDetails {
                     Name = x.Name,
-                    ChannelCount = x.Channels.Where(x => x is not SocketThreadChannel).Count(),
+                    CategoryCount = x.Channels.Where(x => x is SocketCategoryChannel).Count(),
+                    ChannelCount = x.Channels.Where(x => x is not SocketThreadChannel && x is not SocketCategoryChannel).Count(),
                     ActiveCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.ToLower().Contains("coops") && !c.Category.Name.ToLower().Contains("finished")),
                     FinishedCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.ToLower().Contains("coops") && c.Category.Name.ToLower().Contains("finished")),
                 }).ToList(),
@@ -280,6 +281,7 @@ namespace EGG9000.Site.Controllers {
 
         public class GuildDetails {
             public string Name { get; set; }
+            public int CategoryCount { get; set; }
             public int ChannelCount { get; set; }
             public int ActiveCoops { get; set; }
             public int FinishedCoops { get; set; }
@@ -860,10 +862,7 @@ namespace EGG9000.Site.Controllers {
             //    return RedirectToAction("ViewUser", "MyFarms", new { discordId = matchingUser2.DiscordId });
             //}
 
-            Console.WriteLine("Usernames: \n" + string.Join("\n", users.Select(x => (x.Usernames ?? "").ToLower().Split(",")).ToList()));
-
             id = id.ToLower().Trim();
-            Console.WriteLine("Id: " +  id);
             var matchingUsers = users.Where(x => 
                 (x.DiscordUsername ?? "").ToLower().Contains(id) || 
                 (x.Usernames ?? "").ToLower().Split(",").Any(u => u.Contains(id))

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -1124,6 +1124,7 @@ music
             dbGuild.PublicScoreGrid = model.PublicScoreGrid;
             dbGuild.RemoveFindCoopSpot = model.RemoveFindCoopSpot;
             dbGuild.CoopNamePrefix = string.IsNullOrWhiteSpace(model.CoopNamePrefix) ? null : model.CoopNamePrefix;
+            dbGuild.AddOutsideCoops = model.AddOutsideCoops;
             await _db.SaveChangesAsync();
 
             return Ok();
@@ -1160,6 +1161,7 @@ music
             public bool PublicScoreGrid { get; set; }
             public string CoopNamePrefix { get; set; }
             public bool RemoveFindCoopSpot { get; set; }
+            public bool AddOutsideCoops { get; set; }
         }
 
         //public async Task<IActionResult> SaveCoopCategories(ulong id, List<ulong> coopCategories) {

--- a/EGG9000.Site/Views/Admin/ConfigureServer.cshtml
+++ b/EGG9000.Site/Views/Admin/ConfigureServer.cshtml
@@ -309,13 +309,17 @@
 	<div class="card-header">Other Settings</div>
 	<div class="card-body">
 		<div>
-		<label>
-			<input class="custom-input" type="checkbox" value="true" id="PublicScoreGrid" checked="@Model.PublicScoreGrid" /> Allow everyone to view Score Grid
-		</label>
-		<br/>
-		<label>
-				<input class="custom-input" type="checkbox" value="true" id="RemoveFindCoopSpot" checked="@Model.RemoveFindCoopSpot" /> Remove <button class="btn btn-primary btn-sm" disabled>Find Coop Spot</button> buttons from Co-op channels
-		</label>
+			<label>
+				<input class="custom-input" type="checkbox" value="true" id="PublicScoreGrid" checked="@Model.PublicScoreGrid" /> Allow everyone to view Score Grid
+			</label>
+			<br/>
+			<label>
+					<input class="custom-input" type="checkbox" value="true" id="RemoveFindCoopSpot" checked="@Model.RemoveFindCoopSpot" /> Remove <button class="btn btn-primary btn-sm" disabled>Find Coop Spot</button> buttons from Co-op channels
+			</label>
+			<br />
+			<label>
+				<input class="custom-input" type="checkbox" value="true" id="AddOutsideCoops" checked="@Model.AddOutsideCoops" /> Add Outside Co-ops from Backups
+			</label>
 		</div>
 		<label>Co-op Prefix <input style="margin-left: 3px;" class="custom-input" value="@Model.CoopNamePrefix" id="CoopNamePrefix" /></label>
 	</div>
@@ -389,7 +393,8 @@
 						GroupRoles: GetCategoryJoins(".GroupRole"),
 						PublicScoreGrid: $("#PublicScoreGrid").is(":checked"),
 						RemoveFindCoopSpot: $("#RemoveFindCoopSpot").is(":checked"),
-						CoopNamePrefix: $("#CoopNamePrefix").val()
+						CoopNamePrefix: $("#CoopNamePrefix").val(),
+						AddOutsideCoops: $("#AddOutsideCoops").is(":checked"),
 					})
 			}, function () {
 				document.location = document.location;

--- a/EGG9000.Site/Views/Admin/EventCustomization.cshtml
+++ b/EGG9000.Site/Views/Admin/EventCustomization.cshtml
@@ -1,7 +1,70 @@
 ﻿@model List<EventCustomization>
+@using System.Security.Claims;
 @{
     ViewData["Title"] = "Event Customization";
+
 }
+
+<style>
+    .tooltip-custom {
+        position: relative;
+        display: inline-block;
+    }
+
+        .tooltip-custom:hover .tooltiptext-custom {
+            display: inline-block;
+            z-index: 3;
+            position: absolute;
+            bottom: 25px; /* Adjust this value as needed */
+            left: 50%;
+            transform: translateX(-50%); /* Center the tooltip */
+        }
+
+    .tooltiptext-custom {
+        display: none;
+        border: 1px solid #ccc;
+        padding: 10px;
+        border-radius: 4px;
+        white-space: nowrap;
+        text-align: center; /* Center the text within the tooltip */
+        position: absolute;
+    }
+
+        .tooltiptext-custom .bootstrap-dark {
+            background-color: rgba(33, 37, 41, 0.95);
+        }
+
+        .tooltiptext-custom .bootstrap {
+            background-color: rgba(130, 135, 140, 0.95);
+        }
+
+    .bootstrap-dark .speech-bubble {
+        background-color: rgba(33, 37, 41, 0.95);
+    }
+
+    .bootstrap .speech-bubble {
+        background-color: rgba(130, 135, 140, 0.95);
+    }
+
+    .speech-bubble {
+        position: relative;
+        padding: 10px; /* Adjust the padding to your preference */
+        margin: 10px auto; /* Center the bubble horizontally */
+        border-radius: 5px; /* Rounded corners for the bubble */
+    }
+
+        /* Create the triangle */
+        .speech-bubble :after {
+            content: "";
+            position: absolute;
+            top: 100%;
+            left: 50%;
+            margin-left: -15px; /* Half of the triangle's width */
+            border-width: 15px; /* Adjust the size of the triangle */
+            border-style: solid;
+            border-color: #ccc transparent transparent transparent;
+        }
+</style>
 
 <div ng-controller="AdminPage">
     <h2>Event Customization</h2>
@@ -30,8 +93,30 @@
     </table>
 
     <script type="text/ng-template" id="Edit.html">
-        <div class="modal-header">Edit Item</div>
-        <div class="modal-body">
+        <style>
+            .modal-body {
+                max-height: calc(100vh - 180px); /* Adjust the value as needed */
+                overflow-y: auto;
+            }
+
+            .tip-container {
+                border: 1px solid #ccc;
+                border-radius: 8px;
+                margin-bottom: 10px;
+                padding: 10px;
+            }
+
+            .tip-item {
+                margin-bottom: 10px;
+            }
+        </style>
+        <div class="modal-header d-flex justify-content-between align-items-center">
+            <span>Edit Item</span>
+            <button type="button" class="close" ng-click="Cancel()" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+            </button>
+        </div>
+        <div class="modal-body overflow-auto">
             <div class="form-group">
                 <label>Type</label>
                 <input class="form-control" disabled ng-model="item.type" />
@@ -42,23 +127,8 @@
             </div>
             <div class="form-group">
                 <label for="Description">Description</label>
-                <input class="form-control" id="Description" ng-model="item.description" />
+                <textarea spellcheck="false" class="form-control" id="Description" ng-model="item.description"></textarea>
             </div>
-                <h3>Tips</h3>
-            <div ng-repeat="tip in item.Tips track by $index">
-                <div class="form-group">
-                    <label>Title</label>
-                    <input class="form-control" ng-model="tip.Name" />
-                </div>
-                <div class="form-group">
-                    <label>Text</label>
-
-
-                    <input class="form-control" ng-model="tip.Value" />
-                    <button class="btn btn-danger" ng-click="RemoveTip($index)">X</button>
-                </div>
-            </div>
-            <button class="btn btn-success" ng-click="AddTip()">+ Add Tip</button>
             <div class="form-group">
                 <label>ThumbnailUrl</label>
                 <input class="form-control" ng-model="item.thumbnailURL" />
@@ -68,40 +138,57 @@
                 <input class="form-control" ng-model="item.emoji" />
             </div>
 
+            <hr class="mt-1 mb-1">
+            
+            <h3>Tips</h3>
+            <div ng-repeat="tip in item.Tips track by $index" class="tip-container">
+                <div class="form-group tip-item">
+                    <label>Title</label>
+                    <input class="form-control" ng-model="tip.Name" />
+                </div>
+                <div class="form-group tip-item">
+                    <label>Text</label>
+                    <textarea spellcheck="false" class="form-control" ng-model="tip.Value"></textarea>
+                </div>
+                <div class="form-group tip-item">
+                    <label>Remove Tip</label> <br>
+                    <button class="btn btn-danger" ng-click="RemoveTip($index)">X</button>
+                </div>
+            </div>
+
+            <button class="mt-2 btn btn-success" ng-click="AddTip()">+ Add Tip</button>
+
+            <hr class="mt-1 mb-1">
+
             <h3>Notifications</h3>
-            <div ng-repeat="notification in item.settings.notifications track by $index">
-                <div class="row">
+            <div class="pb-2" ng-repeat="notification in item.settings.notifications track by $index">
+                <div class="row align-items-center">
                     <div class="col">
-                        GuildId
+                        <label for="roleId{{$index}}">Role ID</label>
+                        <input id="roleId{{$index}}" class="form-control" ng-model="notification.roleIdString" />
                     </div>
                     <div class="col">
-                        <input class="form-control" ng-model="notification.guildID" />
+                        <label for="minValue{{$index}}" class="tooltip-custom">
+                            Min Value
+                            <span class="tooltiptext-custom speech-bubble">
+                                The minimum value the event must be to ping this role. <br>
+                                For example, to ping a role specifically <br>for 3x prestige you would enter 3
+                            </span>
+                        </label>
+                        <input id="minValue{{$index}}" class="form-control" ng-model="notification.minValue" />
                     </div>
                     <div class="col">
-                        RoleID
-                    </div>
-                    <div class="col">
-                        <input class="form-control" ng-model="notification.roleID" />
-                    </div>
-                    <div class="col">
-                        MinValue
-                    </div>
-                    <div class="col">
-                        <input class="form-control" ng-model="notification.minValue" />
-                    </div>
-                    <div class="col">
-                        <button class="btn btn-danger" ng-click="$parent.settings.notifications.splice($index)">X</button>
+                        <label for="removeNotif{{$index}}">Remove</label> <br>
+                        <button id="removeNotif{{$index}}" class="btn btn-danger" ng-click="$parent.item.settings.notifications.splice($index, 1)">X</button>
                     </div>
                 </div>
             </div>
-            <button class="btn btn-success" ng-click="item.settings.notifications.push({})">+ Add Notification</button>
+            <button class="mt-2 btn btn-success" ng-click="item.settings.notifications.push({})">+ Add Notification</button>
+        </div>        
+        <div class="modal-footer">
+            <button class="btn btn-success" ng-click="Save()">Save</button>
+            <button class="btn btn-default" ng-click="Cancel()">Cancel</button>
         </div>
-        @if (User.IsInRole("Admin")) {
-            <div class="modal-footer">
-                <button class="btn btn-success" ng-click="Save()">Save</button>
-                <button class="btn btn-default" ng-click="Cancel()">Cancel</button>
-            </div>
-        }
     </script>
 </div>
 @section Scripts {
@@ -166,8 +253,8 @@
 
                             $scope.Save = function Save() {
                                 $scope.item.Fields = JSON.stringify($scope.item.Tips);
-                                console.log($scope.item);
                                 $scope.item._settings = JSON.stringify($scope.item.settings);
+                                console.log($scope.item);
                                 $http({ method: 'POST', data: item, url: '/admin/saveeventcustomization/' })
                                     .then(function successCallback(response) {
                                         if (response.data.Error) {

--- a/EGG9000.Site/Views/Admin/Index.cshtml
+++ b/EGG9000.Site/Views/Admin/Index.cshtml
@@ -32,6 +32,7 @@
 				<thead>
 					<tr>
 						<th>Server</th>
+						<th>Categories</th>
 						<th>Channels</th>
 						<th>Active Coops</th>
 						<th>🏁 Coops</th>
@@ -45,15 +46,16 @@
 						int available;
 						if (first) {
 							first = false;
-							available = Math.Max(450 - guild.ChannelCount, 0);
+							available = Math.Max(450 - guild.ChannelCount - guild.CategoryCount, 0);
 
 						} else {
-							available = Math.Max(500 - guild.ChannelCount, 0);
+							available = Math.Max(500 - guild.ChannelCount - guild.CategoryCount, 0);
 
 						}
 						availableSum += available;
 						<tr>
 							<td>@guild.Name</td>
+							<td>@guild.CategoryCount</td>
 							<td>@guild.ChannelCount</td>
 							<td>@guild.ActiveCoops</td>
 							<td>@guild.FinishedCoops</td>
@@ -62,7 +64,7 @@
 					}
 				}
 				<tr>
-					<th colspan="4" align="right">Total Channels Available for Co-ops</th>
+					<th colspan="5" align="right">Total Channels Available for Co-ops</th>
 					<td>
 						@availableSum
 					</td>

--- a/EGG9000.Site/Views/Admin/SearchID.cshtml
+++ b/EGG9000.Site/Views/Admin/SearchID.cshtml
@@ -7,15 +7,15 @@
 	<thead>
 		<tr>
 			<th>Discord User</th>
-			<th colspan="99">Egg Inc Usernames</th>
+			<th colspan="99">Egg Inc Username(s)</th>
 		</tr>
 	</thead>
 	@foreach (var user in Model) {
 		<tr>
-			<td>
+			<td style="margin-right: 10px;">
 				<a href="/MyFarms/ViewUser?discordId=@(user.DiscordId)"> @user.DiscordUsername </a>
 			</td>
-			@foreach (var username in user.Usernames.Split(",")) {
+			@foreach (var username in (user.Usernames ?? "").Split(",")) {
 				<td>@username</td>
 			}
 		</tr>

--- a/EGG9000.Site/Views/MyFarms/-ContractHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ContractHistory.cshtml
@@ -11,6 +11,10 @@
 	List<(object, DateTimeOffset)> allFarms = new List<(object, DateTimeOffset)>();
 	allFarms.AddRange(farms.Where(x => !string.IsNullOrEmpty(x.ContractId)).Select(x => ((object)x, x.Started)));
 	allFarms.AddRange(backup.ArchivedFarms?.Where(x => !farms.Any(y => y.ContractId == x.ContractId)).Select(x => ((object)x, x.Started)));
+
+	string LimitToThirty(string input){
+		return (input.Length > 30 ? $"{input.Substring(0, 30)}..." : input);
+	}
 }
 <div class="card" style="margin-top:15px">
 	<h4 class="card-header">Active Farms</h4>
@@ -59,7 +63,7 @@
 								<td>@(contract?.Name ?? farm.ContractId)</td>
 								<td>
 									<a href="/coop/@farm.ContractId/@(farm.CoopId ?? coop?.Name)">
-										@(farm.CoopId ?? coop?.Name)
+										@(LimitToThirty(farm.CoopId ?? coop?.Name))
 									</a>
 									@if (coop is not null && !coop.DeletedChannel)
 									{
@@ -138,7 +142,7 @@
 								<td>@(contract?.Name ?? farm.ContractId)</td>
 								<td>
 									<a href="/coop/@farm.ContractId/@(farm.CoopId ?? coop?.Name)">
-										@(farm.CoopId ?? coop?.Name)
+										@(LimitToThirty(farm.CoopId ?? coop?.Name))
 									</a>
 									@if (coop is not null && !coop.DeletedChannel) {
 										<a href="discord://discordapp.com/channels/@coop.OverflowGuildId/@coop.DiscordChannelId/"><img src="/images/discordicon.png" style="max-height: 1em;" /></a>
@@ -174,7 +178,7 @@
 								<td>
 									@if (!string.IsNullOrEmpty(farm.CoopId) || (contract?.MaxUsers ?? 0) > 1) {
 										<a href="/coop/@farm.ContractId/@(farm.CoopId)">
-											@(farm.CoopId)
+											@(LimitToThirty(farm.CoopId))
 										</a>
 									} else {
 										<em>Solo</em>

--- a/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
@@ -489,11 +489,11 @@
                         style="stroke-dasharray: @circumfrence @circumfrence; stroke-dashoffset: @initialOffset;"/>
                         <circle class="ship-progress-anti-ring" id="ship-antiring-@index-@shipIndex" stroke-width="@strokeWidth" stroke="gray" fill="transparent" r="@radius" cx="@baseSize" cy="@baseSize"
                         style="stroke-dasharray: @circumfrence @circumfrence; stroke-dashoffset: @initialAntiOffset;" />
-                        <image alt="@mission.Ship.ToString().Replace("_", " ")" x="@imageOffsets" y="@imageOffsets" width="@shipImageSize" height="@shipImageSize" xlink:href="@shipEmojiLink" />
+                        <image alt="@MissionHelpers.GetProperShipName(mission.Ship)" x="@imageOffsets" y="@imageOffsets" width="@shipImageSize" height="@shipImageSize" xlink:href="@shipEmojiLink" />
                     </svg><br/>
                 }
                 <span style="font-size: 1.1rem; color: @durationColor(mission.Duration);">@mission.Duration.ToString().Replace("Epic", "Extended").Replace("Long","Standard")</span><br>
-                @mission.Ship.ToString().Replace("_", " ")<br>
+                @MissionHelpers.GetProperShipName(mission.Ship)<br>
                 <span id="ship-progress-stars-@index-@shipIndex" style="font-size: 1.2rem;">
                     @for (var i = 0; i < MissionHelpers.MaxShipLevels[mission.Ship]; i++) {
                         <span class="ShipCardStar @((i < mission.Stars) ? "GoldenStar" : "GrayStar")">★</span>

--- a/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
@@ -4,6 +4,7 @@
 @using System.Text;
 @using static EGG9000.Common.Coops.ArtifactCombos;
 @using static Ei.MissionInfo.Types;
+@using static EGG9000.Common.Helpers.MissionHelpers;
 @inject DiscordSocketClient DiscordClient
 @model (int Index, CustomBackup Backup,  List<Coop> JoinedCoops, List<Contract> Contracts)
 
@@ -753,8 +754,8 @@
                                             @if (!alreadyMaxed){
                                                 <span class="blue-text" id="@ship.Key-time-needed-asc-@index"
                                                       data-short="@shortsTimeMax" data-standard="@standardsTimeMax" data-extended="@extendedsTimeMax"
-                                                      dt-short="@Model.Backup.MinutesToString(shortsTimeMax)" dt-standard="@Model.Backup.MinutesToString(standardsTimeMax)" dt-extended="@Model.Backup.MinutesToString(extendedsTimeMax)">
-                                                    @Model.Backup.MinutesToString(shortsTimeMax)
+                                              dt-short="@MissionHelpers.MinutesToString(shortsTimeMax)" dt-standard="@MissionHelpers.MinutesToString(standardsTimeMax)" dt-extended="@MissionHelpers.MinutesToString(extendedsTimeMax)">
+                                            @MissionHelpers.MinutesToString(shortsTimeMax)
                                                 </span>
                                     }
                                         </td>

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -30,6 +30,11 @@
     string emojiDelegage(Match match) {
         return $"<img src='https://cdn.discordapp.com/emojis/{match.Groups[1]}.png?size=22' />";
     };
+
+    string accountName(EggIncAccount account){
+        return account.Backup?.UserName ?? account.Id.toString();
+    }
+
     var inDB = Model.User.DiscordId > 0;
 
 }
@@ -189,7 +194,7 @@
                 <div>
                     <img style="max-height: 30px;" src="/images/Egg_@((int)xref.Coop.Contract.Details.Egg).png" />
                     @if(Model.User.EggIncAccounts.Count > 1) {
-                        <span>@xref.Coop.Contract.Name - @xref.Coop.Name ( @Model.User.EggIncAccounts.FirstOrDefault(a => a.Id == xref.EggIncId)?.Backup.UserName ?? @xref.EggIncId )</span>
+                        <span>@xref.Coop.Contract.Name - @xref.Coop.Name ( @accountName(Model.User.EggIncAccounts.FirstOrDefault(a => a.Id == xref.EggIncId)) )</span>
                     } else {
                         <span>@xref.Coop.Contract.Name - @xref.Coop.Name</span>
                     }

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -32,7 +32,7 @@
     };
 
     string accountName(EggIncAccount account){
-        return account.Backup?.UserName ?? account.Id.toString();
+        return account.Backup?.UserName ?? account.Id;
     }
 
     var inDB = Model.User.DiscordId > 0;

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -425,9 +425,6 @@
                                                 }
                                             </table>
                                         </div>
-
-
-
                                     }
                                 </div>
                                 <div class="col-sm">


### PR DESCRIPTION
- Add custom stige message for Hocho
- Re-write constants declared in `MissionHelpers` to pull data from `eiafx_config` instead
- Enum mapped `ship` and `durationType` strings to their respective types in `eiafx_config.cs`
- Fixed searching by EID and Username on the site search
- Fixed an issue where 0-star ships would incorrectly report "0 ships to level up"
- Fixed the same issue, where 0-star ships would always report 0% to next level
- Removed some custom code in favor of using `TimeSpan`
- Fixed a bad null-check in `/FindCoopForUser` that was leading to always "No coop spot founds"
- Update MyFarms and Ship Return DMs to use "proper"/display names of ships instead of parsed proto names
- Update `/ViewInventory` to pull a fresh artifact hall before running logic, add null check for backup and artifact hall
- Added customize server option to disable adding co-ops from backups
- Added field to coops to differentiate which were added from backups
- Change `/AddCoop` to be FH+ instead of Admin
- Add an explicit "no" during OrganizeCoops logic for users with redo leggacy set to No
- Limit coop codes to 30 characters on MyFarms
- Add Inventory Embed (same as `/ViewInventory`) to Artifact Cheater message
- Fix timer on 50x earnings boost to be 2 hours
- Add contextual code to deal with users that join and have been in the server before, are disabled, etc, instead of relying on next `LeaderboardUpdater` run
- Edit `/AddCoop` to use AutoCompleters, and add AnyGrade as an option - simplify some of the logic
- Edit the counts on the admin page to include Category Count, and not care about case in looking for `coops` text