### PR TITLE
Daveed changes

### DIFF
--- a/EGG9000.Bot/Automated/Coops/CoopDeleteChannel.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopDeleteChannel.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -34,11 +35,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     coop.DeletedChannel = true;
                     _logger.LogWarning("Unable to find co-op channel for {coopName}", coop.Name);
                 }
-                try {
-                    await _db.SaveChangesAsync(CancellationToken.None);
-                } catch(Exception) {
-                    await _db.SaveChangesAsync(CancellationToken.None);
-                }
+                await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
             }
         }
     }

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -601,27 +601,13 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(!coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = true;
                         await coopChannel.SendMessageAsync($"Coop {coop.Name} is now projected to finish!");
-                        try {
-                            await _db.SaveChangesAsync(CancellationToken.None);
-                        } catch(Exception) {
-                            await Task.Delay(100, cancellationToken);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) { }
-                        }
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = false;
                         await coopChannel.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish.");
-                        try {
-                            await _db.SaveChangesAsync(CancellationToken.None);
-                        } catch(Exception) {
-                            await Task.Delay(100, cancellationToken);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) { }
-                        }
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
 
@@ -654,14 +640,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         coop.Finished = true;
                         coop.Status = CoopStatusEnum.Completed;
                         finalChannelUpdate = true;
-                        try {
-                            await _db.SaveChangesAsync(CancellationToken.None);
-                        } catch(Exception) {
-                            await Task.Delay(100, cancellationToken);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) { }
-                        }
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
                 }
 
@@ -1210,12 +1189,7 @@ namespace EGG9000.Bot.Automated.Coops {
                 }
 
 
-                try {
-                    await _db.SaveChangesAsync(CancellationToken.None);
-                } catch(Exception) {
-                    await _db.SaveChangesAsync(CancellationToken.None);
-                }
-
+                await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
 
                 var times = timings.Finished();
 
@@ -1224,12 +1198,6 @@ namespace EGG9000.Bot.Automated.Coops {
                 _logger.LogError(e, "Error in co-op {coopid}", coopName ?? coopid.ToString());
                 _bugsnag.Notify(e);
             }
-        }
-
-        public static int GetDigit(int number, int digit) {
-            for(var i = 0; i < digit - 1; i++)
-                number /= 10;
-            return number % 10;
         }
 
         public async Task HandleSleeping(UserFarmDetails user, ITextChannel coopChannel, Coop coop, ApplicationDbContext _db, Guild dbguild) {

--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -5,6 +5,7 @@ using Discord.WebSocket;
 using EGG9000.Common.Contracts;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
 
 using MassTransit.Initializers;
@@ -81,11 +82,7 @@ namespace EGG9000.Bot.Automated.Coops {
                             coop.ThreadParentChannel = parent.Id;
                             coop.OverflowGuildId = parent.Guild.Id;
                             _logger.LogInformation("Thread created for {coopName}", coop.Name);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            }
+                            await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                         } else {
                             _logger.LogWarning("Thread NOT created for {coopName}", coop.Name);
                         }
@@ -166,7 +163,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     }
                     if(ultraProRole != null) ultraRoles.Add(ultraProRole);
 
-                    headerChannel = await server.Guild.CreateCoopThreadHeaderAsync(gradeRole, ultraRoles, contractEmbed, category.DiscordCategory, coop);
+                    headerChannel = await server.Guild.CreateCoopThreadHeaderAsync(gradeRole, ultraRoles, contractEmbed, category.DiscordCategory, coop, _logger);
                 }
                 if(headerChannel == null) continue;
                 try {

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -865,7 +865,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 //Checking if users are gusset glitching
                 var afCheaterChannel = ChannelHelper.DetermineChannelType(dbguild, guild, GuildChannelType.CheaterThread);
-                if(afCheaterChannel != null) {
+                if(afCheaterChannel != null && !status.AllGoalsAchieved) {
                     var contractScalar = coop.Contract.Details?.GradeSpecs[((int)coop.League) - 1]?.Modifiers?.FirstOrDefault(m => m.Dimension == Ei.GameModifier.Types.GameDimension.HabCapacity)?.Value ?? 1;
                     foreach(var u in usersWithStatus.Where(x => x.Xref is not null && !x.Xref.GussetCheatDetected)) {
                         var farm = u.Backup.Farms.FirstOrDefault(x => x.CoopId is not null && x.CoopId.ToLower() == coop.Name.ToLower());

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -611,27 +611,13 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(!coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = true;
                         await coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!");
-                        try {
-                            await _db.SaveChangesAsync(CancellationToken.None);
-                        } catch(Exception) {
-                            await Task.Delay(100, cancellationToken);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) { }
-                        }
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = false;
                         await coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish.");
-                        try {
-                            await _db.SaveChangesAsync(CancellationToken.None);
-                        } catch(Exception) {
-                            await Task.Delay(100, cancellationToken);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) { }
-                        }
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(!coop.Finished && status.Finished()) {
@@ -655,14 +641,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         finalChannelUpdate = true;
                         coop.Status = CoopStatusEnum.CompletedAllCheckIn;
                         coop.ThreadArchived = true;
-                        try {
-                            await _db.SaveChangesAsync(CancellationToken.None);
-                        } catch(Exception) {
-                            await Task.Delay(100, cancellationToken);
-                            try {
-                                await _db.SaveChangesAsync(CancellationToken.None);
-                            } catch(Exception) { }
-                        }
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
                 }
 

--- a/EGG9000.Bot/Automated/NewContracts.cs
+++ b/EGG9000.Bot/Automated/NewContracts.cs
@@ -109,12 +109,7 @@ namespace EGG9000.Bot.Automated {
                 }
             }
 
-
-            try {
-                await _db.SaveChangesAsync(CancellationToken.None);
-            } catch(Exception) {
-                await _db.SaveChangesAsync(CancellationToken.None);
-            }
+            await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
 
             if(needsUpdate)
                 ContractUpdater.ResetTimeStatic();

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -687,8 +687,8 @@ namespace EGG9000.Bot.Commands {
             var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
             await dbGuild.DeleteCoopThreadHeadersAsync(_client, guildContract.Contract);
 
-            //guildContract.DeletedChannel = true;
-            //await db.SaveChangesAsync();
+            guildContract.DeletedChannel = true;
+            await db.SaveChangesAsync();
             var channel = (SocketTextChannel)command.Channel;
             await channel.DeleteAsync();
         }

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -27,6 +27,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 using static EGG9000.Common.Helpers.Prefarm;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory;
 
 namespace EGG9000.Bot.Commands {
     public static class RegisterCommandsSlash {
@@ -503,25 +504,42 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Get a users status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, [SlashParam] SocketUser user, [SlashParam(Required = false)] bool ShowInChannel = false) {
-            return _userstatus(command, db, _client, apiLink, user, true, ShowInChannel);
+        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, [SlashParam] SocketUser user, [SlashParam(Required = false)] bool showinchannel = false, 
+            [SlashParam(Required = false, Description = "Pull a fresh backup for all accounts of this user before reporting their status")] bool pullfreshbackup = false ) {
+            return _userstatus(command, db, _client, apiLink, user, true, showinchannel, pullfreshbackup);
         }
 
         [SlashCommand(Description = "Get your status", AllowInDMs = true)]
         public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink) {
-            return _userstatus(command, db, _client, apiLink, command.User, false, false);
+            return _userstatus(command, db, _client, apiLink, command.User);
         }
-        public static async Task _userstatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, IUser user, bool admin = false, bool showInChannel = false) {
+        public static async Task _userstatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, APILink apiLink, IUser user, bool admin = false, bool showInChannel = false, bool pullFreshBackup = false) {
             await command.DeferAsync(ephemeral: !showInChannel);
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"); });
                 return;
             }
-
             if(dbuser.EggIncAccounts == null || dbuser.EggIncAccounts.Count == 0) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"No registered accounts found for <@{user.Id}>"); });
                 return;
+            }
+
+            //Pull a fresh backup before userstatus
+            if(pullFreshBackup) {
+                foreach(var account in dbuser.EggIncAccounts) {
+                    var rawBackup = await ContractsAPI.FirstContact(account.Id);
+                    if(rawBackup is null || rawBackup.Backup is null) {
+                        await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Backup for account `{account?.Backup?.UserName ?? account.Id}` returned as null from the API"); });
+                        return;
+                    }
+                    var customBackup = new CustomBackup(rawBackup.Backup, account?.Backup ?? null);
+                    if(customBackup?.Farms is not null) {
+                        account.Backup = customBackup;
+                    }
+                }
+                dbuser.UpdateAccounts();
+                await db.SaveChangesAsync();
             }
 
             var guild = await db.Guilds.FirstOrDefaultAsync(x => x.Id == dbuser.GuildId);

--- a/EGG9000.Bot/Program.cs
+++ b/EGG9000.Bot/Program.cs
@@ -101,12 +101,12 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
 
             services.AddHostedService<StaffCoopsMessage>();
             services.AddHostedService<EventUpdater>();
-            //services.AddHostedService<CoopReorder>();
+            services.AddHostedService<CoopReorder>();
             services.AddHostedService<CoopDeleteChannel>();
 
-            //services.Configure<UpdaterOptions<CoopStatusUpdater>>(x => x.DelayStart = TimeSpan.FromMinutes(5));
-            //services.AddSingleton<CoopStatusUpdater>();
-            //services.AddHostedService(provider => provider.GetService<CoopStatusUpdater>());
+            services.Configure<UpdaterOptions<CoopStatusUpdater>>(x => x.DelayStart = TimeSpan.FromMinutes(5));
+            services.AddSingleton<CoopStatusUpdater>();
+            services.AddHostedService(provider => provider.GetService<CoopStatusUpdater>());
 
             services.Configure<UpdaterOptions<ThreadsCoopStatusUpdater>>(x => x.DelayStart = TimeSpan.FromMinutes(5));
             services.AddSingleton<ThreadsCoopStatusUpdater>();

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -51,8 +51,10 @@ namespace EGG9000.Common.Services {
             var db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var guildContract = await db.GuildContracts.FirstOrDefaultAsync(x => x.DiscordChannelId == arg.Id);
             if(guildContract is not null) {
+                var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
+                await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract);
                 guildContract.DeletedChannel = true;
-                await db.SaveChangesAsync();
+                return;
             }
             var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id || x.DiscordChannelId == arg.Id);
             if(coop is not null && coop.ThreadID != 0) {
@@ -62,7 +64,6 @@ namespace EGG9000.Common.Services {
                 coop.DeletedChannel = true;
                 await db.SaveChangesAsync();
             }
-
         }
 
         public Task StopAsync(CancellationToken cancellationToken) {

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -1,8 +1,10 @@
 ﻿
 using Discord;
 using Discord.WebSocket;
+using EGG9000.Bot;
 using EGG9000.Bot.Commands;
 using EGG9000.Bot.Common.Helpers;
+using EGG9000.Bot.EggIncAPI;
 using EGG9000.Bot.Helpers;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
@@ -13,8 +15,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 
 namespace EGG9000.Common.Services {
 
@@ -129,31 +133,31 @@ namespace EGG9000.Common.Services {
                 return;
             }
 
-            
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
-            if(dbuser is not null && dbuser.TempDisabled) {
-                var welChannel = await _discord.GetChannelAsync(GuildChannelType.Welcome, user.Guild);
-                var disabledMsg = $"Welcome to the server {user.Mention}! Looks like you are currently disabled, please wait for someone from staff to get you re-enabled.";
-                await welChannel.SendMessageAsync(disabledMsg);
-                await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(user.Guild.Id), GuildChannelType.BannedUserThread, new() { Text = $"{user.Mention} just joined and is disabled." }, _logger);
-            }
-
-            if(dbuser != null && dbuser.GuildId == user.Guild.Id) {
-                await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, []);
-                var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!" }, _logger);
-                await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
-                return;
-            } else if(dbuser is not null && dbuser.GuildId == 0) {
-                var previouslyHere = await db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.GuildId == user.Guild.Id);
-                if(previouslyHere) {
-                    dbuser.GuildId = user.Guild.Id;
-                    dbuser.UpdateAccounts();
-                    await db.SaveChangesAsync();
-                    await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, []);
-                    var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!" }, _logger);
-                    await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
+            if(dbuser is not null) {
+                if(dbuser.TempDisabled) {
+                    var disabledMsg = $"Welcome to the server {user.Mention}! Looks like you have previously been `/disable`-d, please wait for someone from staff to reach out to discuss this.";
+                    await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(user.Guild.Id), GuildChannelType.Welcome, new() { Text = disabledMsg }, _logger);
+                    await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(user.Guild.Id), GuildChannelType.BannedUserThread, new() { Text = $"{user.Mention} just joined and is disabled." }, _logger);
                     return;
                 }
+                dbuser.EggIncAccounts.ForEach(async account => {
+                    var rawBackup = await ContractsAPI.FirstContact(account.Id);
+                    if(rawBackup is null || rawBackup.Backup is null) return;
+                    var customBackup = new CustomBackup(rawBackup.Backup, account?.Backup ?? null);
+                    account.Backup = customBackup?.Farms is not null ? customBackup : account.Backup;
+                });
+                if(dbuser.GuildId == 0 && await db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.GuildId == user.Guild.Id)) {
+                    dbuser.GuildId = user.Guild.Id;
+                }
+                dbuser.UpdateAccounts();
+                await db.SaveChangesAsync();
+                var earningsBonus = dbuser.EggIncAccounts.Max(x => x.Backup.EarningsBonus);
+                var role = await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, []);
+                var roleText = role is not null ? $" You have been assigned the rank of {role?.Name} thanks to your EB of {earningsBonus.ToEggString()}" : "";
+                var response = await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(dbuser.GuildId), GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!{roleText}" }, _logger);
+                await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
+                return;
             }
 
             if(_debug) return;

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -54,6 +54,7 @@ namespace EGG9000.Common.Services {
                 var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
                 await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract);
                 guildContract.DeletedChannel = true;
+                await db.SaveChangesAsync();
                 return;
             }
             var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id || x.DiscordChannelId == arg.Id);

--- a/EGG9000.Common/Helpers/DBHelpers.cs
+++ b/EGG9000.Common/Helpers/DBHelpers.cs
@@ -1,0 +1,22 @@
+﻿using EGG9000.Common.Database;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Helpers {
+    public static class DBHelpers {
+
+        public static async Task<(bool, int)> SaveChangesAsyncRetry(this ApplicationDbContext db, int retryCount = 1, CancellationToken cancellationToken = default) {
+            var currentRetry = 0;
+            while(true) {
+                try {
+                    return (true, await db.SaveChangesAsync(cancellationToken));
+                } catch(Exception) {
+                    if(currentRetry >= retryCount) return (false, currentRetry);
+                    currentRetry++;
+                }
+            }
+        }
+
+    }
+}

--- a/EGG9000.Common/Helpers/DBHelpers.cs
+++ b/EGG9000.Common/Helpers/DBHelpers.cs
@@ -12,6 +12,9 @@ namespace EGG9000.Common.Helpers {
                 try {
                     return (true, await db.SaveChangesAsync(cancellationToken));
                 } catch(Exception) {
+                    //Slight delay between attempts
+                    await Task.Delay(100, cancellationToken);
+                    //If we reached max retry count, exit
                     if(currentRetry >= retryCount) return (false, currentRetry);
                     currentRetry++;
                 }

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -4,6 +4,7 @@ using Discord.WebSocket;
 using EGG9000.Common.Contracts;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using Humanizer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -31,7 +32,7 @@ namespace EGG9000.Common.Services {
                              GatewayIntents.GuildMessageReactions | GatewayIntents.DirectMessages | GatewayIntents.MessageContent
         };
         private static readonly List<DiscordSemahpore> _serverSemaphores = [];
-        private static readonly TimeSpan _semaphoreTimeoutTime = TimeSpan.FromMinutes(3);
+        private static readonly TimeSpan _semaphoreTimeoutTime = TimeSpan.FromMinutes(1);
         public DiscordHostedService(Microsoft.Extensions.Configuration.IConfiguration Configuration, IMemoryCache cache, IServiceProvider provider, ILogger<DiscordHostedService> logger) : base(config) {
             _configuration = Configuration;
             _provider = provider;
@@ -241,21 +242,36 @@ namespace EGG9000.Common.Services {
             return guild.GetInUseThreads(parentChannel).Count;
         }
 
-        public static async Task<SocketGuildChannel> CreateCoopThreadHeaderAsync(this SocketGuild guild, SocketRole leagueRole, List<SocketRole> ultraRoles, Embed contractEmbed, SocketGuildChannel category, Coop coop) {
+        public static async Task<SocketGuildChannel> CreateCoopThreadHeaderAsync(this SocketGuild guild, SocketRole leagueRole, List<SocketRole> ultraRoles, Embed contractEmbed, SocketGuildChannel category, Coop coop, ILogger logger) {
             if(category is null || category.Id  == 0) return null;
 
             var name = $"{coop.Contract.GetE9KName()}-{PlayerGradeDetails.GetNameFromLeague(coop.League).ToLower()}";
-
-            //Catch possible dupes before they happen
-            Thread.Sleep(1000);
-
             if(guild.Channels.Any(c => c.Name == name)) return guild.Channels.First(c => c.Name == name);
-            
+
+            //Wait on the Server's lock, timeout defined in DiscordHostedService
+            logger.LogInformation("CreateCoopThreadHeaderAsync: Waiting on Semaphore lock for guild {guild}", guild.Name);
+            var dtNow = DateTimeOffset.Now;
+            var ownershipAcquired = await guild.GetServerSemaphore().WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), CancellationToken.None);
+            if(ownershipAcquired) {
+                logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.Now.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
+            } else {
+                logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} timed out after after {unlockTime} minutes.", guild.Name, DiscordHostedService.GetSemaphoreTimeout().TotalMinutes);
+            }
+
+            //Check again
+            if(guild.Channels.Any(c => c.Name == name)) {
+                if(ownershipAcquired) guild.GetServerSemaphore().Release();
+                return guild.Channels.First(c => c.Name == name);
+            }
+
             var channel = await guild.CreateTextChannelAsync(
                 name,
                 p => {p.CategoryId = category.Id;}
             );
-            if(channel is null) return null;
+            if(channel is null) {
+                if(ownershipAcquired) guild.GetServerSemaphore().Release();
+                return null;
+            }
             await channel.SendMessageAsync(text: "", embed: contractEmbed);
 
             if(coop.Contract.cc_only && ultraRoles.Count > 0) {
@@ -278,6 +294,7 @@ namespace EGG9000.Common.Services {
                 );
             }
 
+            if(ownershipAcquired) guild.GetServerSemaphore().Release();
             return guild.GetChannel(channel.Id);
         }
 

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -313,7 +313,7 @@ namespace EGG9000.Common.Services {
         }
 
         public static string GetE9KName(this Contract contract, bool toLower = true) {
-            return (toLower ? contract.Name.ToLower() : contract.Name).Split(":").Last().Trim().Replace(" ", "-");
+            return Regex.Replace((toLower ? contract.Name.ToLower() : contract.Name).Split(":").Last().Trim().Replace(" ", "-"), "[^a-zA-Z0-9-]", "");
         }
 
         public static async Task<SocketTextChannel> GetParentChannelAsync(this IThreadChannel threadChannel) {

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -143,6 +143,23 @@ namespace EGG9000.Site.Controllers {
         }
 
 
+        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin")]
+        public async Task<ActionResult> LatestDemerits() {
+            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+            var dbguild = await _db.Guilds.FirstAsync(x => x.Id == guildId);
+            var demerits = await _db.Demerit.AsQueryable().Include(d => d.User).Where(d => d.User.GuildId == guildId).ToListAsync();
+
+            return View((demerits, dbguild.Name));
+        }
+
+        [Authorize(Roles = "Admin,GuildAdmin")]
+        public async Task<IActionResult> RemoveDemerit([FromQuery] Guid id) {
+            var demerit = _db.Demerit.FirstOrDefault(x => x.Id == id);
+            _db.Remove(demerit);
+            await _db.SaveChangesAsync();
+            return Redirect(Request.Headers["Referer"].ToString());
+        }
+
         public async Task<IActionResult> LookForLargeJump() {
             var snapshots = await _db.UserSnapShots.ToListAsync();
 

--- a/EGG9000.Site/Views/Admin/Index.cshtml
+++ b/EGG9000.Site/Views/Admin/Index.cshtml
@@ -21,6 +21,7 @@
 <a href="/admin/standardpermit" class="btn btn-primary">Standard Permits</a>
 <a href="/admin/inactiveplayers" class="btn btn-primary">Inactive Players</a>
 <a href="/admin/automatedtasks" class="btn btn-primary">Automated Tasks</a>
+<a href="/admin/latestdemerits" class="btn btn-primary">Latest Demerits</a>
 
 <div class="clearfix">
 	<div class="float-left card">

--- a/EGG9000.Site/Views/Admin/LatestDemerits.cshtml
+++ b/EGG9000.Site/Views/Admin/LatestDemerits.cshtml
@@ -1,0 +1,52 @@
+﻿@model (List<Demerit> Demerits, string GuildName)
+@{
+    ViewData["Title"] = "Latest Demerits";
+
+    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
+
+    var emojiReplace = new Regex(@"<:[^:]+:(\d+)>");
+    string emojiDelegage(Match match)
+    {
+        return $"<img src='https://cdn.discordapp.com/emojis/{match.Groups[1]}.png?size=22' />";
+    };
+}
+
+<table class="table table-striped">
+    <caption style="caption-side: top; text-align: center; font-weight: bold;">Latest Demerits for @Model.GuildName</caption>
+    <thead>
+        <tr>
+            <th class="text-left">Date</th>
+            <th>User</th>
+            <th>Reason</th>
+            @if (isAdmin)
+            {
+                <th></th>
+            }
+        </tr>
+    </thead>
+    @if (Model.Demerits.Count > 0)
+    {
+        <tbody>
+            @foreach (var demerit in Model.Demerits.OrderByDescending(x => x.When))
+            {
+                <tr class="@(demerit.When < DateTimeOffset.Now.AddMonths(-1) && !demerit.Permanent ? "Expired" : "")">
+                    <td style="white-space: nowrap">@demerit.When.ToString("yyyy-MM-dd HH:mm")</td>
+                    <td>@(demerit.User.DiscordUsername)</td>
+                    <td> @Html.Raw(emojiReplace.Replace(demerit.Reason, emojiDelegage))</td>
+                    @if (isAdmin)
+                    {
+                        <td><a href="/admin/removedemerit?id=@demerit.Id" title="Remove Demerit">X</a></td>
+                    }
+                </tr>
+            }
+        </tbody>
+    }
+    else
+    {
+        <tbody>
+            <tr style="padding: 20px; margin-top:20px; text-align: center">
+                <td colspan="@(isAdmin ? "4" : "3")">No recent demerits.</td>
+            </tr>
+        </tbody>
+    }
+</table>


### PR DESCRIPTION
- Add page to see latest Demerits for admins
- Fix messages sent when a disabled user joins the server
- Change from a static 1000ms delay during header channel creation to semaphore locking
- Add a flag to pull a fresh backup in `/a userstatus`
- Add a helper method to `ApplicationDBContext` to allow for one-method retrying X times
- Change gusset cheat detection to not apply during yellow-scroll (incorrectly detecting cheaters)