### PR TITLE
DaveedChanges

### DIFF
--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -198,7 +198,7 @@ namespace EGG9000.Bot.Automated.Coops {
             public int ThreadsLeft {
                 get {
                     if(Guild == null) return 0;
-                    return (ServerFunction == ServerFunction.Primary ? 900 : 995) - Guild.GetInUseThreadCount();
+                    return (ServerFunction == ServerFunction.Primary ? 975 : 995) - Guild.GetInUseThreadCount();
                 }
             }
 

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -88,7 +88,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         try {
                             var sw = new Stopwatch();
                             sw.Start();
-                            await ProcessCoop(coop.Id, guild, users, dbguild, cancellationToken, slashCommands);
+                            await ProcessCoop(coop.Id, guild, users, dbguild, slashCommands, cancellationToken);
                             sw.Stop();
                             var completed = Interlocked.Increment(ref completedCoops);
                             _logger.LogInformation("Finished processing {coopName}, Time: {time} ({completed} of {total})", coop.Name, sw.Elapsed.Humanize(), completed, totalCoops);
@@ -366,7 +366,7 @@ namespace EGG9000.Bot.Automated.Coops {
             };
         }
 
-        public async Task ProcessCoop(Guid coopid, SocketGuild guild, List<UserWithBackup> users, Guild dbguild, CancellationToken cancellationToken, List<SocketApplicationCommand> slashCommands) {
+        public async Task ProcessCoop(Guid coopid, SocketGuild guild, List<UserWithBackup> users, Guild dbguild, List<SocketApplicationCommand> slashCommands, CancellationToken cancellationToken) {
             var timings = new TimingsFactory(null);
             timings.Start();
             string coopName = null;
@@ -392,15 +392,11 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(coopHeaderChannel != null) {
                             coopThread = (await coopHeaderChannel.GetActiveThreadsAsync()).FirstOrDefault(t => t.Id == coop.ThreadID);
                         }
-                    } catch(Exception) {
-                    }
+                    } catch(Exception) {}
                 }
 
                 if(coopThread == null) {
                     _logger.LogWarning("ERROR FINDING THREAD FOR CO-OP: {coopName}", coop.Name);
-                    Console.WriteLine($"Setting thread ID to 0 for {coop.Name}");
-                    coop.ThreadID = 0;
-                    await _db.SaveChangesAsync(CancellationToken.None);
                     return;
                 }
 
@@ -722,7 +718,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                 }
                             });
                         coop.RolesAddedToThread = true;
-                        await _db.SaveChangesAsyncRetry(1);
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     } catch(Exception) {
                         _logger.LogInformation("Failed to compile role pings for {coop}", coopName);
                     }
@@ -1220,17 +1216,12 @@ namespace EGG9000.Bot.Automated.Coops {
                     await UpdateChannel(msgs, embedBuilder.Build(), coopThread, coop, statusReponse.DiscordMessages);
                 }
 
-
-                try {
-                    await _db.SaveChangesAsync(CancellationToken.None);
-                } catch(Exception) {
-                    await _db.SaveChangesAsync(CancellationToken.None);
-                }
+                await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
 
 
                 var times = timings.Finished();
 
-                _logger.LogTrace("Co-op timings {timings} - {coop}", String.Join(",", times.Select(x => $"{x.name}:{x.time.Humanize().ShortenTime()}")), coop.Name);
+                _logger.LogTrace("Co-op timings {timings} - {coop}", string.Join(",", times.Select(x => $"{x.name}:{x.time.Humanize().ShortenTime()}")), coop.Name);
             } catch(Exception e) {
                 _logger.LogError(e, "Error in co-op {coopid}", coopName ?? coopid.ToString());
                 _bugsnag.Notify(e);

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -59,9 +59,7 @@ namespace EGG9000.Bot.Automated.Coops {
 #endif
 
 
-            var totalCoops = coops.Count();
             var completedCoops = 0;
-
             var throttler = new SemaphoreSlim(5);
             var guildCoopGroups = coops.GroupBy(x => x.OverflowGuildId > 0 ? x.OverflowGuildId : x.GuildId).OrderBy(x => x.Count());
             foreach(var guildCoops in guildCoopGroups) {
@@ -91,7 +89,7 @@ namespace EGG9000.Bot.Automated.Coops {
                             await ProcessCoop(coop.Id, guild, users, dbguild, slashCommands, cancellationToken);
                             sw.Stop();
                             var completed = Interlocked.Increment(ref completedCoops);
-                            _logger.LogInformation("Finished processing {coopName}, Time: {time} ({completed} of {total})", coop.Name, sw.Elapsed.Humanize(), completed, totalCoops);
+                            _logger.LogInformation("Finished processing {coopName}, Time: {time} ({completed} of {total})", coop.Name, sw.Elapsed.Humanize(), completed, coops.Count);
                         } finally {
                             throttler.Release();
                         }

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -110,26 +110,6 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
 
         #region ContractAutoCompletes
         /*
-        *  Currently un-used. If we open up `/findcoopforuser` to users in the future, this is what we should use.
-        *  Was previously being used in `/findcoopforuser` as the staff only command, but was limiting the staff
-        *  that could move users to ultra coops to "staff who have ultra"
-        */
-        public class ContractAutoComplete(ApplicationDbContext db) : IAutoCompleteHandler {
-            private readonly ApplicationDbContext _db = db;
-
-            public async Task Run(SocketAutocompleteInteraction arg) {
-                var dbUser = _db.DBUsers.FirstOrDefault(x => x.DiscordId == arg.User.Id);
-                var hasSubscriptionAccounts = dbUser.EggIncAccounts.Where(x => x.HasActiveSubscription()).Any();
-
-                var contracts = await _db.Contracts.Where(x => hasSubscriptionAccounts ? (x.GoodUntil > DateTimeOffset.Now) : (x.GoodUntil > DateTimeOffset.Now && !x.cc_only)).Select(x => new { x.ID, x.Name }).ToListAsync();
-                var stringArg = (string)arg.Data.Current.Value;
-                if(!string.IsNullOrEmpty(stringArg) && stringArg != " ") contracts = contracts.Where(x => x.Name.Contains(stringArg) || x.ID.Contains(stringArg)).ToList(); //Filter by name
-
-                await arg.RespondAsync(null, contracts.DistinctBy(x => x.Name).ToList().Select(c => new AutocompleteResult(c.Name, c.ID)).ToArray());
-            }
-        }
-
-        /*
          *  Clone of ContractAutoComplete with no limitation on who can select Ultra coops
          */
         public class StaffContractAutoComplete(ApplicationDbContext db) : IAutoCompleteHandler {

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -118,7 +118,7 @@ namespace EGG9000.Bot.Commands {
                 var dbguild = await db.Guilds.AsQueryable().FirstAsync(x => x.Id == coop.GuildId);
                 if(coop.ThreadID != 0) {
                     var slashCommands = (await guild.GetApplicationCommandsAsync()).ToList().Where(c => c.Type == ApplicationCommandType.Slash).ToList();
-                    await coopStatusUpdaterThreads.ProcessCoop(coop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default, slashCommands);
+                    await coopStatusUpdaterThreads.ProcessCoop(coop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, slashCommands, default);
                 } else if(coop.DiscordChannelId != 0) {
                     await coopStatusUpdater.ProcessCoop(coop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default);
                 }
@@ -601,7 +601,7 @@ namespace EGG9000.Bot.Commands {
             var dbguild = await db.Guilds.AsQueryable().FirstAsync(x => x.Id == targetCoop.GuildId);
             if(targetCoop.ThreadID != 0) {
                 var slashCommands = (await guild.GetApplicationCommandsAsync()).ToList().Where(c => c.Type == ApplicationCommandType.Slash).ToList();
-                await coopStatusUpdaterThreads.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default, slashCommands);
+                await coopStatusUpdaterThreads.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, slashCommands, default);
             } else if(targetCoop.DiscordChannelId != 0) {
                 await coopStatusUpdater.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default);
             }

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -327,11 +327,9 @@ namespace EGG9000.Bot.Commands {
                 var userids = coop.UserCoopsXrefs.Select(x => x.UserId).ToList();
                 var users = await db.DBUsers.Where(x => userids.Contains(x.Id)).ToListAsync();
                 var usersWithBackups = users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Account = y, Backup = y.Backup, User = x })).ToList();
-                var details = new CoopDetails(coop, contract, (uint)account.GetGrade(), usersWithBackups, _client, coop.LastStatusUpdate);    
-                if(coop.ThreadID != 0 && (_client.GetGuild(coop.GuildId).GetThreadChannel(coop.ThreadID)?.IsLocked ?? true || (_client.GetGuild(coop.GuildId).GetThreadChannel(coop.ThreadID)?.IsArchived ?? true)))
-                    continue;
+                var details = new CoopDetails(coop, contract, (uint)account.GetGrade(), usersWithBackups, _client, coop.LastStatusUpdate);
 
-                if(coop.DiscordChannelId != 0 && (_client.GetGuild(coop.GuildId).GetTextChannel(coop.DiscordChannelId) == null || coop.DeletedChannel))
+                if(coop.ThreadID == 0 || coop.ThreadArchived)
                     continue;
               
                 if(details.HasSpots) {

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -208,7 +208,8 @@ namespace EGG9000.Bot.Commands {
 
 
             //Add the grade role before moving them, to give them access to the header channel (if applicable)
-            var discordUser = _client.Guilds.FirstOrDefault(g => g.Id == command.GuildId).GetUser(dbuser.DiscordId);
+            var currentGuild = _client.Guilds.FirstOrDefault(g => g.Id == command.GuildId);
+            var discordUser = currentGuild.GetUser(dbuser.DiscordId);
             var gradeRole = dbGuild.ChannelDetails.FirstOrDefault(x => x.ChannelType == newgrade switch {
                 1 => GuildChannelType.GradeC,
                 2 => GuildChannelType.GradeB,
@@ -218,6 +219,10 @@ namespace EGG9000.Bot.Commands {
                 _ => default
             });
             if(gradeRole != null) {
+                //Get the main guild
+                var mainGuild = _client.Guilds.FirstOrDefault(g => g.Id == dbGuild.DiscordSeverId);
+                var socketGradeRole = mainGuild.GetRole(gradeRole.Id);
+
                 //Fetch a new backup so they don't lose access to this channel when role update happens
                 var rawBackup = await ContractsAPI.FirstContact(account.Id);
                 var customBackup = new CustomBackup(rawBackup.Backup, account?.Backup ?? null);
@@ -231,7 +236,13 @@ namespace EGG9000.Bot.Commands {
                     account.Backup = customBackup;
                     dbuser.UpdateAccounts();
                 }
-                await discordUser.AddRoleAsync(gradeRole.Id);
+                await mainGuild.GetUser(dbuser.DiscordId).AddRoleAsync(socketGradeRole.Id);
+                if(mainGuild.Id != currentGuild.Id) {
+                    var currentGuildSocketRole = currentGuild.Roles.FirstOrDefault(r => r.Name == socketGradeRole.Name);
+                    if(currentGuildSocketRole != null) {
+                        await discordUser.AddRoleAsync(currentGuildSocketRole.Id);
+                    }
+                }
             }
 
             /* MOVING TO NEW COOP */

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -379,7 +379,7 @@ namespace EGG9000.Bot.Commands {
 
             var newxref = await CreateCoopsV2.MoveUser(newCoop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", discordUser, dbuser, (SocketThreadChannel)coopChannel, (SocketTextChannel)command.Channel);
             if(newxref == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to add permission for {discordUser.Mention}{(newCoop.GuildId != newCoop.OverflowGuildId ? ", possibly not in overflow server" : "")}"));
+                await command.RespondAsync(content: "", embed: EmbedError($"Unable to add permission for {discordUser.Mention}{(newCoop.GuildId != newCoop.OverflowGuildId ? ", possibly not in overflow server.\n**User was not moved to a coop.**" : "")}"));
                 return;
             }
             db.Add(newxref);

--- a/EGG9000.Bot/Commands/Informational/CraftCommand.cs
+++ b/EGG9000.Bot/Commands/Informational/CraftCommand.cs
@@ -6,6 +6,7 @@ using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Extensions;
 using EGG9000.Common.Helpers;
+using EGG9000.Common.JsonData.EiAfxConfig;
 using EGG9000.Common.JsonData.EiAfxData;
 using EGG9000.Common.Services;
 using Microsoft.EntityFrameworkCore;
@@ -79,19 +80,6 @@ namespace EGG9000.Bot.Commands {
             await component.UpdateAsync(x => { x.Components = null; x.Content = contentString; });
         }
 
-        private static readonly List<double> LevelMultipliers = [
-            1.00, 1.05, 1.10,
-            1.15, 1.20, 1.25,
-            1.30, 1.35, 1.40,
-            1.45, 1.50, 1.55,
-            1.60, 1.65, 1.70,
-            1.75, 1.85, 2.00,
-            2.25, 2.50, 3.00,
-            3.50, 4.00, 4.50,
-            5.00, 6.00, 7.00,
-            8.00, 9.00, 10.00
-        ];
-
         private static async Task<string> CraftStringBuilder(EggIncAccount account, int quantity, TierInput quality, ArtifactFamily requestedArtifact) {
             var stringBuilder = new StringBuilder();
             var backup = account.Backup;
@@ -128,7 +116,8 @@ namespace EGG9000.Bot.Commands {
             var goldenEggs = backup.GoldenEggsEarned - backup.GoldenEggsSpent;
             stringBuilder.Append(goldenEggs >= basket.GetTotalCost() ? "You have enough GE!" : "You do not have enough GE!");
 
-            var coefficientPair = BaseCraftingCoefficients.FirstOrDefault(a => a.Key.Artifact.ToLower() == requestedArtifact.name.ToLower() && a.Key.Tier == (int)quality);
+            var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
+            var coefficientPair = baseCraftingCoefficients.FirstOrDefault(a => a.Key.Artifact.ToLower() == requestedArtifact.name.ToLower() && a.Key.Tier == (int)quality);
             if(!coefficientPair.Equals(default(KeyValuePair<EggIncArtifactInstance, List<double>>))) {
                 var secondStringBuilder = new StringBuilder();
                 var keyAf = coefficientPair.Key;
@@ -150,17 +139,25 @@ namespace EGG9000.Bot.Commands {
                     var secondPercentageStrs = new List<string>();
 
                     var quantityCraftText = "";
-                    switch(quantity.ToString().Last()) {
-                        case '1': quantityCraftText = $"{quantity}st"; break;
-                        case '2': quantityCraftText = $"{quantity}nd"; break;
-                        case '3': quantityCraftText = $"{quantity}rd"; break;
-                        case '4':
-                        case '5':
-                        case '6':
-                        case '7':
-                        case '8':
-                        case '9':
-                        case '0': quantityCraftText = $"{quantity}th"; break;
+                    if(quantity >= 11 && quantity <= 13) {
+                        switch(quantity) {
+                            case 11: quantityCraftText = "11th"; break;
+                            case 12: quantityCraftText = "12th"; break;
+                            case 13: quantityCraftText = "13th"; break;
+                        }
+                    } else {
+                        switch(quantity.ToString().Last()) {
+                            case '1': quantityCraftText = $"{quantity}st"; break;
+                            case '2': quantityCraftText = $"{quantity}nd"; break;
+                            case '3': quantityCraftText = $"{quantity}rd"; break;
+                            case '4':
+                            case '5':
+                            case '6':
+                            case '7':
+                            case '8':
+                            case '9':
+                            case '0': quantityCraftText = $"{quantity}th"; break;
+                        }
                     }
 
                     if(secondPercentages[Rarity.Rare][0] > 0 || secondPercentages[Rarity.Epic][0] > 0 || secondPercentages[Rarity.Legendary][0] > 0) {
@@ -185,7 +182,7 @@ namespace EGG9000.Bot.Commands {
 
         private static Dictionary<Rarity, List<double>> GetCraftPercentages(uint numCrafted, uint craftingLevel, List<double> baseRates) {
             var numCraftedScalar = Math.Min(1.0, (double)(numCrafted / 400.0));
-            var craftingScalar = LevelMultipliers[(int)craftingLevel - 1];
+            var craftingScalar = Root.Get().craftingLevelMultipliers[(int)craftingLevel - 1];
 
             var baseRareRate = baseRates[0];
             var baseEpicRate = baseRates[1];

--- a/EGG9000.Bot/Commands/Informational/CraftCommand.cs
+++ b/EGG9000.Bot/Commands/Informational/CraftCommand.cs
@@ -14,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.ConstrainedExecution;
 using System.Text;
 using System.Threading.Tasks;
 using static EGG9000.Bot.Commands.DiscordEnums.AutoCompleteHandlers;
@@ -42,7 +43,8 @@ namespace EGG9000.Bot.Commands {
 
             if(dbUser.EggIncAccounts.Count == 1) {
                 await command.RespondAsync(
-                    await CraftStringBuilder(dbUser.EggIncAccounts.First(), quantity, quality, requestedArtifact)
+                    content: "",
+                    embeds: (await CraftStringBuilder(dbUser.EggIncAccounts.First(), quantity, quality, requestedArtifact)).ToArray()
                 );
             } else {
                 var builder = new ComponentBuilder();
@@ -74,13 +76,12 @@ namespace EGG9000.Bot.Commands {
             var quantity = int.Parse(dataObjs[2]);
             var requestedArtifact = EggIncArtifacts.GetEiAfxData().artifact_families.FirstOrDefault(x => x.id == dataObjs[3]);
 
-            var contentString = await CraftStringBuilder(account, quantity, quality, requestedArtifact);
-            //await component.UpdateAsync(x => { x.Components = null; x.Content = "Success"; });
-            //await component.Channel.SendMessageAsync(contentString);
-            await component.UpdateAsync(x => { x.Components = null; x.Content = contentString; });
+            var embeds = await CraftStringBuilder(account, quantity, quality, requestedArtifact);
+            await component.UpdateAsync(x => { x.Components = null; x.Content = ""; x.Embeds = embeds.ToArray(); });
         }
 
-        private static async Task<string> CraftStringBuilder(EggIncAccount account, int quantity, TierInput quality, ArtifactFamily requestedArtifact) {
+        private static async Task<List<Embed>> CraftStringBuilder(EggIncAccount account, int quantity, TierInput quality, ArtifactFamily requestedArtifact) {
+            var embeds = new List<Embed>();
             var stringBuilder = new StringBuilder();
             var backup = account.Backup;
             if(backup == null) {
@@ -94,27 +95,43 @@ namespace EGG9000.Bot.Commands {
             var crafter = new Crafter(backup.ArtifactHall);
             var basket = crafter.GetCraft(quantity, (int)quality, requestedArtifact.id);
 
-            stringBuilder.AppendFormat($"```{"Name",-20}{"Using",-8}{"Need",-8}{"Cost",-8}");
-            stringBuilder.AppendLine();
-            stringBuilder.Append("―――――――――――――――――――――――――――――――――――――――――――");
-            stringBuilder.AppendLine();
-
             var ingredients = from kvp in basket.GetIngredients()
                               orderby EggIncArtifacts.GetFamilyShorthand(kvp.Value.Tier.family) ascending, kvp.Value.Tier.tier_number descending
                               select kvp;
-            foreach(var ingredient in ingredients) {
-                stringBuilder.AppendFormat($"{$"T{ingredient.Value.Tier.tier_number} {EggIncArtifacts.GetFamilyShorthand(ingredient.Value.Tier.family)}",-20}");
-                stringBuilder.AppendFormat($"{ingredient.Value.Use.Format(),-8}");
-                stringBuilder.AppendFormat($"{ingredient.Value.GetNeed(),-8}");
-                stringBuilder.AppendFormat($"{ingredient.Value.Cost.Format(),-8}");
-                stringBuilder.AppendLine();
-            }
 
+            var longestIngredientLength = ingredients.Max(i => $"T{i.Value.Tier.tier_number} {EggIncArtifacts.GetFamilyShorthand(i.Value.Tier.family)}".Length) + 3;
+            stringBuilder.AppendLine($"```");
+            // Create headers with proper alignment and padding
+            stringBuilder.AppendFormat("{0,-" + longestIngredientLength + "}", "Name");
+            stringBuilder.AppendFormat("{0,-9}", "In Inv");
+            stringBuilder.AppendFormat("{0,-8}", "Need");
+            stringBuilder.AppendFormat("{0,-8}", "Cost");
+            stringBuilder.AppendLine(new string('―', longestIngredientLength + 22));
+
+            foreach(var ingredient in ingredients) {
+                // Build the formatted ingredient name
+                var formattedIngredient = $"T{ingredient.Value.Tier.tier_number} {EggIncArtifacts.GetFamilyShorthand(ingredient.Value.Tier.family)}";
+                stringBuilder.AppendFormat("{0,-" + longestIngredientLength + "}", formattedIngredient);
+                stringBuilder.AppendFormat("{0,-9}", ingredient.Value.Use.Format());
+                stringBuilder.AppendFormat("{0,-8}", ingredient.Value.GetNeed());
+                stringBuilder.AppendFormat("{0,-8}", ingredient.Value.Cost.Format());
+                stringBuilder.AppendLine(); // Add a new line after each ingredient
+            }
             stringBuilder.AppendLine("```");
-            stringBuilder.Append($"Total Cost: **{basket.GetTotalCost().ToString("#,0", new CultureInfo("en-US"))} GE**");
+            var ingredientEmbed = new EmbedBuilder()
+                .WithColor(Color.DarkGreen)
+                .WithDescription(stringBuilder.ToString())
+                .WithAuthor(new EmbedAuthorBuilder()
+                .WithName("Ingredients")
+                .WithIconUrl("https://cdn.discordapp.com/avatars/514257192803893272/47be266c55cab32eacfb33c9affc82dd.webp"))
+                .Build();
+            embeds.Add(ingredientEmbed);
+
+            stringBuilder = new();
+            stringBuilder.Append($"Total Cost: <:Golden_Egg_GE:692439755798872075> **{basket.GetTotalCost().ToString("#,0", new CultureInfo("en-US"))}**");
             stringBuilder.AppendLine();
             var goldenEggs = backup.GoldenEggsEarned - backup.GoldenEggsSpent;
-            stringBuilder.Append(goldenEggs >= basket.GetTotalCost() ? "You have enough GE!" : "You do not have enough GE!");
+            stringBuilder.Append(goldenEggs >= basket.GetTotalCost() ? "_You have enough <:Golden_Egg_GE:692439755798872075>!_" : "_You do not have enough <:Golden_Egg_GE:692439755798872075>!_");
 
             var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
             var coefficientPair = baseCraftingCoefficients.FirstOrDefault(a => a.Key.Artifact.ToLower() == requestedArtifact.name.ToLower() && a.Key.Tier == (int)quality);
@@ -168,16 +185,20 @@ namespace EGG9000.Bot.Commands {
                         secondStringBuilder.AppendLine(string.Join(" | ", secondPercentageStrs));
                     }
                 }
-
-                if(stringBuilder.Length + secondStringBuilder.Length < 2000) {
-                    stringBuilder.Append(secondStringBuilder);
-                } else {
-                    stringBuilder.AppendLine("\n**(Message too long to show rarity chances)**");
-                }
+                stringBuilder.Append(secondStringBuilder);
             }
 
+            var costAndOddsEmbed = new EmbedBuilder()
+                .WithColor(Color.DarkGreen)
+                .WithDescription(stringBuilder.ToString())
+                .WithAuthor(new EmbedAuthorBuilder()
+                .WithName("Cost & Odds")
+                .WithIconUrl("https://cdn.discordapp.com/avatars/514257192803893272/47be266c55cab32eacfb33c9affc82dd.webp"))
+                .Build();
+            embeds.Add(costAndOddsEmbed);
 
-            return stringBuilder.ToString();
+
+            return embeds;
         }
 
         private static Dictionary<Rarity, List<double>> GetCraftPercentages(uint numCrafted, uint craftingLevel, List<double> baseRates) {

--- a/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
@@ -1,4 +1,5 @@
-﻿using EGG9000.Bot.EggIncAPI;
+﻿using Discord;
+using EGG9000.Bot.EggIncAPI;
 using EGG9000.Bot.Helpers;
 using EGG9000.Common.Commands;
 using EGG9000.Common.Database;
@@ -7,8 +8,11 @@ using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
 using Ei;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -131,7 +135,7 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand(Description = "Calculate your Legendary Luck Coefficient (LLC)", ParentCommand = "formulae", AllowInDMs = true)]
-        public static async Task Llc(FauxCommand command, ApplicationDbContext db) {
+        public static async Task Llc(FauxCommand command, ApplicationDbContext db, IMemoryCache _cache, ILogger _logger) {
             await command.DeferAsync();
             var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(dbUser == null) {
@@ -149,7 +153,7 @@ namespace EGG9000.Bot.Commands {
                 if(dbUser.EggIncAccounts.Count > 1) {
                     sb.AppendLine($"\n**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})**");
                 }
-                await LLCCalculate(account, sb, dbUser.DiscordUsername);
+                await LLCCalculate(account, sb, dbUser.DiscordUsername, _cache, _logger);
             }
             
             await command.ModifyOriginalResponseAsync(x => x.Content = sb.ToString());
@@ -179,15 +183,35 @@ namespace EGG9000.Bot.Commands {
             return (resultLastType, resultSecondToLastType);
         }
 
+        [SlashCommand(Description="Testing")]
+        public static async Task GetCachedLLCCoeffs(FauxCommand command, IMemoryCache _cache, ILogger _logger) {
+            await command.DeferAsync();
+            var cachedCoeffs = await GetShipDataTable(_cache, _logger);
+            var coeffsString = "";
+            cachedCoeffs.ForEach(c => {
+                coeffsString += c.ship + " " + c.type + " [" + string.Join(", ", c.legendaryDropRates) + "]\n";
+            });
+            var bytes = Encoding.UTF8.GetBytes(coeffsString);
+            await command.RespondWithFileAsync(attachment: new FileAttachment(new MemoryStream(bytes), "Coefficients.txt"), text: "bruh");
+        }
+
         [ComponentCommand]
-        private static async Task LLCCalculate(EggIncAccount account, StringBuilder sb, string userName) {
+        private static async Task LLCCalculate(EggIncAccount account, StringBuilder sb, string userName, IMemoryCache _cache, ILogger _logger) {
 
             var backup = await ContractsAPI.FirstContact(account.Id);
             if(backup?.Backup?.ArtifactsDb?.MissionArchive is not null && account?.Backup?.ArtifactHall is not null) {
+                var shipCoefficientTable = await GetShipDataTable(_cache, _logger);
+
+                //Catch the case where the cache is invalidated, and the API returns an error
+                if(shipCoefficientTable is null) {
+                    sb.AppendLine($"Ship coefficients were not cached, and Menno's API did not respond to refresh them. Please try again later.");
+                    return;
+                }
+
                 var shipsSent = new ShipsSent(backup.Backup);
 
                 var sumOfRatios = 0.0;
-                foreach(var (ship, type, dropRates) in shipDataTable) {
+                foreach(var (ship, type, dropRates) in shipCoefficientTable) {
                     var rateIndex = 0;
                     foreach(var rate in dropRates) {
                         if(rate == 0.0) {

--- a/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
@@ -5,6 +5,7 @@ using EGG9000.Common.Commands;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
+using EGG9000.Common.JsonData.EiAfxConfig;
 using EGG9000.Common.Services;
 using Ei;
 using Microsoft.EntityFrameworkCore;
@@ -183,24 +184,12 @@ namespace EGG9000.Bot.Commands {
             return (resultLastType, resultSecondToLastType);
         }
 
-        [SlashCommand(Description="Testing")]
-        public static async Task GetCachedLLCCoeffs(FauxCommand command, IMemoryCache _cache, ILogger _logger) {
-            await command.DeferAsync();
-            var cachedCoeffs = await GetShipDataTable(_cache, _logger);
-            var coeffsString = "";
-            cachedCoeffs.ForEach(c => {
-                coeffsString += c.ship + " " + c.type + " [" + string.Join(", ", c.legendaryDropRates) + "]\n";
-            });
-            var bytes = Encoding.UTF8.GetBytes(coeffsString);
-            await command.RespondWithFileAsync(attachment: new FileAttachment(new MemoryStream(bytes), "Coefficients.txt"), text: "bruh");
-        }
-
         [ComponentCommand]
         private static async Task LLCCalculate(EggIncAccount account, StringBuilder sb, string userName, IMemoryCache _cache, ILogger _logger) {
-
             var backup = await ContractsAPI.FirstContact(account.Id);
             if(backup?.Backup?.ArtifactsDb?.MissionArchive is not null && account?.Backup?.ArtifactHall is not null) {
                 var shipCoefficientTable = await GetShipDataTable(_cache, _logger);
+                var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
 
                 //Catch the case where the cache is invalidated, and the API returns an error
                 if(shipCoefficientTable is null) {
@@ -225,7 +214,7 @@ namespace EGG9000.Bot.Commands {
 
                 var afHall = account.Backup.ArtifactHall;
                 var newLLCSum = 0.0;
-                foreach(var craftType in BaseCraftingCoefficients.Where(c => c.Value[2] != 0)) {
+                foreach(var craftType in baseCraftingCoefficients.Where(c => c.Value[2] != 0)) {
 
                     //Don't account for Lunar totems in LLC calc, re: sync with Menno data
                     if(craftType.Key.Artifact == "Lunar Totem" && craftType.Key.Tier == 4) continue;
@@ -248,7 +237,7 @@ namespace EGG9000.Bot.Commands {
                         //Calculate "assumed" or simulated crafting level
                         var simulatedCraftingLevel = GetCraftingLevel(assumedXpPerCraft * i);
                         //Retrieve the multiplier offset for this level (-1 due to returning "display value" vs. index)
-                        var simulatedMultiplier = levelMultipliers[simulatedCraftingLevel - 1];
+                        var simulatedMultiplier = Root.Get().craftingLevelMultipliers[simulatedCraftingLevel - 1];
 
                         //Calculate the true rate based on simulated multiplier
                         var simulatedRate = Math.Max(10.0, baseLegRate / simulatedMultiplier);
@@ -289,8 +278,9 @@ namespace EGG9000.Bot.Commands {
         }
         private static int GetCraftingLevel(double CraftingXP) {
             var currentLevel = 1;
+            var xpThresholds = Root.Get().craftingLevelXpThresholds;
 
-            for(var i = xpThresholds.Length - 1; i >= 0; i--) {
+            for(var i = xpThresholds.Count - 1; i >= 0; i--) {
                 if(CraftingXP >= xpThresholds[i]) {
                     currentLevel = i + 1;
                     break;

--- a/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
@@ -8,6 +8,7 @@ using EGG9000.Common.Helpers;
 using EGG9000.Common.JsonData.EiAfxConfig;
 using EGG9000.Common.Services;
 using Ei;
+using Humanizer.Localisation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -43,65 +44,42 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var sb = new StringBuilder();
-
+            var embeds = new List<Embed>();
             foreach(var account in dbUser.EggIncAccounts.Where(x => x.Backup is not null)) {
-                if(dbUser.EggIncAccounts.Count > 1)
-                    sb.AppendLine($"\n**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})**");
-                MERCalculate(account, sb, dbUser.DiscordUsername, (int)MERValue);
+                var embed = MERCalculate(account, (int)MERValue);
+                var newBuilder = embed.ToEmbedBuilder();
+                newBuilder.Title = $"**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})** {(string.IsNullOrWhiteSpace(embed.Title) ? "" : " ")}" + embed.Title;
+                embed = newBuilder.Build();
+                embeds.Add(embed);
             }
 
-            await command.ModifyOriginalResponseAsync(x => x.Content = sb.ToString());
+            await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embeds = embeds.ToArray(); });
         }
 
-        private static void MERCalculate(EggIncAccount account, StringBuilder sb, string userName, int MERValue) {
-            double calculateMER(double se, long pe) {
-                var result = (91 * (Math.Log10(se)) + 200 - pe) / 10;
-                return result;
-            }
+        private static Embed MERCalculate(EggIncAccount account, int MERValue) {
+            var seQ = account.Backup.SoulEggs / 1e18; // Convert to quintillions
+            long pe = account.Backup.EggsOfProphecy;
+            var MER = Math.Round((91 * Math.Log10(seQ) + 200 - pe) / 10, 2);
 
-            string calculateNeededSE(long MER, double se, long pe) {
-                var result = Math.Pow(10, ((10 * MER - 200 + pe) / 91.0)) * 1e18;
-                result -= se;
-                return result.ToEggString();
-            }
-
-            double seQ;
-            double calculateNeededPE(long MER, long pe) {
-                var result = (-10 * MER) + (91 * Math.Log10(seQ)) + 200;
-                result -= pe;
-                return result;
-            }
-
-            var backup = account.Backup;
-
-            var seStr = backup.SoulEggs.ToEggString();
-            seQ = backup.SoulEggs / 1e18; // Convert to quintillions
-            var seTotal = backup.SoulEggs;
-            long pe = backup.EggsOfProphecy;
-            var MER = Math.Round(calculateMER(seQ, pe), 2);
-
-            long MERgoal;
-            if(MERValue != 0) {
-                MERgoal = MERValue;
-            } else {
-                var value = Math.Round(calculateMER(seQ, pe), 1);
-                if(value < 30) {
-                    MERgoal = 30;
-                } else if(value < 40) {
-                    MERgoal = 40;
-                } else {
-                    MERgoal = 50;
-                }
-            }
+            var MERgoal = MERValue != 0 ? MERValue : Math.Max(30, Math.Min(50, (long)Math.Round(MER / 10) * 10));
+            var description = $"<:Egg_of_Prophecy_PE:669981330477547580>`{pe}` & <:Soul_Egg_SE:724341890794913964>`{account.Backup.SoulEggs.ToEggString()}`";
 
             if(MERgoal > MER) {
-                var MERse = calculateNeededSE(MERgoal, seTotal, pe);
-                sb.AppendLine($"The **MER** for **{userName}** is `{MER}` (<:Egg_of_Prophecy_PE:669981330477547580>`{pe}` and<:Soul_Egg_SE:724341890794913964>`{seStr}`)\nAn additional <:Soul_Egg_SE:724341890794913964>`{MERse}` is needed for MER {MERgoal}");
+                var MERse = Math.Pow(10, (10 * MERgoal - 200 + pe) / 91.0) * 1e18 - account.Backup.SoulEggs;
+                description += $"\nAn additional <:Soul_Egg_SE:724341890794913964>`{MERse.ToEggString()}` is needed for MER {MERgoal}";
             } else {
-                var MERpe = Math.Round(calculateNeededPE(MERgoal, pe), 1);
-                sb.AppendLine($"The **MER** for **{userName}** is `{MER}` (<:Egg_of_Prophecy_PE:669981330477547580>`{pe}` and<:Soul_Egg_SE:724341890794913964>`{seStr}`)\nYou're able to maintain MER {MERgoal} for another <:Egg_of_Prophecy_PE:669981330477547580>`{MERpe}`");
+                var MERpe = (-10 * MERgoal) + (91 * Math.Log10(seQ)) + 200 - pe;
+                description += $"\nYou can maintain MER {MERgoal} for another <:Egg_of_Prophecy_PE:669981330477547580>`{MERpe:n0}`";
             }
+
+            return new EmbedBuilder()
+                .WithTitle($"`{MER}`")
+                .WithColor(Color.Gold)
+                .WithDescription(description)
+                .WithAuthor(new EmbedAuthorBuilder()
+                .WithName("Mystical Egg Ratio")
+                .WithIconUrl("https://cdn.discordapp.com/avatars/514257192803893272/47be266c55cab32eacfb33c9affc82dd.webp"))
+                .Build();
         }
 
         private class ShipData(string type, string duration, int level, double legendaryDropRate) {
@@ -147,23 +125,22 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var sb = new StringBuilder();
-
-
+            var embeds = new List<Embed>();
             foreach(var account in dbUser.EggIncAccounts.Where(x => x.Backup is not null)) {
-                if(dbUser.EggIncAccounts.Count > 1) {
-                    sb.AppendLine($"\n**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})**");
-                }
-                await LLCCalculate(account, sb, dbUser.DiscordUsername, _cache, _logger);
+                var embed = await LLCCalculate(account, dbUser.DiscordUsername, _cache, _logger);
+                var newBuilder = embed.ToEmbedBuilder();
+                newBuilder.Title = $"**{account.Backup.UserName} ({account.Backup.EarningsBonus.ToEggString()})** {(string.IsNullOrWhiteSpace(embed.Title) ? "" : " " )}" + embed.Title;
+                embed = newBuilder.Build();
+                embeds.Add(embed);
             }
             
-            await command.ModifyOriginalResponseAsync(x => x.Content = sb.ToString());
+            await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embeds = embeds.ToArray(); });
         }
 
         public static (int, int) GetCompledShipsOfDuration(EggIncAccount account, DurationType duration) {
             var maxShipLevels = MissionHelpers.MaxShipLevels.ToList();
-            var lastShipType = maxShipLevels[maxShipLevels.Count - 1].Key;
-            var secondToLastShipType = maxShipLevels[maxShipLevels.Count - 2].Key;
+            var lastShipType = maxShipLevels[^1].Key;
+            var secondToLastShipType = maxShipLevels[^2].Key;
 
             var shipsForLastType = account.Backup.ShipsSent
                 .Where(x => x.ship == lastShipType && x.type == duration)
@@ -185,108 +162,101 @@ namespace EGG9000.Bot.Commands {
         }
 
         [ComponentCommand]
-        private static async Task LLCCalculate(EggIncAccount account, StringBuilder sb, string userName, IMemoryCache _cache, ILogger _logger) {
+        private static async Task<Embed> LLCCalculate(EggIncAccount account, string userName, IMemoryCache _cache, ILogger _logger) {
             var backup = await ContractsAPI.FirstContact(account.Id);
-            if(backup?.Backup?.ArtifactsDb?.MissionArchive is not null && account?.Backup?.ArtifactHall is not null) {
-                var shipCoefficientTable = await GetShipDataTable(_cache, _logger);
-                var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
 
-                //Catch the case where the cache is invalidated, and the API returns an error
-                if(shipCoefficientTable is null) {
-                    sb.AppendLine($"Ship coefficients were not cached, and Menno's API did not respond to refresh them. Please try again later.");
-                    return;
-                }
+            if(backup?.Backup?.ArtifactsDb?.MissionArchive is null || account?.Backup?.ArtifactHall is null) {
+                return EmbedError($"Unable to retrieve backup, please try again later.");
+            }
 
-                var shipsSent = new ShipsSent(backup.Backup);
+            var shipCoefficientTable = await GetShipDataTable(_cache, _logger);
+            var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
 
-                var sumOfRatios = 0.0;
-                foreach(var (ship, type, dropRates) in shipCoefficientTable) {
-                    var rateIndex = 0;
-                    foreach(var rate in dropRates) {
-                        if(rate == 0.0) {
-                            rateIndex++;
-                            continue;
-                        }
-                        sumOfRatios += shipsSent.GetShipsCount(ship, type, (uint)rateIndex) / rate;
+            //Catch the case where the cache is invalidated, and the API returns an error
+            if(shipCoefficientTable is null) {
+                return EmbedError($"Ship coefficients were not cached, and Menno's API did not respond to refresh them. Please try again later.");
+            }
+
+            var shipsSent = new ShipsSent(backup.Backup);
+
+            var sumOfRatios = 0.0;
+            foreach(var (ship, type, dropRates) in shipCoefficientTable) {
+                var rateIndex = 0;
+                foreach(var rate in dropRates) {
+                    if(rate == 0.0) {
                         rateIndex++;
+                        continue;
                     }
-                }
-
-                var afHall = account.Backup.ArtifactHall;
-                var newLLCSum = 0.0;
-                foreach(var craftType in baseCraftingCoefficients.Where(c => c.Value[2] != 0)) {
-
-                    //Don't account for Lunar totems in LLC calc, re: sync with Menno data
-                    if(craftType.Key.Artifact == "Lunar Totem" && craftType.Key.Tier == 4) continue;
-
-                    //Get the number of crafts that have been performed for this artifact
-                    var numCrafted = (double)(afHall.Where(a => a.NumberCrafted > 0).FirstOrDefault(a => a.Artifact.Tier == craftType.Key.Tier && a.Artifact.Artifact == craftType.Key.Artifact)?.NumberCrafted ?? 0.0);
-                    if(numCrafted == 0) continue;
-                    //Calculate an assumed XP per craft
-                    var assumedXpPerCraft = account.Backup.CraftingXP / numCrafted;
-                    //Sum up total legendary coefficients
-                    for(var i = 0; i < numCrafted; i++) {
-
-                        //Calculate "repetitive craft" scalar
-                        var craftingCountCoefficient = Math.Min(1.0, (double)(i / 400.0));
-                        var fixedCraftingCountCoefficient = 1.0 - craftingCountCoefficient * 0.3; //Where these numbers come from, I have no idea
-
-                        //Get the base Legendary rate for the artifact in question
-                        var baseLegRate = craftType.Value[2];
-
-                        //Calculate "assumed" or simulated crafting level
-                        var simulatedCraftingLevel = GetCraftingLevel(assumedXpPerCraft * i);
-                        //Retrieve the multiplier offset for this level (-1 due to returning "display value" vs. index)
-                        var simulatedMultiplier = Root.Get().craftingLevelMultipliers[simulatedCraftingLevel - 1];
-
-                        //Calculate the true rate based on simulated multiplier
-                        var simulatedRate = Math.Max(10.0, baseLegRate / simulatedMultiplier);
-                        var simulatedRatio = 1.0 / simulatedRate;
-
-                        //Calculate the legendary threshold based on the simulated ratio
-                        var simulatedThreshold = Math.Pow(simulatedRatio, fixedCraftingCountCoefficient);
-                        //Ceiling at 0.1
-                        var ceilingedThreshold = Math.Min(0.1, simulatedThreshold);
-
-                        //Add the threshold to the running sum
-                        newLLCSum += ceilingedThreshold;
-                    }
-                }
-
-                var (linerEpicCount, henEpicCount) = GetCompledShipsOfDuration(account, DurationType.Epic);
-                var (linerLongCount, henLongCount) = GetCompledShipsOfDuration(account, DurationType.Long);
-                var (linerShortCount, henShortCount) = GetCompledShipsOfDuration(account, DurationType.Short);
-
-                var craftCount = GetTotalCraftWithLegendaryPossibility(account.Backup.ArtifactHall);
-                var legCount = GetLegendaryArtifactCount(account.Backup.ArtifactHall, llcCount: true);
-
-                var newExpectedLeggies = newLLCSum + sumOfRatios;
-                var newLLC = Math.Round(legCount - newExpectedLeggies, 2);
-                var newLLCPercent = newExpectedLeggies != 0 ? (int)Math.Round((legCount * 100 / newExpectedLeggies) - 100) : 0;
-                var newDisplayPercent = newLLCPercent == int.MinValue ? "-∞" : $"{newLLCPercent}%";
-
-                sb.AppendLine(
-                    $"\nThe **LLC** for **{userName}** is `{newLLC:f2}` (`{newDisplayPercent}`)" +
-                    $"\n:tools: Total crafts with legendary possibility: `{craftCount}`" +
-                    $"\n<:Henerprise:801748924146384906> Henerprises: `{henEpicCount}` extended / `{henLongCount}` standard / `{henShortCount}` short" +
-                    $"\n<:Atreggies:1215022229826314380> Atreggies: `{linerEpicCount}` extended / `{linerLongCount}` standard / `{linerShortCount}` short" +
-                    $"\n<:leggy:1113516502516248636> Legendaries: `{Math.Round(newExpectedLeggies, 2)}` expected / `{legCount}` acquired"
-                );
-            } else {
-                sb.AppendLine($"Unable to retrieve backup for {userName}. Please try again later.");
-            }
-        }
-        private static int GetCraftingLevel(double CraftingXP) {
-            var currentLevel = 1;
-            var xpThresholds = Root.Get().craftingLevelXpThresholds;
-
-            for(var i = xpThresholds.Count - 1; i >= 0; i--) {
-                if(CraftingXP >= xpThresholds[i]) {
-                    currentLevel = i + 1;
-                    break;
+                    sumOfRatios += shipsSent.GetShipsCount(ship, type, (uint)rateIndex) / rate;
+                    rateIndex++;
                 }
             }
-            return currentLevel;
+
+            var afHall = account.Backup.ArtifactHall;
+            var newLLCSum = 0.0;
+            foreach(var craftType in baseCraftingCoefficients.Where(c => c.Value[2] != 0)) {
+
+                //Don't account for Lunar totems in LLC calc, re: sync with Menno data
+                if(craftType.Key.Artifact == "Lunar Totem" && craftType.Key.Tier == 4) continue;
+
+                //Get the number of crafts that have been performed for this artifact
+                var numCrafted = (double)(afHall.Where(a => a.NumberCrafted > 0).FirstOrDefault(a => a.Artifact.Tier == craftType.Key.Tier && a.Artifact.Artifact == craftType.Key.Artifact)?.NumberCrafted ?? 0.0);
+                if(numCrafted == 0) continue;
+                //Calculate an assumed XP per craft
+                var assumedXpPerCraft = account.Backup.CraftingXP / numCrafted;
+                //Sum up total legendary coefficients
+                for(var i = 0; i < numCrafted; i++) {
+
+                    //Calculate "repetitive craft" scalar
+                    var craftingCountCoefficient = Math.Min(1.0, (double)(i / 400.0));
+                    var fixedCraftingCountCoefficient = 1.0 - craftingCountCoefficient * 0.3; //Where these numbers come from, I have no idea
+
+                    //Get the base Legendary rate for the artifact in question
+                    var baseLegRate = craftType.Value[2];
+
+                    //Calculate "assumed" or simulated crafting level
+                    var simulatedCraftingLevel = GetCraftingLevel(assumedXpPerCraft * i);
+                    //Retrieve the multiplier offset for this level (-1 due to returning "display value" vs. index)
+                    var simulatedMultiplier = Root.Get().craftingLevelMultipliers[(int)simulatedCraftingLevel - 1];
+
+                    //Calculate the true rate based on simulated multiplier
+                    var simulatedRate = Math.Max(10.0, baseLegRate / simulatedMultiplier);
+                    var simulatedRatio = 1.0 / simulatedRate;
+
+                    //Calculate the legendary threshold based on the simulated ratio
+                    var simulatedThreshold = Math.Pow(simulatedRatio, fixedCraftingCountCoefficient);
+                    //Ceiling at 0.1
+                    var ceilingedThreshold = Math.Min(0.1, simulatedThreshold);
+
+                    //Add the threshold to the running sum
+                    newLLCSum += ceilingedThreshold;
+                }
+            }
+
+            var (linerEpicCount, henEpicCount) = GetCompledShipsOfDuration(account, DurationType.Epic);
+            var (linerLongCount, henLongCount) = GetCompledShipsOfDuration(account, DurationType.Long);
+            var (linerShortCount, henShortCount) = GetCompledShipsOfDuration(account, DurationType.Short);
+
+            var craftCount = GetTotalCraftWithLegendaryPossibility(account.Backup.ArtifactHall);
+            var legCount = GetLegendaryArtifactCount(account.Backup.ArtifactHall, llcCount: true);
+
+            var newExpectedLeggies = newLLCSum + sumOfRatios;
+            var newLLC = Math.Round(legCount - newExpectedLeggies, 2);
+            var newLLCPercent = newExpectedLeggies != 0 ? (int)Math.Round((legCount * 100 / newExpectedLeggies) - 100) : 0;
+            var newDisplayPercent = newLLCPercent == int.MinValue ? "-∞" : $"{newLLCPercent}%";
+            var description = $"\n:tools: **Possible <:leggy:1113516502516248636> crafts** `{craftCount}`" +
+                $"\n<:Henerprise:801748924146384906> **Henerprises** `{henEpicCount}` extended / `{henLongCount}` standard / `{henShortCount}` short" +
+                $"\n<:Atreggies:1215022229826314380> **Atreggies** `{linerEpicCount}` extended / `{linerLongCount}` standard / `{linerShortCount}` short" +
+                $"\n<:leggy:1113516502516248636> **Legendaries** `{Math.Round(newExpectedLeggies, 2)}` expected / `{legCount}` acquired";
+
+            return new EmbedBuilder()
+                .WithTitle($"`{newLLC:f2}` (`{newDisplayPercent}`)")
+                .WithColor(Color.DarkBlue)
+                .WithDescription(description)
+                .WithAuthor(new EmbedAuthorBuilder()
+                .WithName("Legendary Luck Coefficient")
+                .WithIconUrl("https://cdn.discordapp.com/avatars/514257192803893272/47be266c55cab32eacfb33c9affc82dd.webp"))
+                .Build();
         }
 
         [SlashCommand(Description = "Calculate the EB% based on SE and PE inputs", ParentCommand = "formulae", AllowInDMs = true)]

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -171,7 +171,7 @@ namespace EGG9000.Bot.Commands {
                 var dbguild = await db.Guilds.AsQueryable().FirstAsync(x => x.Id == targetCoop.GuildId);
                 if(targetCoop.ThreadID != 0) {
                     var slashCommands = (await guild.GetApplicationCommandsAsync()).ToList().Where(c => c.Type == ApplicationCommandType.Slash).ToList();
-                    await coopStatusUpdaterThreads.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default, slashCommands);
+                    await coopStatusUpdaterThreads.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, slashCommands, default);
                 } else if(targetCoop.DiscordChannelId != 0) {
                     await coopStatusUpdater.ProcessCoop(targetCoop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default);
                 }

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -149,7 +149,7 @@ namespace EGG9000.Bot.Commands {
                 var dbguild = await db.Guilds.AsQueryable().FirstAsync(x => x.Id == coop.GuildId);
                 if(coop.ThreadID != 0) {
                     var slashCommands = (await guild.GetApplicationCommandsAsync()).ToList().Where(c => c.Type == ApplicationCommandType.Slash).ToList();
-                    await coopStatusUpdaterThreads.ProcessCoop(coop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default, slashCommands);
+                    await coopStatusUpdaterThreads.ProcessCoop(coop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, slashCommands, default);
                 } else if(coop.DiscordChannelId != 0) {
                     await coopStatusUpdater.ProcessCoop(coop.Id, guild, users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList(), dbguild, default);
                 }

--- a/EGG9000.Bot/Jobs/SubscriptionsCheckJob.cs
+++ b/EGG9000.Bot/Jobs/SubscriptionsCheckJob.cs
@@ -5,7 +5,8 @@ using EGG9000.Bot.Helpers;
 using EGG9000.Bot.Services;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
-
+using EGG9000.Common.Helpers;
+using System.Threading;
 using Ei;
 
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace EGG9000.Bot.Jobs {
 
@@ -39,18 +41,22 @@ namespace EGG9000.Bot.Jobs {
                 if(dbguild is null)
                     continue;
                 var guild = _discord.GetGuild(guildGroup.Key);
+                if(guild is null)
+                    continue;
                 var standardRoleId = dbguild.ChannelDetails?.FirstOrDefault(x => x.ChannelType == GuildChannelType.StandardSubscription)?.Id ?? default;
                 var proRoleId = dbguild.ChannelDetails?.FirstOrDefault(x => x.ChannelType == GuildChannelType.ProSubscription)?.Id ?? default;
 
                 await Parallel.ForEachAsync(guildGroup, new ParallelOptions { MaxDegreeOfParallelism = 5 }, async (user, cancellationToken) => {
                     try {
-                        foreach(var account in user.EggIncAccounts) {
-                            await CheckSubscription(db, _discord, user, account, dbguild, guild);
-                        }
-                        var discorduser = guild.GetUser(user.DiscordId);
-                        if(discorduser is not null) {
-                            await CheckRole(standardRoleId, user, false, discorduser);
-                            await CheckRole(proRoleId, user, true, discorduser);
+                        if(user?.EggIncAccounts?.Count > 0) {
+                            foreach(var account in user.EggIncAccounts) {
+                                await CheckSubscription(db, _discord, user, account, dbguild, guild);
+                            }
+                            var discorduser = guild.GetUser(user.DiscordId);
+                            if(discorduser is not null) {
+                                await CheckRole(standardRoleId, user, false, discorduser);
+                                await CheckRole(proRoleId, user, true, discorduser);
+                            }
                         }
                     } catch(Exception e) {
                         _bugsnag.Notify(e);
@@ -58,7 +64,7 @@ namespace EGG9000.Bot.Jobs {
                 });
             }
 
-            await db.SaveChangesAsync();
+            await db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
             _logger.LogInformation("Finished checking subscriptions");
         }
 
@@ -100,7 +106,7 @@ namespace EGG9000.Bot.Jobs {
         }
 
         public async Task CheckRole(ulong roleid, DBUser dbuser, bool pro, SocketGuildUser user) {
-            if(roleid == default)
+            if(roleid == default || dbuser is null || dbuser.EggIncAccounts?.Count == 0|| user is null)
                 return;
             var needsRole = dbuser.EggIncAccounts.Any(y => y.SubscriptionLevel == (pro ? UserSubscriptionInfo.Types.Level.Pro : UserSubscriptionInfo.Types.Level.Standard) && y.HasActiveSubscription());
             var hasRole = user?.Roles?.Any(x => x.Id == roleid) ?? false;

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -13,6 +13,7 @@ using EGG9000.Common.Extensions;
 using EGG9000.Common.Services;
 using MassTransit;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -56,6 +57,7 @@ namespace EGG9000.Bot.Services {
         private readonly List<(SocketApplicationCommand command, ulong guildid)> _globalCommands = [];
         private readonly IPublishEndpoint _publishEndpoint;
         private readonly IDbContextFactory<ApplicationDbContext> _dbContextFactory;
+        private readonly IMemoryCache _cache;
         public CommandService(IConfiguration Configuration,
                 DiscordHostedService discord,
                 APILink apilink,
@@ -68,7 +70,8 @@ namespace EGG9000.Bot.Services {
                 ApplicationDbContext context,
                 IServiceProvider serviceProvider,
                 ILogger<CommandService> logger,
-                IPublishEndpoint publishEndpoint, IDbContextFactory<ApplicationDbContext> dbContextFactory
+                IPublishEndpoint publishEndpoint, IDbContextFactory<ApplicationDbContext> dbContextFactory,
+                IMemoryCache cache
             ) {
             _discord = discord;
             _apilink = apilink;
@@ -85,6 +88,7 @@ namespace EGG9000.Bot.Services {
             _provider = serviceProvider;
             _logger = logger;
             _dbContextFactory = dbContextFactory;
+            _cache = cache;
             logger.LogInformation($"Initiating CommandService");
         }
 
@@ -180,8 +184,10 @@ namespace EGG9000.Bot.Services {
                             parameters.Add(_bugsnag);
                         } else if(parameterInfo.ParameterType == typeof(ILogger)) {
                             parameters.Add(_logger);
+                        }else if(parameterInfo.ParameterType == typeof(IMemoryCache)) {
+                            parameters.Add(_cache);
                         } else {
-                            throw new ArgumentException($"Missing the type for {parameterInfo.Name}");
+                            throw new ArgumentException($"Parameter `{parameterInfo.Name}` is of type `{parameterInfo.ParameterType}`, which has not been implemented to be passed to commands.");
                         }
                     }
 

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using static EGG9000.Common.Helpers.ArtifactHelpers;
 using static Ei.Contract.Types;
 using static Ei.MissionInfo.Types;
 using static Ei.ArtifactSpec.Types;
@@ -199,8 +198,9 @@ namespace EGG9000.Common.Database {
 
         public uint GetCraftingLevel() {
             uint currentLevel = 1;
+            var xpThresholds = JsonData.EiAfxConfig.Root.Get().craftingLevelXpThresholds;
 
-            for(var i = xpThresholds.Length - 1; i >= 0; i--) {
+            for(var i = xpThresholds.Count - 1; i >= 0; i--) {
                 if(CraftingXP >= xpThresholds[i]) {
                     currentLevel = (uint)i + 1;
                     break;

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -196,19 +196,6 @@ namespace EGG9000.Common.Database {
             return artifacts.Where(x => x.Count > 0).ToList();
         }
 
-        public uint GetCraftingLevel() {
-            uint currentLevel = 1;
-            var xpThresholds = JsonData.EiAfxConfig.Root.Get().craftingLevelXpThresholds;
-
-            for(var i = xpThresholds.Count - 1; i >= 0; i--) {
-                if(CraftingXP >= xpThresholds[i]) {
-                    currentLevel = (uint)i + 1;
-                    break;
-                }
-            }
-            return currentLevel;
-        }
-
         public CustomBackup() { }
 
         public CustomBackup(Ei.Backup backup, CustomBackup lastBackup = null) {

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -1,4 +1,6 @@
-﻿using EGG9000.Common.Database.Entities;
+﻿using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.JsonData.EiAfxConfig;
 using Ei;
 using Humanizer;
 using Microsoft.Extensions.Caching.Memory;
@@ -17,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -65,6 +68,22 @@ namespace EGG9000.Common.Helpers {
             }
 
             return mennoData;
+        }
+
+        public static uint GetCraftingLevel(double CraftingXP) {
+            uint currentLevel = 1;
+            var xpThresholds = Root.Get().craftingLevelXpThresholds;
+            for(var i = xpThresholds.Count - 1; i >= 0; i--) {
+                if(CraftingXP >= xpThresholds[i]) {
+                    currentLevel = (uint)i + 1;
+                    break;
+                }
+            }
+            return currentLevel;
+        }
+
+        public static uint GetCraftingLevel(this CustomBackup backup) {
+            return GetCraftingLevel(backup.CraftingXP);
         }
 
         private static async Task<List<(Spaceship ship, DurationType type, List<double> legendaryDropRates)>> GetNewMennoData(ILogger _logger) {

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -1,5 +1,9 @@
 ﻿using EGG9000.Common.Database.Entities;
 using Ei;
+using Humanizer;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
@@ -11,8 +15,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Numerics;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using static Ei.MissionInfo.Types;
 
 namespace EGG9000.Common.Helpers {
@@ -44,24 +51,73 @@ namespace EGG9000.Common.Helpers {
             8.00, 9.00, 10.00
         ];
 
-        public static readonly List<(Spaceship ship, DurationType type, List<double> legendaryDropRates)> shipDataTable = [
-            (Spaceship.Galeggtica, DurationType.Short, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-            (Spaceship.Galeggtica, DurationType.Long, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-            (Spaceship.Galeggtica, DurationType.Epic, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-            (Spaceship.Chickfiant, DurationType.Short, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-            (Spaceship.Chickfiant, DurationType.Long, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
-            (Spaceship.Chickfiant, DurationType.Epic, [0.0, 482.673, 1615.316, 274.828, 431.604, 0.0]),
-            (Spaceship.Voyegger, DurationType.Short, [0.0, 0.0, 9010.667, 8244.540, 3056.498, 1212.981, 654.000]),
-            (Spaceship.Voyegger, DurationType.Long, [579.538, 0.0, 934.343, 372.407, 653.134, 0.0, 0.0]),
-            (Spaceship.Voyegger, DurationType.Epic, [270.244, 133.825, 119.026, 113.645, 105.118, 161.565, 143.500]),
-            (Spaceship.Henerprise, DurationType.Short, [2535.522, 1263.428, 1410.754, 594.269, 501.500, 615.863, 422.235, 483.407]),
-            (Spaceship.Henerprise, DurationType.Long, [0.0, 300.548, 203.415, 319.529, 165.267, 87.388, 84.260, 103.098]),
-            (Spaceship.Henerprise, DurationType.Epic, [55.675, 51.978, 36.620, 38.262, 30.459, 27.887, 25.055, 24.977]),
-            //These are the Henerprise values as it is likely a decent (initial) estimation that the drop rates are similar
-            (Spaceship.Atreggies, DurationType.Short, [2535.522, 1263.428, 1410.754, 594.269, 501.500, 615.863, 422.235, 483.407]),
-            (Spaceship.Atreggies, DurationType.Long, [0.0, 300.548, 203.415, 319.529, 165.267, 87.388, 84.260, 103.098]),
-            (Spaceship.Atreggies, DurationType.Epic, [55.675, 51.978, 36.620, 38.262, 30.459, 27.887, 25.055, 24.977]),
-        ];
+        private class MennoAPIData {
+            public string shipTypeName { get; set; }
+            public Spaceship Ship {
+                get {
+                    if(!Enum.TryParse<Spaceship>(shipTypeName, ignoreCase: true, out var spaceship)) {
+                        return Spaceship.ChickenOne;
+                    }
+                    return spaceship;
+                }
+            }
+            public string shipDurationTypeName { get; set; }
+            public DurationType DurationType {
+                get {
+                    if(!Enum.TryParse<DurationType>(shipDurationTypeName, ignoreCase: true, out var durationType)) {
+                        return DurationType.Tutorial;
+                    }
+                    return durationType;
+                }
+            }
+            public int shipLevel { get; set; }
+            public double shipsNeededPerLegendary { get; set; }
+        }
+
+        private static HttpClient _httpClient;
+        private static readonly string MennoAPIURL = "https://eggincdatacollection.azurewebsites.net/";
+        private static readonly string APIEndpoint = "api/GetLLCData";
+        private static readonly string MennoDataKey = "MennoDataCache";
+        public static async Task<List<(Spaceship ship, DurationType type, List<double> legendaryDropRates)>> GetShipDataTable(IMemoryCache _cache, ILogger _logger) {
+            if(!_cache.TryGetValue(MennoDataKey, out List<(Spaceship ship, DurationType type, List<double> legendaryDropRates)> mennoData)) {
+                mennoData = await GetNewMennoData(_logger);
+                _cache.Set(MennoDataKey, mennoData, TimeSpan.FromHours(6));
+            }
+
+            return mennoData;
+        }
+
+        private static async Task<List<(Spaceship ship, DurationType type, List<double> legendaryDropRates)>> GetNewMennoData(ILogger _logger) {
+            _httpClient ??= new() {
+                BaseAddress = new Uri(MennoAPIURL)
+            };
+            //Dispose of any junk requests left over, prevent mem leaks
+            _httpClient.CancelPendingRequests();
+            try {
+                var response = await _httpClient.GetAsync(APIEndpoint);
+                response.EnsureSuccessStatusCode();
+                var jsonResponse = await response.Content.ReadAsStringAsync();
+                var shipDataArray = JsonConvert.DeserializeObject<MennoAPIData[]>(jsonResponse);
+
+                _logger.LogInformation("Menno Ship Coefficients were refreshed at {refreshTime}, and will be invalidated again at {invalidationTime}", DateTimeOffset.Now.Humanize(), DateTimeOffset.Now.AddHours(6).Humanize());
+
+                return shipDataArray.GroupBy(data => new { data.Ship, data.DurationType })
+                    .SelectMany(shipGrouping => shipGrouping.GroupBy(sg => sg.Ship)
+                        .Select(durationGrouping => (
+                            ship: durationGrouping.First().Ship,
+                            type: durationGrouping.First().DurationType,
+                            legendaryDropRates: durationGrouping
+                                .OrderBy(d => d.shipLevel)
+                                .Select(d => d.shipsNeededPerLegendary)
+                                .ToList()
+                        )
+                    )
+                ).ToList();
+            } catch(HttpRequestException ex) {
+                _logger.LogError("Failed to load Menno Ship Coefficients from API: {exception}", ex);
+                return null;
+            }
+        }
 
         public static string GetArtifactFairnessScoreString(List<ArtifactCount> ArtifactHall) {
             return (ArtifactHall is null || ArtifactHall.Count == 0) ? "0 (null artifact hall)" : GetArtifactFairnessScore(ArtifactHall).ToString("E");

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -31,26 +31,6 @@ namespace EGG9000.Common.Helpers {
 
     public static class ArtifactHelpers {
 
-        public static readonly long[] xpThresholds = [
-            0, 500, 3000, 8000, 18000, 43000, 93000, 193000, 443000, 943000, 1943000,
-            3943000, 7943000, 15943000, 30943000, 50943000, 85943000, 145943000, 245943000,
-            395943000, 595943000, 845943000, 1145943000, 1470943000, 1820943000, 2220943000,
-            2720943000, 3320943000, 4070943000, 5070943000
-        ];
-
-        public static readonly List<double> levelMultipliers = [
-            1.00, 1.05, 1.10,
-            1.15, 1.20, 1.25,
-            1.30, 1.35, 1.40,
-            1.45, 1.50, 1.55,
-            1.60, 1.65, 1.70,
-            1.75, 1.85, 2.00,
-            2.25, 2.50, 3.00,
-            3.50, 4.00, 4.50,
-            5.00, 6.00, 7.00,
-            8.00, 9.00, 10.00
-        ];
-
         private class MennoAPIData {
             public string shipTypeName { get; set; }
             public Spaceship Ship {
@@ -126,60 +106,6 @@ namespace EGG9000.Common.Helpers {
         public static BigInteger GetArtifactFairnessScore(List<ArtifactCount> ArtifactHall) {
             return (ArtifactHall is null || ArtifactHall.Count == 0) ? 0 : (BigInteger)ArtifactHall.Sum(a => Math.Pow(GetFairness(a.Artifact)[a.Artifact.Tier - 1], a.Artifact.Rarity + 1) * a.Count);
         }
-
-        public static readonly Dictionary<EggIncArtifactInstance, List<double>> BaseCraftingCoefficients = new() {
-            { new() { Artifact = "Lunar Totem", Tier = 2}, new() { 30, 0, 0} },
-            { new() { Artifact = "Lunar Totem", Tier = 3}, new() { 20, 0, 0} },
-            { new() { Artifact = "Lunar Totem", Tier = 4}, new() { 30, 250, 1500} },
-            { new() { Artifact = "Light of Eggendil", Tier = 2 }, new() { 15, 0, 0 } },
-            { new() { Artifact = "Light of Eggendil", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Light of Eggendil", Tier = 4 }, new() { 0, 100, 1000 } },
-            { new() { Artifact = "Book of Basan", Tier = 3 }, new() { 0, 100, 0 } },
-            { new() { Artifact = "Book of Basan", Tier = 4 }, new() { 0, 150, 1000 } },
-            { new() { Artifact = "Tachyon Deflector", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Tachyon Deflector", Tier = 4 }, new() { 120, 500, 1200 } },
-            { new() { Artifact = "Ship in a Bottle", Tier = 3 }, new() { 10, 400, 1200 } },
-            { new() { Artifact = "Ship in a Bottle", Tier = 4 }, new() { 100, 400, 1200 } },
-            { new() { Artifact = "Titanium Actuator", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Titanium Actuator", Tier = 4 }, new() { 0, 200, 1000 } },
-            { new() { Artifact = "Dilithium Monocle", Tier = 4 }, new() { 0, 150, 1000 } },
-            { new() { Artifact = "Quantum Metronome", Tier = 2 }, new() { 15, 0, 0 } },
-            { new() { Artifact = "Quantum Metronome", Tier = 3 }, new() { 10, 80, 0 } },
-            { new() { Artifact = "Quantum Metronome", Tier = 4 }, new() { 33, 160, 1000 } },
-            { new() { Artifact = "Phoenix Feather", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Phoenix Feather", Tier = 4 }, new() { 40, 0, 1000 } },
-            { new() { Artifact = "The Chalice", Tier = 2 }, new() { 0, 80, 0 } },
-            { new() { Artifact = "The Chalice", Tier = 3 }, new() { 10, 100, 0 } },
-            { new() { Artifact = "The Chalice", Tier = 4 }, new() { 0, 150, 1000 } },
-            { new() { Artifact = "Interstellar Compass", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Interstellar Compass", Tier = 4 }, new() { 40, 200, 1000 } },
-            { new() { Artifact = "Carved Rainstick", Tier = 4 }, new() { 0, 170, 1000 } },
-            { new() { Artifact = "Beak of Midas", Tier = 3 }, new() { 11, 0, 0 } },
-            { new() { Artifact = "Beak of Midas", Tier = 4 }, new() { 50, 0, 1500 } },
-            { new() { Artifact = "Mercury's Lens", Tier = 2 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Mercury's Lens", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Mercury's Lens", Tier = 4 }, new() { 40, 250, 1000 } },
-            { new() { Artifact = "Neodymium Medallion", Tier = 2 }, new() { 12, 0, 0 } },
-            { new() { Artifact = "Neodymium Medallion", Tier = 3 }, new() { 0, 150, 0 } },
-            { new() { Artifact = "Neodymium Medallion", Tier = 4 }, new() { 40, 200, 1000 } },
-            { new() { Artifact = "Gusset", Tier = 2 }, new() { 0, 100, 0 } },
-            { new() { Artifact = "Gusset", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Gusset", Tier = 4 }, new() { 0, 150, 1000 } },
-            { new() { Artifact = "Tungsten Ankh", Tier = 2 }, new() { 25, 0, 0 } },
-            { new() { Artifact = "Tungsten Ankh", Tier = 3 }, new() { 10, 0, 1000 } },
-            { new() { Artifact = "Tungsten Ankh", Tier = 4 }, new() { 40, 0, 1000 } },
-            { new() { Artifact = "Aurelian Brooch", Tier = 3 }, new() { 10, 100, 0 } },
-            { new() { Artifact = "Aurelian Brooch", Tier = 4 }, new() { 40, 180, 1000 } },
-            { new() { Artifact = "Vial of Martian Dust", Tier = 2 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Vial of Martian Dust", Tier = 3 }, new() { 0, 100, 0 } },
-            { new() { Artifact = "Vial of Martian Dust", Tier = 4 }, new() { 40, 0, 1000 } },
-            { new() { Artifact = "Demeters Necklace", Tier = 2 }, new() { 30, 0, 0 } },
-            { new() { Artifact = "Demeters Necklace", Tier = 3 }, new() { 20, 100, 0 } },
-            { new() { Artifact = "Demeters Necklace", Tier = 4 }, new() { 40, 140, 1000 } },
-            { new() { Artifact = "Puzzle Cube", Tier = 2 }, new() { 0, 80, 0 } },
-            { new() { Artifact = "Puzzle Cube", Tier = 3 }, new() { 10, 0, 0 } },
-            { new() { Artifact = "Puzzle Cube", Tier = 4 }, new() { 50, 170, 1000 } },
-        };
 
         public static int GetAFOrder(string AF) {
             return AF switch {

--- a/EGG9000.Common/JsonData/ei-epic-research.cs
+++ b/EGG9000.Common/JsonData/ei-epic-research.cs
@@ -43,7 +43,7 @@ namespace EGG9000.Common.JsonData.EIEpicResearch {
     public class Root {
         public List<EpicResearchItem> epicResearchItems { get; set; }
 
-        public static Root Instance = null;
+        private static Root Instance = null;
         public static Root Get() {
             if (Instance != null) {
                 return Instance;

--- a/EGG9000.Common/JsonData/eiafx-config.cs
+++ b/EGG9000.Common/JsonData/eiafx-config.cs
@@ -1,4 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using EGG9000.Common.Helpers;
+using Ei;
+using Humanizer;
+using Newtonsoft.Json;
 
 using System;
 using System.Collections.Generic;
@@ -59,11 +62,20 @@ namespace EGG9000.Common.JsonData.EiAfxConfig {
         }
     }
 
+    public class CraftingLevelInfo {
+        public int xpRequired { get; set; }
+        public double rarityMult { get; set; }
+    }
+
     public class Root {
         public List<MissionParameter> missionParameters { get; set; }
         public List<ArtifactParameter> artifactParameters { get; set; }
+        public List<CraftingLevelInfo> craftingLevelInfos { get; set; }
+        public Dictionary<EggIncArtifactInstance, List<double>> baseCraftingCoefficients { get; set; }
+        public Dictionary<int, double> craftingLevelMultipliers { get; set; }
+        public List<long> craftingLevelXpThresholds { get; set; }
 
-        public static Root Instance = null;
+        private static Root Instance = null;
         public static Root Get() {
             if(Instance != null) {
                 return Instance;
@@ -71,15 +83,65 @@ namespace EGG9000.Common.JsonData.EiAfxConfig {
 
             var assembly = Assembly.GetExecutingAssembly();
 
-            string resourceName = assembly.GetManifestResourceNames()
+            var resourceName = assembly.GetManifestResourceNames()
                 .Single(str => str.EndsWith("eiafx-config.json"));
 
-            using(Stream stream = assembly.GetManifestResourceStream(resourceName))
-            using(StreamReader reader = new StreamReader(stream)) {
-                string json = reader.ReadToEnd();
-                Instance = JsonConvert.DeserializeObject<Root>(json);
-                return Instance;
-            }
+            using var stream = assembly.GetManifestResourceStream(resourceName);
+            using var reader = new StreamReader(stream);
+            var json = reader.ReadToEnd();
+            Instance = JsonConvert.DeserializeObject<Root>(json);
+
+            // Compile the crafting coefficients from artifactParameters
+            Instance.baseCraftingCoefficients = Instance.artifactParameters
+                .GroupBy(config => new { config.spec.name, config.spec.level })
+                .Where(artifactLevelGrouping => artifactLevelGrouping.Count() > 1) // Weed out stones and ingredients, artifact levels with no rarity
+                .ToDictionary(
+                    artifactLevelGrouping => {
+                        // Create an EggIncArtifactInstance
+                        var firstGroup = artifactLevelGrouping.First();
+                        var afInstanceName = firstGroup.spec.name.Replace("_", " ").Titleize();
+                        afInstanceName = afInstanceName.Replace("Vial ", "Vial Of ");
+                        afInstanceName = afInstanceName.Replace("Of", "of").Replace(" In ", " in ").Replace(" A ", " a ");
+                        afInstanceName = afInstanceName.Replace("Ornate ", "");
+                        afInstanceName = afInstanceName.Replace("Mercurys ", "Mercury's ");
+
+                        var afInstance = new EggIncArtifactInstance() {
+                            Artifact = afInstanceName,
+                            Tier = (byte)((int)Enum.Parse<ArtifactSpec.Types.Level>(firstGroup.spec.level, ignoreCase: true) + 1),
+                        };
+
+                        return afInstance;
+                    },
+                    artifactLevelGrouping => {
+                        var commonCoeff = artifactLevelGrouping.First(c => c.spec.rarity == "COMMON").oddsMultiplier;
+                        var rareCoeff = commonCoeff / (artifactLevelGrouping.FirstOrDefault(c => c.spec.rarity == "RARE")?.oddsMultiplier ?? 1);
+                        var epicCoeff = commonCoeff / (artifactLevelGrouping.FirstOrDefault(c => c.spec.rarity == "EPIC")?.oddsMultiplier ?? 1);
+                        var legendaryCoeff = commonCoeff / (artifactLevelGrouping.FirstOrDefault(c => c.spec.rarity == "LEGENDARY")?.oddsMultiplier ?? 1);
+
+                        // Ensure coefficients are set to 0 if they are undefined
+                        if(rareCoeff == commonCoeff) rareCoeff = 0;
+                        if(epicCoeff == commonCoeff) epicCoeff = 0;
+                        if(legendaryCoeff == commonCoeff) legendaryCoeff = 0;
+
+                        rareCoeff = Math.Round(rareCoeff, 0, MidpointRounding.AwayFromZero);
+                        epicCoeff = Math.Round(epicCoeff, 0, MidpointRounding.AwayFromZero);
+                        legendaryCoeff = Math.Round(legendaryCoeff, 0, MidpointRounding.AwayFromZero);
+
+                        return new List<double> { rareCoeff, epicCoeff, legendaryCoeff };
+                    }
+                );
+
+            Instance.craftingLevelMultipliers = Instance.craftingLevelInfos.ToDictionary(info => Instance.craftingLevelInfos.IndexOf(info), info => info.rarityMult);
+
+            long runningSum = 0;
+            Instance.craftingLevelXpThresholds = Instance.craftingLevelInfos
+                .Select(level => {
+                    runningSum += level.xpRequired;
+                    return runningSum;
+                })
+                .Prepend(0).Take(30).ToList();
+
+            return Instance;
         }
     }
 

--- a/EGG9000.Common/JsonData/eiafx-config.json
+++ b/EGG9000.Common/JsonData/eiafx-config.json
@@ -6,9 +6,9 @@
         {
           "durationType": "TUTORIAL",
           "seconds": 60,
-          "quality": 0.9,
+          "quality": 0.8999999761581421,
           "minQuality": 0,
-          "maxQuality": 1.3,
+          "maxQuality": 1.2999999523162842,
           "capacity": 4,
           "levelCapacityBump": 0,
           "levelQualityBump": 0
@@ -18,34 +18,33 @@
           "seconds": 1200,
           "quality": 1,
           "minQuality": 0,
-          "maxQuality": 1.4,
+          "maxQuality": 1.399999976158142,
           "capacity": 4,
           "levelCapacityBump": 0,
-          "levelQualityBump": 0.1
+          "levelQualityBump": 0.10000000149011612
         },
         {
           "durationType": "LONG",
           "seconds": 3600,
-          "quality": 1.1,
+          "quality": 1.100000023841858,
           "minQuality": 0,
-          "maxQuality": 1.7,
+          "maxQuality": 1.7000000476837158,
           "capacity": 5,
           "levelCapacityBump": 1,
-          "levelQualityBump": 0.14
+          "levelQualityBump": 0.14000000059604645
         },
         {
           "durationType": "EPIC",
           "seconds": 7200,
-          "quality": 1.2,
+          "quality": 1.2000000476837158,
           "minQuality": 0,
-          "maxQuality": 2.2,
+          "maxQuality": 2.200000047683716,
           "capacity": 6,
           "levelCapacityBump": 1,
-          "levelQualityBump": 0.17
+          "levelQualityBump": 0.17000000178813934
         }
       ],
-      "levelMissionRequirements": [],
-      "capacityDEPRECATED": 0
+      "levelMissionRequirements": []
     },
     {
       "ship": "CHICKEN_NINE",
@@ -53,39 +52,38 @@
         {
           "durationType": "SHORT",
           "seconds": 1800,
-          "quality": 1.4,
+          "quality": 1.399999976158142,
           "minQuality": 0,
-          "maxQuality": 1.9,
+          "maxQuality": 1.899999976158142,
           "capacity": 7,
           "levelCapacityBump": 1,
-          "levelQualityBump": 0.1
+          "levelQualityBump": 0.10000000149011612
         },
         {
           "durationType": "LONG",
           "seconds": 3600,
-          "quality": 1.6,
+          "quality": 1.600000023841858,
           "minQuality": 0,
-          "maxQuality": 2.35,
+          "maxQuality": 2.3499999046325684,
           "capacity": 8,
           "levelCapacityBump": 1,
-          "levelQualityBump": 0.18
+          "levelQualityBump": 0.18000000715255737
         },
         {
           "durationType": "EPIC",
           "seconds": 10800,
           "quality": 1.75,
           "minQuality": 0,
-          "maxQuality": 2.7,
+          "maxQuality": 2.700000047683716,
           "capacity": 9,
           "levelCapacityBump": 1,
-          "levelQualityBump": 0.2
+          "levelQualityBump": 0.20000000298023224
         }
       ],
       "levelMissionRequirements": [
         4,
         10
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "CHICKEN_HEAVY",
@@ -93,29 +91,29 @@
         {
           "durationType": "SHORT",
           "seconds": 2700,
-          "quality": 1.9,
+          "quality": 1.899999976158142,
           "minQuality": 0,
-          "maxQuality": 3.1,
+          "maxQuality": 3.0999999046325684,
           "capacity": 12,
           "levelCapacityBump": 1,
-          "levelQualityBump": 0.2
+          "levelQualityBump": 0.20000000298023224
         },
         {
           "durationType": "LONG",
           "seconds": 5400,
-          "quality": 2.1,
+          "quality": 2.0999999046325684,
           "minQuality": 0,
-          "maxQuality": 3.3,
+          "maxQuality": 3.299999952316284,
           "capacity": 14,
           "levelCapacityBump": 2,
-          "levelQualityBump": 0.22
+          "levelQualityBump": 0.2199999988079071
         },
         {
           "durationType": "EPIC",
           "seconds": 14400,
-          "quality": 2.4,
+          "quality": 2.4000000953674316,
           "minQuality": 0,
-          "maxQuality": 3.6,
+          "maxQuality": 3.5999999046325684,
           "capacity": 15,
           "levelCapacityBump": 2,
           "levelQualityBump": 0.25
@@ -125,8 +123,7 @@
         5,
         15,
         25
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "BCR",
@@ -136,17 +133,17 @@
           "seconds": 5400,
           "quality": 2.5,
           "minQuality": 0,
-          "maxQuality": 3.2,
+          "maxQuality": 3.200000047683716,
           "capacity": 18,
           "levelCapacityBump": 2,
-          "levelQualityBump": 0.22
+          "levelQualityBump": 0.2199999988079071
         },
         {
           "durationType": "LONG",
           "seconds": 14400,
-          "quality": 2.7,
+          "quality": 2.700000047683716,
           "minQuality": 0,
-          "maxQuality": 3.6,
+          "maxQuality": 3.5999999046325684,
           "capacity": 20,
           "levelCapacityBump": 2,
           "levelQualityBump": 0.25
@@ -154,12 +151,12 @@
         {
           "durationType": "EPIC",
           "seconds": 28800,
-          "quality": 2.9,
+          "quality": 2.9000000953674316,
           "minQuality": 0,
-          "maxQuality": 4.2,
+          "maxQuality": 4.199999809265137,
           "capacity": 22,
           "levelCapacityBump": 3,
-          "levelQualityBump": 0.27
+          "levelQualityBump": 0.27000001072883606
         }
       ],
       "levelMissionRequirements": [
@@ -167,8 +164,7 @@
         15,
         25,
         40
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "MILLENIUM_CHICKEN",
@@ -178,7 +174,7 @@
           "seconds": 10800,
           "quality": 3,
           "minQuality": 0.5,
-          "maxQuality": 4.1,
+          "maxQuality": 4.099999904632568,
           "capacity": 10,
           "levelCapacityBump": 1,
           "levelQualityBump": 0.25
@@ -186,7 +182,7 @@
         {
           "durationType": "LONG",
           "seconds": 21600,
-          "quality": 3.3,
+          "quality": 3.299999952316284,
           "minQuality": 0.5,
           "maxQuality": 4.5,
           "capacity": 12,
@@ -198,7 +194,7 @@
           "seconds": 43200,
           "quality": 3.5,
           "minQuality": 0.5,
-          "maxQuality": 5.4,
+          "maxQuality": 5.400000095367432,
           "capacity": 14,
           "levelCapacityBump": 2,
           "levelQualityBump": 0.25
@@ -209,8 +205,7 @@
         25,
         40,
         50
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "CORELLIHEN_CORVETTE",
@@ -220,30 +215,30 @@
           "seconds": 14400,
           "quality": 3.5,
           "minQuality": 1.5,
-          "maxQuality": 4.3,
+          "maxQuality": 4.300000190734863,
           "capacity": 18,
           "levelCapacityBump": 3,
-          "levelQualityBump": 0.27
+          "levelQualityBump": 0.27000001072883606
         },
         {
           "durationType": "LONG",
           "seconds": 43200,
-          "quality": 3.8,
-          "minQuality": 1.6,
+          "quality": 3.799999952316284,
+          "minQuality": 1.600000023841858,
           "maxQuality": 5,
           "capacity": 21,
           "levelCapacityBump": 3,
-          "levelQualityBump": 0.27
+          "levelQualityBump": 0.27000001072883606
         },
         {
           "durationType": "EPIC",
           "seconds": 86400,
-          "quality": 4.1,
+          "quality": 4.099999904632568,
           "minQuality": 1.75,
-          "maxQuality": 5.9,
+          "maxQuality": 5.900000095367432,
           "capacity": 24,
           "levelCapacityBump": 4,
-          "levelQualityBump": 0.27
+          "levelQualityBump": 0.27000001072883606
         }
       ],
       "levelMissionRequirements": [
@@ -251,8 +246,7 @@
         25,
         40,
         50
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "GALEGGTICA",
@@ -262,30 +256,30 @@
           "seconds": 21600,
           "quality": 4,
           "minQuality": 2,
-          "maxQuality": 5.2,
+          "maxQuality": 5.199999809265137,
           "capacity": 27,
           "levelCapacityBump": 4,
-          "levelQualityBump": 0.28
+          "levelQualityBump": 0.2800000011920929
         },
         {
           "durationType": "LONG",
           "seconds": 57600,
-          "quality": 4.3,
-          "minQuality": 2.3,
-          "maxQuality": 6.1,
+          "quality": 4.300000190734863,
+          "minQuality": 2.299999952316284,
+          "maxQuality": 6.099999904632568,
           "capacity": 30,
           "levelCapacityBump": 5,
-          "levelQualityBump": 0.28
+          "levelQualityBump": 0.2800000011920929
         },
         {
           "durationType": "EPIC",
           "seconds": 108000,
-          "quality": 4.6,
+          "quality": 4.599999904632568,
           "minQuality": 2.5,
-          "maxQuality": 7.2,
+          "maxQuality": 7.199999809265137,
           "capacity": 35,
           "levelCapacityBump": 6,
-          "levelQualityBump": 0.28
+          "levelQualityBump": 0.2800000011920929
         }
       ],
       "levelMissionRequirements": [
@@ -294,8 +288,7 @@
         40,
         50,
         60
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "CHICKFIANT",
@@ -305,30 +298,30 @@
           "seconds": 28800,
           "quality": 5,
           "minQuality": 3,
-          "maxQuality": 7.2,
+          "maxQuality": 7.199999809265137,
           "capacity": 20,
           "levelCapacityBump": 3,
-          "levelQualityBump": 0.29
+          "levelQualityBump": 0.28999999165534973
         },
         {
           "durationType": "LONG",
           "seconds": 86400,
-          "quality": 5.6,
-          "minQuality": 3.2,
+          "quality": 5.599999904632568,
+          "minQuality": 3.200000047683716,
           "maxQuality": 8,
           "capacity": 24,
           "levelCapacityBump": 4,
-          "levelQualityBump": 0.29
+          "levelQualityBump": 0.28999999165534973
         },
         {
           "durationType": "EPIC",
           "seconds": 172800,
-          "quality": 6.3,
-          "minQuality": 3.4,
-          "maxQuality": 9.2,
+          "quality": 6.300000190734863,
+          "minQuality": 3.4000000953674316,
+          "maxQuality": 9.199999809265137,
           "capacity": 28,
           "levelCapacityBump": 5,
-          "levelQualityBump": 0.29
+          "levelQualityBump": 0.28999999165534973
         }
       ],
       "levelMissionRequirements": [
@@ -337,8 +330,7 @@
         40,
         50,
         60
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "VOYEGGER",
@@ -346,32 +338,32 @@
         {
           "durationType": "SHORT",
           "seconds": 43200,
-          "quality": 5.8,
-          "minQuality": 3.3,
+          "quality": 5.800000190734863,
+          "minQuality": 3.299999952316284,
           "maxQuality": 8.5,
           "capacity": 30,
           "levelCapacityBump": 4,
-          "levelQualityBump": 0.3
+          "levelQualityBump": 0.30000001192092896
         },
         {
           "durationType": "LONG",
           "seconds": 129600,
-          "quality": 6.4,
-          "minQuality": 3.8,
-          "maxQuality": 9.7,
+          "quality": 6.400000095367432,
+          "minQuality": 3.799999952316284,
+          "maxQuality": 9.699999809265137,
           "capacity": 35,
           "levelCapacityBump": 5,
-          "levelQualityBump": 0.3
+          "levelQualityBump": 0.30000001192092896
         },
         {
           "durationType": "EPIC",
           "seconds": 259200,
-          "quality": 7.1,
-          "minQuality": 3.9,
+          "quality": 7.099999904632568,
+          "minQuality": 3.9000000953674316,
           "maxQuality": 12,
           "capacity": 40,
           "levelCapacityBump": 6,
-          "levelQualityBump": 0.3
+          "levelQualityBump": 0.30000001192092896
         }
       ],
       "levelMissionRequirements": [
@@ -381,8 +373,7 @@
         50,
         60,
         70
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "HENERPRISE",
@@ -390,22 +381,22 @@
         {
           "durationType": "SHORT",
           "seconds": 86400,
-          "quality": 6.6,
-          "minQuality": 3.8,
+          "quality": 6.599999904632568,
+          "minQuality": 3.799999952316284,
           "maxQuality": 9.5,
           "capacity": 45,
           "levelCapacityBump": 5,
-          "levelQualityBump": 0.31
+          "levelQualityBump": 0.3100000023841858
         },
         {
           "durationType": "LONG",
           "seconds": 172800,
-          "quality": 7.3,
-          "minQuality": 4.1,
+          "quality": 7.300000190734863,
+          "minQuality": 4.099999904632568,
           "maxQuality": 11.5,
           "capacity": 50,
           "levelCapacityBump": 6,
-          "levelQualityBump": 0.31
+          "levelQualityBump": 0.3100000023841858
         },
         {
           "durationType": "EPIC",
@@ -415,7 +406,7 @@
           "maxQuality": 14,
           "capacity": 56,
           "levelCapacityBump": 7,
-          "levelQualityBump": 0.31
+          "levelQualityBump": 0.3100000023841858
         }
       ],
       "levelMissionRequirements": [
@@ -427,8 +418,7 @@
         70,
         80,
         100
-      ],
-      "capacityDEPRECATED": 0
+      ]
     },
     {
       "ship": "ATREGGIES",
@@ -436,32 +426,32 @@
         {
           "durationType": "SHORT",
           "seconds": 172800,
-          "quality": 6.7,
-          "minQuality": 3.2,
+          "quality": 6.699999809265137,
+          "minQuality": 3.200000047683716,
           "maxQuality": 9.5,
           "capacity": 60,
           "levelCapacityBump": 7,
-          "levelQualityBump": 0.31
+          "levelQualityBump": 0.3100000023841858
         },
         {
           "durationType": "LONG",
           "seconds": 259200,
-          "quality": 7.4,
+          "quality": 7.400000095367432,
           "minQuality": 4,
           "maxQuality": 11.5,
           "capacity": 78,
           "levelCapacityBump": 8,
-          "levelQualityBump": 0.31
+          "levelQualityBump": 0.3100000023841858
         },
         {
           "durationType": "EPIC",
           "seconds": 345600,
-          "quality": 8.1,
+          "quality": 8.100000381469727,
           "minQuality": 4,
           "maxQuality": 14,
           "capacity": 86,
           "levelCapacityBump": 10,
-          "levelQualityBump": 0.31
+          "levelQualityBump": 0.3100000023841858
         }
       ],
       "levelMissionRequirements": [
@@ -473,8 +463,7 @@
         200,
         300,
         500
-      ],
-      "capacityDEPRECATED": 0
+      ]
     }
   ],
   "artifactParameters": [
@@ -482,8 +471,7 @@
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 0.7,
       "oddsMultiplier": 0.9,
@@ -491,119 +479,134 @@
       "craftingPrice": 10.884288412526262,
       "craftingPriceLow": 1.0884288412526262,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 2.4,
+      "baseQuality": 3.4,
       "oddsMultiplier": 0.9,
-      "value": 1761.019978227228,
-      "craftingPrice": 47.913865687063435,
-      "craftingPriceLow": 4.7913865687063435,
+      "value": 5316.895747425241,
+      "craftingPrice": 553.06362134269,
+      "craftingPriceLow": 55.306362134269,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 273
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
-      "baseQuality": 2.4,
+      "baseQuality": 3.4,
       "oddsMultiplier": 0.03,
-      "value": 9533.573023546802,
-      "craftingPrice": 164.57493587807534,
-      "craftingPriceLow": 16.457493587807534,
+      "value": 29009.906728304657,
+      "craftingPrice": 2224.071894953307,
+      "craftingPriceLow": 222.40718949533073,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 273
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 5.2,
+      "baseQuality": 6.5,
       "oddsMultiplier": 0.9,
-      "value": 20635.543530214734,
-      "craftingPrice": 4749.2332108829305,
-      "craftingPriceLow": 474.92332108829305,
+      "value": 42117.18655389979,
+      "craftingPrice": 12234.403014763031,
+      "craftingPriceLow": 1223.4403014763031,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 13972
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
-      "baseQuality": 5.2,
+      "baseQuality": 6.5,
       "oddsMultiplier": 0.045000000000000005,
-      "value": 92198.15277355726,
-      "craftingPrice": 17593.435333745667,
-      "craftingPriceLow": 1759.3435333745667,
+      "value": 188266.98091224505,
+      "craftingPrice": 45364.80537445132,
+      "craftingPriceLow": 4536.4805374451325,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 13972
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 8.1,
+      "baseQuality": 11.1,
       "oddsMultiplier": 0.9,
-      "value": 85144.84138859452,
-      "craftingPrice": 28986.362701660517,
-      "craftingPriceLow": 2898.636270166052,
+      "value": 233323.6777587343,
+      "craftingPrice": 91819.47585371402,
+      "craftingPriceLow": 9181.947585371401,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 210070
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
-      "baseQuality": 8.1,
+      "baseQuality": 11.1,
       "oddsMultiplier": 0.03,
-      "value": 466245.57219795085,
-      "craftingPrice": 118146.71134350491,
-      "craftingPriceLow": 11814.671134350492,
+      "value": 1277854.4844458757,
+      "craftingPrice": 374317.488458762,
+      "craftingPriceLow": 37431.7488458762,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 210070
     },
     {
       "spec": {
         "name": "LUNAR_TOTEM",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
-      "baseQuality": 8.1,
+      "baseQuality": 11.1,
       "oddsMultiplier": 0.0036000000000000003,
-      "value": 1345887.8643011414,
-      "craftingPrice": 173728.14778686856,
-      "craftingPriceLow": 17372.814778686858,
+      "value": 3688800.984116335,
+      "craftingPrice": 550423.1853538837,
+      "craftingPriceLow": 55042.31853538837,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 210070
+    },
+    {
+      "spec": {
+        "name": "LUNAR_TOTEM",
+        "level": "GREATER",
+        "rarity": "LEGENDARY"
+      },
+      "baseQuality": 11.1,
+      "oddsMultiplier": 0.0006,
+      "value": 9035643.936517887,
+      "craftingPrice": 699243.8600528153,
+      "craftingPriceLow": 69924.38600528153,
+      "craftingPriceDomain": 300,
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 210070
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3,
       "oddsMultiplier": 0.9,
@@ -611,14 +614,14 @@
       "craftingPrice": 252.84770529002446,
       "craftingPriceLow": 25.284770529002447,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 106
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5,
       "oddsMultiplier": 0.9,
@@ -626,14 +629,14 @@
       "craftingPrice": 3982.3340851195303,
       "craftingPriceLow": 398.23340851195303,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3236
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 5,
       "oddsMultiplier": 0.075,
@@ -641,14 +644,14 @@
       "craftingPrice": 12912.343112462666,
       "craftingPriceLow": 1291.2343112462668,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3236
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7,
       "oddsMultiplier": 0.9,
@@ -656,14 +659,14 @@
       "craftingPrice": 16466.27574895902,
       "craftingPriceLow": 1646.627574895902,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 20703
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 7,
       "oddsMultiplier": 0.006,
@@ -671,14 +674,14 @@
       "craftingPrice": 91063.11081687585,
       "craftingPriceLow": 9106.311081687585,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 20703
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.9,
@@ -686,14 +689,14 @@
       "craftingPrice": 58753.38978017112,
       "craftingPriceLow": 5875.338978017113,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.022500000000000003,
@@ -701,14 +704,14 @@
       "craftingPrice": 254795.56837754766,
       "craftingPriceLow": 25479.556837754768,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.0045000000000000005,
@@ -716,14 +719,14 @@
       "craftingPrice": 340327.69773973676,
       "craftingPriceLow": 34032.769773973676,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "NEODYMIUM_MEDALLION",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.0009000000000000001,
@@ -731,14 +734,14 @@
       "craftingPrice": 425859.8271019259,
       "craftingPriceLow": 42585.98271019259,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.5,
       "oddsMultiplier": 0.9,
@@ -746,14 +749,14 @@
       "craftingPrice": 654.6462527316444,
       "craftingPriceLow": 65.46462527316444,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 335
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.5,
       "oddsMultiplier": 0.9,
@@ -761,14 +764,14 @@
       "craftingPrice": 6075.3342215176235,
       "craftingPriceLow": 607.5334221517624,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 5586
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.7,
       "oddsMultiplier": 0.9,
@@ -776,14 +779,14 @@
       "craftingPrice": 23885.78713820905,
       "craftingPriceLow": 2388.578713820905,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 33987
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 7.7,
       "oddsMultiplier": 0.08181818181818182,
@@ -791,14 +794,14 @@
       "craftingPrice": 75680.32503065384,
       "craftingPriceLow": 7568.032503065384,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 33987
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 10.9,
       "oddsMultiplier": 0.9,
@@ -806,14 +809,14 @@
       "craftingPrice": 86083.09692165616,
       "craftingPriceLow": 8608.309692165616,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 192350
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 10.9,
       "oddsMultiplier": 0.018000000000000002,
@@ -821,14 +824,14 @@
       "craftingPrice": 390707.63392673945,
       "craftingPriceLow": 39070.76339267394,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 192350
     },
     {
       "spec": {
         "name": "BEAK_OF_MIDAS",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 10.9,
       "oddsMultiplier": 0.0006,
@@ -836,14 +839,14 @@
       "craftingPrice": 655554.7925999137,
       "craftingPriceLow": 65555.47925999136,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 192350
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.2,
       "oddsMultiplier": 0.9,
@@ -851,14 +854,14 @@
       "craftingPrice": 30365.963161253043,
       "craftingPriceLow": 3036.5963161253044,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 46885
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 10.2,
       "oddsMultiplier": 0.9,
@@ -866,14 +869,14 @@
       "craftingPrice": 67892.95266783626,
       "craftingPriceLow": 6789.295266783626,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 139175
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 10.2,
       "oddsMultiplier": 0.06,
@@ -881,14 +884,14 @@
       "craftingPrice": 234201.08564302573,
       "craftingPriceLow": 23420.108564302573,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 139175
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.2,
       "oddsMultiplier": 0.9,
@@ -896,14 +899,14 @@
       "craftingPrice": 168121.51742510966,
       "craftingPriceLow": 16812.151742510967,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 481723
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 13.2,
       "oddsMultiplier": 0.09000000000000001,
@@ -911,14 +914,14 @@
       "craftingPrice": 518315.9277558416,
       "craftingPriceLow": 51831.59277558416,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 481723
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 16.1,
       "oddsMultiplier": 0.9,
@@ -926,14 +929,14 @@
       "craftingPrice": 330068.88139860204,
       "craftingPriceLow": 33006.8881398602,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1224134
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 16.1,
       "oddsMultiplier": 0.009000000000000001,
@@ -941,14 +944,14 @@
       "craftingPrice": 1705165.3306623492,
       "craftingPriceLow": 170516.53306623493,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1224134
     },
     {
       "spec": {
         "name": "LIGHT_OF_EGGENDIL",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 16.1,
       "oddsMultiplier": 0.0009000000000000001,
@@ -956,14 +959,14 @@
       "craftingPrice": 2392713.5552942227,
       "craftingPriceLow": 239271.3555294223,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1224134
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 1.2,
       "oddsMultiplier": 0.9,
@@ -971,14 +974,14 @@
       "craftingPrice": 10.884288412526262,
       "craftingPriceLow": 1.0884288412526262,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.2,
       "oddsMultiplier": 0.9,
@@ -986,14 +989,14 @@
       "craftingPrice": 383.0591740345165,
       "craftingPriceLow": 38.30591740345165,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 175
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 3.2,
       "oddsMultiplier": 0.03,
@@ -1001,14 +1004,14 @@
       "craftingPrice": 1530.9632903454944,
       "craftingPriceLow": 153.09632903454946,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 175
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.8,
       "oddsMultiplier": 0.9,
@@ -1016,14 +1019,14 @@
       "craftingPrice": 7628.255209965302,
       "craftingPriceLow": 762.8255209965303,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 7514
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 5.8,
       "oddsMultiplier": 0.045000000000000005,
@@ -1031,14 +1034,14 @@
       "craftingPrice": 28275.141612526757,
       "craftingPriceLow": 2827.514161252676,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 7514
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 5.8,
       "oddsMultiplier": 0.009000000000000001,
@@ -1046,14 +1049,14 @@
       "craftingPrice": 39367.54864881382,
       "craftingPriceLow": 3936.754864881382,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 7514
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.9,
       "oddsMultiplier": 0.9,
@@ -1061,14 +1064,14 @@
       "craftingPrice": 41267.36017482524,
       "craftingPriceLow": 4126.736017482524,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 70868
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 8.9,
       "oddsMultiplier": 0.022500000000000003,
@@ -1076,14 +1079,14 @@
       "craftingPrice": 178954.0480237371,
       "craftingPriceLow": 17895.40480237371,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 70868
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 8.9,
       "oddsMultiplier": 0.0064285714285714285,
@@ -1091,14 +1094,14 @@
       "craftingPrice": 225713.175270233,
       "craftingPriceLow": 22571.317527023304,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 70868
     },
     {
       "spec": {
         "name": "DEMETERS_NECKLACE",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 8.9,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1106,14 +1109,14 @@
       "craftingPrice": 299097.9444117777,
       "craftingPriceLow": 29909.79444117777,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 70868
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 1.75,
       "oddsMultiplier": 0.9,
@@ -1121,14 +1124,14 @@
       "craftingPrice": 10.884288412526262,
       "craftingPriceLow": 1.0884288412526262,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.8,
       "oddsMultiplier": 0.9,
@@ -1136,14 +1139,14 @@
       "craftingPrice": 3302.9795121962293,
       "craftingPriceLow": 330.297951219623,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2546
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 4.8,
       "oddsMultiplier": 0.09000000000000001,
@@ -1151,14 +1154,14 @@
       "craftingPrice": 10162.610762734788,
       "craftingPriceLow": 1016.2610762734789,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2546
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.9,
       "oddsMultiplier": 0.9,
@@ -1166,14 +1169,14 @@
       "craftingPrice": 26353.836097569845,
       "craftingPriceLow": 2635.3836097569847,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 38768
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 7.9,
       "oddsMultiplier": 0.009000000000000001,
@@ -1181,14 +1184,14 @@
       "craftingPrice": 136107.93610618685,
       "craftingPriceLow": 13610.793610618686,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 38768
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.9,
@@ -1196,14 +1199,14 @@
       "craftingPrice": 139253.5905900352,
       "craftingPriceLow": 13925.35905900352,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 371742
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.022500000000000003,
@@ -1211,14 +1214,14 @@
       "craftingPrice": 603946.1620801127,
       "craftingPriceLow": 60394.61620801128,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 371742
     },
     {
       "spec": {
         "name": "VIAL_MARTIAN_DUST",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1226,14 +1229,14 @@
       "craftingPrice": 1009431.81238975,
       "craftingPriceLow": 100943.18123897501,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 371742
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 2.5,
       "oddsMultiplier": 0.9,
@@ -1241,14 +1244,14 @@
       "craftingPrice": 66.59445840168073,
       "craftingPriceLow": 6.659445840168073,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 23
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.3,
       "oddsMultiplier": 0.9,
@@ -1256,14 +1259,14 @@
       "craftingPrice": 5167.170021853153,
       "craftingPriceLow": 516.7170021853153,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4528
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "LESSER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 5.3,
       "oddsMultiplier": 0.009000000000000001,
@@ -1271,14 +1274,14 @@
       "craftingPrice": 26653.052041599185,
       "craftingPriceLow": 2665.3052041599185,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4528
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.1,
       "oddsMultiplier": 0.9,
@@ -1286,14 +1289,14 @@
       "craftingPrice": 28986.362701660517,
       "craftingPriceLow": 2898.636270166052,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 44048
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 8.1,
       "oddsMultiplier": 0.09000000000000001,
@@ -1301,14 +1304,14 @@
       "craftingPrice": 89347.24936344361,
       "craftingPriceLow": 8934.72493634436,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 44048
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.1,
       "oddsMultiplier": 0.9,
@@ -1316,14 +1319,14 @@
       "craftingPrice": 163774.02398097588,
       "craftingPriceLow": 16377.402398097589,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 464653
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 13.1,
       "oddsMultiplier": 0.006,
@@ -1331,14 +1334,14 @@
       "craftingPrice": 906121.6895966304,
       "craftingPriceLow": 90612.16895966305,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 464653
     },
     {
       "spec": {
         "name": "ORNATE_GUSSET",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 13.1,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1346,14 +1349,14 @@
       "craftingPrice": 1187188.3626854073,
       "craftingPriceLow": 118718.83626854073,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 464653
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.5,
       "oddsMultiplier": 0.9,
@@ -1361,14 +1364,14 @@
       "craftingPrice": 2436.48740397206,
       "craftingPriceLow": 243.64874039720598,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1727
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6,
       "oddsMultiplier": 0.9,
@@ -1376,14 +1379,14 @@
       "craftingPrice": 8798.389851840679,
       "craftingPriceLow": 879.838985184068,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 9057
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "LESSER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 6,
       "oddsMultiplier": 0.011250000000000001,
@@ -1391,14 +1394,14 @@
       "craftingPrice": 43638.569016142304,
       "craftingPriceLow": 4363.856901614231,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 9057
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.2,
       "oddsMultiplier": 0.9,
@@ -1406,14 +1409,14 @@
       "craftingPrice": 30365.963161253043,
       "craftingPriceLow": 3036.5963161253044,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 46885
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 8.2,
       "oddsMultiplier": 0.09000000000000001,
@@ -1421,14 +1424,14 @@
       "craftingPrice": 93600.70627760199,
       "craftingPriceLow": 9360.070627760198,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 46885
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 8.2,
       "oddsMultiplier": 0.009000000000000001,
@@ -1436,14 +1439,14 @@
       "craftingPrice": 156835.44939395096,
       "craftingPriceLow": 15683.544939395097,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 46885
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.9,
@@ -1451,14 +1454,14 @@
       "craftingPrice": 139253.5905900352,
       "craftingPriceLow": 13925.35905900352,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 371742
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.006,
@@ -1466,14 +1469,14 @@
       "craftingPrice": 770449.3313496936,
       "craftingPriceLow": 77044.93313496937,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 371742
     },
     {
       "spec": {
         "name": "THE_CHALICE",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1481,14 +1484,14 @@
       "craftingPrice": 1009431.81238975,
       "craftingPriceLow": 100943.18123897501,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 371742
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8,
       "oddsMultiplier": 0.9,
@@ -1496,14 +1499,14 @@
       "craftingPrice": 27649.208085869246,
       "craftingPriceLow": 2764.920808586925,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 41344
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 10.3,
       "oddsMultiplier": 0.45,
@@ -1511,14 +1514,14 @@
       "craftingPrice": 114405.16112254915,
       "craftingPriceLow": 11440.516112254916,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 237510
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.3,
       "oddsMultiplier": 0.27,
@@ -1526,14 +1529,14 @@
       "craftingPrice": 360472.9141829376,
       "craftingPriceLow": 36047.29141829376,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1043048
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 13.3,
       "oddsMultiplier": 0.0027,
@@ -1541,14 +1544,14 @@
       "craftingPrice": 1079292.0864457446,
       "craftingPriceLow": 107929.20864457446,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1043048
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 16.8,
       "oddsMultiplier": 0.18000000000000002,
@@ -1556,14 +1559,14 @@
       "craftingPrice": 934701.7962797529,
       "craftingPriceLow": 93470.17962797529,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3663626
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 16.8,
       "oddsMultiplier": 0.0012000000000000001,
@@ -1571,14 +1574,14 @@
       "craftingPrice": 2659838.975924153,
       "craftingPriceLow": 265983.8975924153,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3663626
     },
     {
       "spec": {
         "name": "BOOK_OF_BASAN",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 16.8,
       "oddsMultiplier": 0.00018,
@@ -1586,14 +1589,14 @@
       "craftingPrice": 3313008.090832436,
       "craftingPriceLow": 331300.8090832436,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3663626
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5,
       "oddsMultiplier": 0.9,
@@ -1601,14 +1604,14 @@
       "craftingPrice": 3982.3340851195303,
       "craftingPriceLow": 398.23340851195303,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3236
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7,
       "oddsMultiplier": 0.9,
@@ -1616,14 +1619,14 @@
       "craftingPrice": 16466.27574895902,
       "craftingPriceLow": 1646.627574895902,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 20703
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 9.4,
       "oddsMultiplier": 0.9,
@@ -1631,14 +1634,14 @@
       "craftingPrice": 50473.35522948144,
       "craftingPriceLow": 5047.335522948145,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 93053
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 9.4,
       "oddsMultiplier": 0.09000000000000001,
@@ -1646,14 +1649,14 @@
       "craftingPrice": 155593.96325546651,
       "craftingPriceLow": 15559.396325546651,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 93053
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 14.6,
       "oddsMultiplier": 0.9,
@@ -1661,14 +1664,14 @@
       "craftingPrice": 237296.52599969838,
       "craftingPriceLow": 23729.65259996984,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 775063
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 14.6,
       "oddsMultiplier": 0.022500000000000003,
@@ -1676,14 +1679,14 @@
       "craftingPrice": 1029184.2206469376,
       "craftingPriceLow": 102918.42206469376,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 775063
     },
     {
       "spec": {
         "name": "PHOENIX_FEATHER",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 14.6,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1691,14 +1694,14 @@
       "craftingPrice": 1720176.7532079872,
       "craftingPriceLow": 172017.67532079873,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 775063
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 2,
       "oddsMultiplier": 0.9,
@@ -1706,14 +1709,14 @@
       "craftingPrice": 12.984473392276133,
       "craftingPriceLow": 1.2984473392276135,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5,
       "oddsMultiplier": 0.9,
@@ -1721,14 +1724,14 @@
       "craftingPrice": 3982.3340851195303,
       "craftingPriceLow": 398.23340851195303,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3236
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 5,
       "oddsMultiplier": 0.036000000000000004,
@@ -1736,14 +1739,14 @@
       "craftingPrice": 15550.008136948381,
       "craftingPriceLow": 1555.0008136948381,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3236
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.8,
       "oddsMultiplier": 0.9,
@@ -1751,14 +1754,14 @@
       "craftingPrice": 25099.583520452903,
       "craftingPriceLow": 2509.9583520452907,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 36318
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 7.8,
       "oddsMultiplier": 0.09000000000000001,
@@ -1766,14 +1769,14 @@
       "craftingPrice": 77363.89021974104,
       "craftingPriceLow": 7736.389021974104,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 36318
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "NORMAL",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 7.8,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1781,14 +1784,14 @@
       "craftingPrice": 181892.5036183173,
       "craftingPriceLow": 18189.25036183173,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 36318
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 11.7,
       "oddsMultiplier": 0.9,
@@ -1796,14 +1799,14 @@
       "craftingPrice": 110546.05156578263,
       "craftingPriceLow": 11054.605156578264,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 270812
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 11.7,
       "oddsMultiplier": 0.022500000000000003,
@@ -1811,14 +1814,14 @@
       "craftingPrice": 479433.9969771763,
       "craftingPriceLow": 47943.39969771763,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 270812
     },
     {
       "spec": {
         "name": "TUNGSTEN_ANKH",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 11.7,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1826,14 +1829,14 @@
       "craftingPrice": 801321.5794639963,
       "craftingPriceLow": 80132.15794639965,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 270812
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 1.9,
       "oddsMultiplier": 0.9,
@@ -1841,14 +1844,14 @@
       "craftingPrice": 10.884288412526262,
       "craftingPriceLow": 1.0884288412526262,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 3
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.9,
       "oddsMultiplier": 0.9,
@@ -1856,14 +1859,14 @@
       "craftingPrice": 1186.987877072454,
       "craftingPriceLow": 118.6987877072454,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 699
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.7,
       "oddsMultiplier": 0.9,
@@ -1871,14 +1874,14 @@
       "craftingPrice": 13827.006445722829,
       "craftingPriceLow": 1382.700644572283,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 16424
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 6.7,
       "oddsMultiplier": 0.09000000000000001,
@@ -1886,14 +1889,14 @@
       "craftingPrice": 42609.3201081484,
       "craftingPriceLow": 4260.93201081484,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 16424
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 6.7,
       "oddsMultiplier": 0.009000000000000001,
@@ -1901,14 +1904,14 @@
       "craftingPrice": 71391.63377057397,
       "craftingPriceLow": 7139.163377057397,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 16424
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.9,
@@ -1916,14 +1919,14 @@
       "craftingPrice": 58753.38978017112,
       "craftingPriceLow": 5875.338978017113,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.022500000000000003,
@@ -1931,14 +1934,14 @@
       "craftingPrice": 254795.56837754766,
       "craftingPriceLow": 25479.556837754768,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.005,
@@ -1946,14 +1949,14 @@
       "craftingPrice": 334728.4079595657,
       "craftingPriceLow": 33472.840795956574,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "AURELIAN_BROOCH",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 9.8,
       "oddsMultiplier": 0.0009000000000000001,
@@ -1961,14 +1964,14 @@
       "craftingPrice": 425859.8271019259,
       "craftingPriceLow": 42585.98271019259,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 114342
     },
     {
       "spec": {
         "name": "CARVED_RAINSTICK",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.2,
       "oddsMultiplier": 0.9,
@@ -1976,14 +1979,14 @@
       "craftingPrice": 1737.1258057153536,
       "craftingPriceLow": 173.71258057153537,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1126
     },
     {
       "spec": {
         "name": "CARVED_RAINSTICK",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.2,
       "oddsMultiplier": 0.9,
@@ -1991,14 +1994,14 @@
       "craftingPrice": 10082.597698931942,
       "craftingPriceLow": 1008.2597698931943,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 10830
     },
     {
       "spec": {
         "name": "CARVED_RAINSTICK",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.8,
       "oddsMultiplier": 0.9,
@@ -2006,14 +2009,14 @@
       "craftingPrice": 39572.06875196083,
       "craftingPriceLow": 3957.2068751960833,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 66967
     },
     {
       "spec": {
         "name": "CARVED_RAINSTICK",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.2,
       "oddsMultiplier": 0.9,
@@ -2021,14 +2024,14 @@
       "craftingPrice": 168121.51742510966,
       "craftingPriceLow": 16812.151742510967,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 481723
     },
     {
       "spec": {
         "name": "CARVED_RAINSTICK",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 13.2,
       "oddsMultiplier": 0.005294117647058823,
@@ -2036,14 +2039,14 @@
       "craftingPrice": 949212.2622199913,
       "craftingPriceLow": 94921.22622199914,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 481723
     },
     {
       "spec": {
         "name": "CARVED_RAINSTICK",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 13.2,
       "oddsMultiplier": 0.0009000000000000001,
@@ -2051,14 +2054,14 @@
       "craftingPrice": 1218704.7484173055,
       "craftingPriceLow": 121870.47484173055,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 481723
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 0.5,
       "oddsMultiplier": 0.9,
@@ -2066,14 +2069,14 @@
       "craftingPrice": 10.884288412526262,
       "craftingPriceLow": 1.0884288412526262,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 2.6,
       "oddsMultiplier": 0.9,
@@ -2081,14 +2084,14 @@
       "craftingPrice": 90.58078159145558,
       "craftingPriceLow": 9.058078159145557,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 32
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "LESSER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 2.6,
       "oddsMultiplier": 0.011250000000000001,
@@ -2096,14 +2099,14 @@
       "craftingPrice": 410.0305232591817,
       "craftingPriceLow": 41.00305232591817,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 32
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.8,
       "oddsMultiplier": 0.9,
@@ -2111,14 +2114,14 @@
       "craftingPrice": 14672.71777625263,
       "craftingPriceLow": 1467.271777625263,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 17767
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 6.8,
       "oddsMultiplier": 0.09000000000000001,
@@ -2126,14 +2129,14 @@
       "craftingPrice": 45216.73929332794,
       "craftingPriceLow": 4521.673929332795,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 17767
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 11.1,
       "oddsMultiplier": 0.7200000000000001,
@@ -2141,14 +2144,14 @@
       "craftingPrice": 110353.42219619015,
       "craftingPriceLow": 11035.342219619015,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 252473
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 11.1,
       "oddsMultiplier": 0.014400000000000001,
@@ -2156,14 +2159,14 @@
       "craftingPrice": 435279.79379024333,
       "craftingPriceLow": 43527.979379024335,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 252473
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 11.1,
       "oddsMultiplier": 0.004235294117647059,
@@ -2171,14 +2174,14 @@
       "craftingPrice": 536924.6231000856,
       "craftingPriceLow": 53692.46231000857,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 252473
     },
     {
       "spec": {
         "name": "PUZZLE_CUBE",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 11.1,
       "oddsMultiplier": 0.00072,
@@ -2186,14 +2189,14 @@
       "craftingPrice": 684100.5232600003,
       "craftingPriceLow": 68410.05232600003,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 252473
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.3,
       "oddsMultiplier": 0.9,
@@ -2201,14 +2204,14 @@
       "craftingPrice": 5167.170021853153,
       "craftingPriceLow": 516.7170021853153,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4528
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.2,
       "oddsMultiplier": 0.9,
@@ -2216,14 +2219,14 @@
       "craftingPrice": 18400.435579257086,
       "craftingPriceLow": 1840.0435579257087,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 23997
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 7.2,
       "oddsMultiplier": 0.06,
@@ -2231,14 +2234,14 @@
       "craftingPrice": 63455.62080009511,
       "craftingPriceLow": 6345.562080009511,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 23997
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 10.2,
       "oddsMultiplier": 0.9,
@@ -2246,14 +2249,14 @@
       "craftingPrice": 67892.95266783626,
       "craftingPriceLow": 6789.295266783626,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 139175
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 10.2,
       "oddsMultiplier": 0.09000000000000001,
@@ -2261,14 +2264,14 @@
       "craftingPrice": 209300.4596913331,
       "craftingPriceLow": 20930.04596913331,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 139175
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "NORMAL",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 10.2,
       "oddsMultiplier": 0.011250000000000001,
@@ -2276,14 +2279,14 @@
       "craftingPrice": 337004.163369746,
       "craftingPriceLow": 33700.4163369746,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 139175
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 14.5,
       "oddsMultiplier": 0.63,
@@ -2291,14 +2294,14 @@
       "craftingPrice": 306621.05881638423,
       "craftingPriceLow": 30662.105881638425,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 992590
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 14.5,
       "oddsMultiplier": 0.01909090909090909,
@@ -2306,14 +2309,14 @@
       "craftingPrice": 1039891.8413708396,
       "craftingPriceLow": 103989.18413708397,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 992590
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 14.5,
       "oddsMultiplier": 0.0039375,
@@ -2321,14 +2324,14 @@
       "craftingPrice": 1370962.1505129095,
       "craftingPriceLow": 137096.21505129096,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 992590
     },
     {
       "spec": {
         "name": "QUANTUM_METRONOME",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 14.5,
       "oddsMultiplier": 0.00063,
@@ -2336,14 +2339,14 @@
       "craftingPrice": 1755282.3386991795,
       "craftingPriceLow": 175528.23386991795,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 992590
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.2,
       "oddsMultiplier": 0.9,
@@ -2351,14 +2354,14 @@
       "craftingPrice": 10082.597698931942,
       "craftingPriceLow": 1008.2597698931943,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 10830
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.6,
       "oddsMultiplier": 0.9,
@@ -2366,14 +2369,14 @@
       "craftingPrice": 36322.08776382367,
       "craftingPriceLow": 3632.2087763823674,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 59659
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 11.8,
       "oddsMultiplier": 0.9,
@@ -2381,14 +2384,14 @@
       "craftingPrice": 113895.40446427745,
       "craftingPriceLow": 11389.540446427745,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 282119
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 11.8,
       "oddsMultiplier": 0.09000000000000001,
@@ -2396,14 +2399,14 @@
       "craftingPrice": 351130.97685396334,
       "craftingPriceLow": 35113.09768539634,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 282119
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.45,
@@ -2411,14 +2414,14 @@
       "craftingPrice": 442510.33730818,
       "craftingPriceLow": 44251.033730818,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1522971
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.0045000000000000005,
@@ -2426,14 +2429,14 @@
       "craftingPrice": 1575554.896943225,
       "craftingPriceLow": 157555.48969432252,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1522971
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.0011250000000000001,
@@ -2441,14 +2444,14 @@
       "craftingPrice": 1916635.2958172602,
       "craftingPriceLow": 191663.52958172603,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1522971
     },
     {
       "spec": {
         "name": "SHIP_IN_A_BOTTLE",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.000375,
@@ -2456,14 +2459,14 @@
       "craftingPrice": 2186935.1167904404,
       "craftingPriceLow": 218693.51167904405,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1522971
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.25,
       "oddsMultiplier": 0.63,
@@ -2471,14 +2474,14 @@
       "craftingPrice": 25004.06272054376,
       "craftingPriceLow": 2500.406272054376,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 32903
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 9.25,
       "oddsMultiplier": 0.45,
@@ -2486,14 +2489,14 @@
       "craftingPrice": 77412.17339000841,
       "craftingPriceLow": 7741.217339000841,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 139767
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13,
       "oddsMultiplier": 0.45,
@@ -2501,14 +2504,14 @@
       "craftingPrice": 259516.13593495343,
       "craftingPriceLow": 25951.613593495345,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 728996
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 13,
       "oddsMultiplier": 0.045000000000000005,
@@ -2516,14 +2519,14 @@
       "craftingPrice": 591755.4482275364,
       "craftingPriceLow": 59175.54482275364,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 728996
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 17,
       "oddsMultiplier": 0.09000000000000001,
@@ -2531,14 +2534,14 @@
       "craftingPrice": 1220591.9609198547,
       "craftingPriceLow": 122059.19609198548,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4858320
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 17,
       "oddsMultiplier": 0.00075,
@@ -2546,14 +2549,14 @@
       "craftingPrice": 2935268.9922836637,
       "craftingPriceLow": 293526.8992283664,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4858320
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 17,
       "oddsMultiplier": 0.00018,
@@ -2561,14 +2564,14 @@
       "craftingPrice": 3446401.703852121,
       "craftingPriceLow": 344640.1703852121,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4858320
     },
     {
       "spec": {
         "name": "TACHYON_DEFLECTOR",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 17,
       "oddsMultiplier": 0.00007500000000000001,
@@ -2576,14 +2579,14 @@
       "craftingPrice": 3759957.573244698,
       "craftingPriceLow": 375995.7573244698,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4858320
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.32,
       "oddsMultiplier": 0.9,
@@ -2591,14 +2594,14 @@
       "craftingPrice": 1997.9608216045747,
       "craftingPriceLow": 199.79608216045747,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1343
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.1,
       "oddsMultiplier": 0.9,
@@ -2606,14 +2609,14 @@
       "craftingPrice": 9425.903016579625,
       "craftingPriceLow": 942.5903016579625,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 9913
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.7,
       "oddsMultiplier": 0.9,
@@ -2621,14 +2624,14 @@
       "craftingPrice": 37923.86568706343,
       "craftingPriceLow": 3792.386568706343,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 63232
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 8.7,
       "oddsMultiplier": 0.09000000000000001,
@@ -2636,14 +2639,14 @@
       "craftingPrice": 116902.53437675915,
       "craftingPriceLow": 11690.253437675916,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 63232
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.45,
@@ -2651,14 +2654,14 @@
       "craftingPrice": 226570.17270178822,
       "craftingPriceLow": 22657.017270178825,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 604836
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.011250000000000001,
@@ -2666,14 +2669,14 @@
       "craftingPrice": 691262.7441918658,
       "craftingPriceLow": 69126.27441918658,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 604836
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.0022500000000000003,
@@ -2681,14 +2684,14 @@
       "craftingPrice": 894005.5693466844,
       "craftingPriceLow": 89400.55693466845,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 604836
     },
     {
       "spec": {
         "name": "INTERSTELLAR_COMPASS",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 0.00045000000000000004,
@@ -2696,14 +2699,14 @@
       "craftingPrice": 1096748.394501503,
       "craftingPriceLow": 109674.83945015032,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 604836
     },
     {
       "spec": {
         "name": "DILITHIUM_MONOCLE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.45,
       "oddsMultiplier": 0.9,
@@ -2711,14 +2714,14 @@
       "craftingPrice": 5839.0495942893185,
       "craftingPriceLow": 583.9049594289319,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 5306
     },
     {
       "spec": {
         "name": "DILITHIUM_MONOCLE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.75,
       "oddsMultiplier": 0.9,
@@ -2726,14 +2729,14 @@
       "craftingPrice": 24487.66975599118,
       "craftingPriceLow": 2448.7669755991183,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 35138
     },
     {
       "spec": {
         "name": "DILITHIUM_MONOCLE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 10.7,
       "oddsMultiplier": 0.9,
@@ -2741,14 +2744,14 @@
       "craftingPrice": 80590.78159145554,
       "craftingPriceLow": 8059.078159145554,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 175798
     },
     {
       "spec": {
         "name": "DILITHIUM_MONOCLE",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.9,
@@ -2756,14 +2759,14 @@
       "craftingPrice": 271970.13787116244,
       "craftingPriceLow": 27197.013787116244,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 936029
     },
     {
       "spec": {
         "name": "DILITHIUM_MONOCLE",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.006,
@@ -2771,14 +2774,14 @@
       "craftingPrice": 1504774.31904237,
       "craftingPriceLow": 150477.431904237,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 936029
     },
     {
       "spec": {
         "name": "DILITHIUM_MONOCLE",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.0009000000000000001,
@@ -2786,14 +2789,14 @@
       "craftingPrice": 1971536.97732373,
       "craftingPriceLow": 197153.69773237302,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 936029
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.5,
       "oddsMultiplier": 0.9,
@@ -2801,14 +2804,14 @@
       "craftingPrice": 6075.3342215176235,
       "craftingPriceLow": 607.5334221517624,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 5586
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.9,
       "oddsMultiplier": 0.9,
@@ -2816,14 +2819,14 @@
       "craftingPrice": 26353.836097569845,
       "craftingPriceLow": 2635.3836097569847,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 38768
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 11,
       "oddsMultiplier": 0.9,
@@ -2831,14 +2834,14 @@
       "craftingPrice": 88920.44682929825,
       "craftingPriceLow": 8892.044682929825,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 201060
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 11,
       "oddsMultiplier": 0.09000000000000001,
@@ -2846,14 +2849,14 @@
       "craftingPrice": 274130.49059383944,
       "craftingPriceLow": 27413.049059383946,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 201060
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 14.2,
       "oddsMultiplier": 0.9,
@@ -2861,14 +2864,14 @@
       "craftingPrice": 215900.7257144192,
       "craftingPriceLow": 21590.072571441924,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 680184
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 14.2,
       "oddsMultiplier": 0.0045000000000000005,
@@ -2876,14 +2879,14 @@
       "craftingPrice": 1250728.3363683326,
       "craftingPriceLow": 125072.83363683327,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 680184
     },
     {
       "spec": {
         "name": "TITANIUM_ACTUATOR",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 14.2,
       "oddsMultiplier": 0.0009000000000000001,
@@ -2891,14 +2894,14 @@
       "craftingPrice": 1565071.678640618,
       "craftingPriceLow": 156507.1678640618,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 680184
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.3,
       "oddsMultiplier": 0.9,
@@ -2906,14 +2909,14 @@
       "craftingPrice": 462.7556672134456,
       "craftingPriceLow": 46.27556672134456,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 220
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.7,
       "oddsMultiplier": 0.9,
@@ -2921,14 +2924,14 @@
       "craftingPrice": 7084.307300210088,
       "craftingPriceLow": 708.4307300210089,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 6823
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "LESSER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 5.7,
       "oddsMultiplier": 0.09000000000000001,
@@ -2936,14 +2939,14 @@
       "craftingPrice": 21820.85189537198,
       "craftingPriceLow": 2182.085189537198,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 6823
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.2,
       "oddsMultiplier": 0.9,
@@ -2951,14 +2954,14 @@
       "craftingPrice": 30365.963161253043,
       "craftingPriceLow": 3036.5963161253044,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 46885
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "NORMAL",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 8.2,
       "oddsMultiplier": 0.09000000000000001,
@@ -2966,14 +2969,14 @@
       "craftingPrice": 93600.70627760199,
       "craftingPriceLow": 9360.070627760198,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 46885
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "GREATER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.5,
       "oddsMultiplier": 0.45,
@@ -2981,14 +2984,14 @@
       "craftingPrice": 295510.5697132079,
       "craftingPriceLow": 29551.05697132079,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 871817
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "GREATER",
-        "rarity": "RARE",
-        "egg": "INVALID_EGG"
+        "rarity": "RARE"
       },
       "baseQuality": 13.5,
       "oddsMultiplier": 0.011250000000000001,
@@ -2996,14 +2999,14 @@
       "craftingPrice": 901605.2684383809,
       "craftingPriceLow": 90160.5268438381,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 871817
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "GREATER",
-        "rarity": "EPIC",
-        "egg": "INVALID_EGG"
+        "rarity": "EPIC"
       },
       "baseQuality": 13.5,
       "oddsMultiplier": 0.0018000000000000002,
@@ -3011,14 +3014,14 @@
       "craftingPrice": 1202704.2671929123,
       "craftingPriceLow": 120270.42671929124,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 871817
     },
     {
       "spec": {
         "name": "MERCURYS_LENS",
         "level": "GREATER",
-        "rarity": "LEGENDARY",
-        "egg": "INVALID_EGG"
+        "rarity": "LEGENDARY"
       },
       "baseQuality": 13.5,
       "oddsMultiplier": 0.00045000000000000004,
@@ -3026,14 +3029,14 @@
       "craftingPrice": 1430476.8668668661,
       "craftingPriceLow": 143047.68668668662,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 871817
     },
     {
       "spec": {
         "name": "TACHYON_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.25,
       "oddsMultiplier": 0.1,
@@ -3041,14 +3044,14 @@
       "craftingPrice": 495.9365625269282,
       "craftingPriceLow": 49.593656252692824,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 93
     },
     {
       "spec": {
         "name": "TACHYON_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.85,
       "oddsMultiplier": 0.1,
@@ -3056,14 +3059,14 @@
       "craftingPrice": 18048.11950456052,
       "craftingPriceLow": 1804.811950456052,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 8825
     },
     {
       "spec": {
         "name": "TACHYON_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.85,
       "oddsMultiplier": 0.1,
@@ -3071,14 +3074,14 @@
       "craftingPrice": 236946.43179478962,
       "craftingPriceLow": 23694.643179478964,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 289070
     },
     {
       "spec": {
         "name": "DILITHIUM_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7,
       "oddsMultiplier": 0.1,
@@ -3086,14 +3089,14 @@
       "craftingPrice": 19671.158435586985,
       "craftingPriceLow": 1967.1158435586985,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 9893
     },
     {
       "spec": {
         "name": "DILITHIUM_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 10.25,
       "oddsMultiplier": 0.1,
@@ -3101,14 +3104,14 @@
       "craftingPrice": 82572.11155212428,
       "craftingPriceLow": 8257.211155212428,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 68138
     },
     {
       "spec": {
         "name": "DILITHIUM_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 16.85,
       "oddsMultiplier": 0.1,
@@ -3116,14 +3119,14 @@
       "craftingPrice": 459362.6577260761,
       "craftingPriceLow": 45936.265772607614,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 722988
     },
     {
       "spec": {
         "name": "SHELL_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 2.95,
       "oddsMultiplier": 0.1,
@@ -3131,14 +3134,14 @@
       "craftingPrice": 262.01446039016,
       "craftingPriceLow": 26.201446039016005,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 43
     },
     {
       "spec": {
         "name": "SHELL_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.85,
       "oddsMultiplier": 0.1,
@@ -3146,14 +3149,14 @@
       "craftingPrice": 18048.11950456052,
       "craftingPriceLow": 1804.811950456052,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 8825
     },
     {
       "spec": {
         "name": "SHELL_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.85,
       "oddsMultiplier": 0.1,
@@ -3161,59 +3164,59 @@
       "craftingPrice": 183125.19330979357,
       "craftingPriceLow": 18312.519330979358,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 202685
     },
     {
       "spec": {
         "name": "LUNAR_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 3.15,
+      "baseQuality": 3.5,
       "oddsMultiplier": 0.1,
-      "value": 12458.510691143001,
-      "craftingPrice": 406.73373916515897,
-      "craftingPriceLow": 40.6733739165159,
+      "value": 17443.780316316217,
+      "craftingPrice": 774.4270504936512,
+      "craftingPriceLow": 77.44270504936513,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 159
     },
     {
       "spec": {
         "name": "LUNAR_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 6.25,
+      "baseQuality": 7.25,
       "oddsMultiplier": 0.1,
-      "value": 111407.26764593276,
-      "craftingPrice": 12447.66175556308,
-      "craftingPriceLow": 1244.766175556308,
+      "value": 179119.24109794947,
+      "craftingPrice": 22587.5887665827,
+      "craftingPriceLow": 2258.75887665827,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 11890
     },
     {
       "spec": {
         "name": "LUNAR_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 12.25,
+      "baseQuality": 13.25,
       "oddsMultiplier": 0.1,
-      "value": 959504.0221296687,
-      "craftingPrice": 155125.2824260733,
-      "craftingPriceLow": 15512.528242607332,
+      "value": 1233387.7009799972,
+      "craftingPrice": 203548.77583507987,
+      "craftingPriceLow": 20354.877583507987,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 234442
     },
     {
       "spec": {
         "name": "SOUL_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.1,
       "oddsMultiplier": 0.1,
@@ -3221,14 +3224,14 @@
       "craftingPrice": 5196.192179801517,
       "craftingPriceLow": 519.6192179801518,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1733
     },
     {
       "spec": {
         "name": "SOUL_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 9.1,
       "oddsMultiplier": 0.05,
@@ -3236,14 +3239,14 @@
       "craftingPrice": 64770.66459274569,
       "craftingPriceLow": 6477.06645927457,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 45795
     },
     {
       "spec": {
         "name": "SOUL_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.1,
       "oddsMultiplier": 0.04000000000000001,
@@ -3251,14 +3254,14 @@
       "craftingPrice": 250022.00660314143,
       "craftingPriceLow": 25002.200660314145,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 283741
     },
     {
       "spec": {
         "name": "PROPHECY_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.5,
       "oddsMultiplier": 0.05,
@@ -3266,14 +3269,14 @@
       "craftingPrice": 50259.44360952514,
       "craftingPriceLow": 5025.944360952514,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 32523
     },
     {
       "spec": {
         "name": "PROPHECY_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.8,
       "oddsMultiplier": 0.03,
@@ -3281,14 +3284,14 @@
       "craftingPrice": 246536.3313467851,
       "craftingPriceLow": 24653.633134678512,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 271491
     },
     {
       "spec": {
         "name": "PROPHECY_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 17.2,
       "oddsMultiplier": 0.020000000000000004,
@@ -3296,14 +3299,14 @@
       "craftingPrice": 731674.3867735496,
       "craftingPriceLow": 73167.43867735496,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1182751
     },
     {
       "spec": {
         "name": "QUANTUM_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.5,
       "oddsMultiplier": 0.1,
@@ -3311,14 +3314,14 @@
       "craftingPrice": 7252.77796891077,
       "craftingPriceLow": 725.2777968910771,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2668
     },
     {
       "spec": {
         "name": "QUANTUM_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.45,
       "oddsMultiplier": 0.1,
@@ -3326,14 +3329,14 @@
       "craftingPrice": 25118.0955165366,
       "craftingPriceLow": 2511.80955165366,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 13697
     },
     {
       "spec": {
         "name": "QUANTUM_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.7,
       "oddsMultiplier": 0.1,
@@ -3341,14 +3344,14 @@
       "craftingPrice": 228278.68162774845,
       "craftingPriceLow": 22827.868162774845,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 274584
     },
     {
       "spec": {
         "name": "TERRA_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 5.1,
       "oddsMultiplier": 0.1,
@@ -3356,14 +3359,14 @@
       "craftingPrice": 5196.192179801517,
       "craftingPriceLow": 519.6192179801518,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1733
     },
     {
       "spec": {
         "name": "TERRA_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 7.8,
       "oddsMultiplier": 0.1,
@@ -3371,14 +3374,14 @@
       "craftingPrice": 29988.96267971526,
       "craftingPriceLow": 2998.896267971526,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 17357
     },
     {
       "spec": {
         "name": "TERRA_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 14.9,
       "oddsMultiplier": 0.1,
@@ -3386,14 +3389,14 @@
       "craftingPrice": 303837.60124653333,
       "craftingPriceLow": 30383.760124653334,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 407589
     },
     {
       "spec": {
         "name": "LIFE_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6,
       "oddsMultiplier": 0.1,
@@ -3401,14 +3404,14 @@
       "craftingPrice": 10507.145319547104,
       "craftingPriceLow": 1050.7145319547105,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 4326
     },
     {
       "spec": {
         "name": "LIFE_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 9.52,
       "oddsMultiplier": 0.1,
@@ -3416,14 +3419,14 @@
       "craftingPrice": 63177.402251645064,
       "craftingPriceLow": 6317.740225164507,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 47364
     },
     {
       "spec": {
         "name": "LIFE_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 15.2,
       "oddsMultiplier": 0.1,
@@ -3431,14 +3434,14 @@
       "craftingPrice": 325027.91192700906,
       "craftingPriceLow": 32502.791192700908,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 447455
     },
     {
       "spec": {
         "name": "CLARITY_STONE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8,
       "oddsMultiplier": 0.06999999999999999,
@@ -3446,14 +3449,14 @@
       "craftingPrice": 36603.47977819721,
       "craftingPriceLow": 3660.347977819721,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 21893
     },
     {
       "spec": {
         "name": "CLARITY_STONE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.2,
       "oddsMultiplier": 0.05,
@@ -3461,14 +3464,14 @@
       "craftingPrice": 185026.38292691755,
       "craftingPriceLow": 18502.638292691754,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 191437
     },
     {
       "spec": {
         "name": "CLARITY_STONE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 17.5,
       "oddsMultiplier": 0.020000000000000004,
@@ -3476,14 +3479,14 @@
       "craftingPrice": 774986.0513834521,
       "craftingPriceLow": 77498.60513834521,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1281227
     },
     {
       "spec": {
         "name": "TACHYON_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3,
       "oddsMultiplier": 1.06,
@@ -3491,14 +3494,14 @@
       "craftingPrice": 229.70000000000002,
       "craftingPriceLow": 22.970000000000002,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 25
     },
     {
       "spec": {
         "name": "DILITHIUM_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.1,
       "oddsMultiplier": 1.06,
@@ -3506,14 +3509,14 @@
       "craftingPrice": 1392.3999999999992,
       "craftingPriceLow": 139.23999999999992,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 219
     },
     {
       "spec": {
         "name": "SHELL_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 2,
       "oddsMultiplier": 1.06,
@@ -3521,29 +3524,29 @@
       "craftingPrice": 12.700000000000001,
       "craftingPriceLow": 1.2700000000000002,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1
     },
     {
       "spec": {
         "name": "LUNAR_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
-      "baseQuality": 1.7,
+      "baseQuality": 1.9,
       "oddsMultiplier": 1.59,
-      "value": 458.24941627194573,
+      "value": 643.4619150504349,
       "craftingPrice": 10.8,
       "craftingPriceLow": 1.08,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1
     },
     {
       "spec": {
         "name": "SOUL_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.9,
       "oddsMultiplier": 1.06,
@@ -3551,14 +3554,14 @@
       "craftingPrice": 1074.8000000000004,
       "craftingPriceLow": 107.48000000000005,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 159
     },
     {
       "spec": {
         "name": "PROPHECY_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.2,
       "oddsMultiplier": 1.06,
@@ -3566,14 +3569,14 @@
       "craftingPrice": 9122.5,
       "craftingPriceLow": 912.25,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2450
     },
     {
       "spec": {
         "name": "QUANTUM_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.8,
       "oddsMultiplier": 1.06,
@@ -3581,14 +3584,14 @@
       "craftingPrice": 936.0999999999996,
       "craftingPriceLow": 93.60999999999996,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 134
     },
     {
       "spec": {
         "name": "TERRA_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.2,
       "oddsMultiplier": 1.06,
@@ -3596,14 +3599,14 @@
       "craftingPrice": 1572.5,
       "craftingPriceLow": 157.25,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 255
     },
     {
       "spec": {
         "name": "LIFE_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 4.3,
       "oddsMultiplier": 1.06,
@@ -3611,14 +3614,14 @@
       "craftingPrice": 1767.5999999999995,
       "craftingPriceLow": 176.75999999999996,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 296
     },
     {
       "spec": {
         "name": "CLARITY_STONE_FRAGMENT",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6,
       "oddsMultiplier": 1.06,
@@ -3626,14 +3629,14 @@
       "craftingPrice": 7960.699999999999,
       "craftingPriceLow": 796.0699999999999,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2049
     },
     {
       "spec": {
         "name": "GOLD_METEORITE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 1.8,
       "oddsMultiplier": 5.25,
@@ -3641,14 +3644,14 @@
       "craftingPrice": 3.24,
       "craftingPriceLow": 0.32400000000000007,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1
     },
     {
       "spec": {
         "name": "GOLD_METEORITE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.8,
       "oddsMultiplier": 3,
@@ -3656,14 +3659,14 @@
       "craftingPrice": 3982.5299999999993,
       "craftingPriceLow": 398.25299999999993,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 483
     },
     {
       "spec": {
         "name": "GOLD_METEORITE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 11.85,
       "oddsMultiplier": 2.25,
@@ -3671,14 +3674,14 @@
       "craftingPrice": 31373.351250000007,
       "craftingPriceLow": 3137.335125000001,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 7814
     },
     {
       "spec": {
         "name": "TAU_CETI_GEODE",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 2.8,
       "oddsMultiplier": 3,
@@ -3686,14 +3689,14 @@
       "craftingPrice": 42.929999999999986,
       "craftingPriceLow": 4.292999999999998,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 2
     },
     {
       "spec": {
         "name": "TAU_CETI_GEODE",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 8.1,
       "oddsMultiplier": 1.7999999999999998,
@@ -3701,14 +3704,14 @@
       "craftingPrice": 7867.319999999998,
       "craftingPriceLow": 786.7319999999999,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 1196
     },
     {
       "spec": {
         "name": "TAU_CETI_GEODE",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 13.8,
       "oddsMultiplier": 2.25,
@@ -3716,14 +3719,14 @@
       "craftingPrice": 53149.830000000016,
       "craftingPriceLow": 5314.983000000002,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 16135
     },
     {
       "spec": {
         "name": "SOLAR_TITANIUM",
         "level": "INFERIOR",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 3.2,
       "oddsMultiplier": 3,
@@ -3731,14 +3734,14 @@
       "craftingPrice": 104.25000000000003,
       "craftingPriceLow": 10.425000000000004,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 5
     },
     {
       "spec": {
         "name": "SOLAR_TITANIUM",
         "level": "LESSER",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 6.7,
       "oddsMultiplier": 1.6500000000000001,
@@ -3746,14 +3749,14 @@
       "craftingPrice": 3753,
       "craftingPriceLow": 375.3,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 446
     },
     {
       "spec": {
         "name": "SOLAR_TITANIUM",
         "level": "NORMAL",
-        "rarity": "COMMON",
-        "egg": "INVALID_EGG"
+        "rarity": "COMMON"
       },
       "baseQuality": 12.5,
       "oddsMultiplier": 2.55,
@@ -3761,7 +3764,130 @@
       "craftingPrice": 37794.36000000001,
       "craftingPriceLow": 3779.436000000001,
       "craftingPriceDomain": 300,
-      "craftingPriceCurve": 0.2
+      "craftingPriceCurve": 0.2,
+      "craftingXp": 10090
+    }
+  ],
+  "craftingLevelInfos": [
+    {
+      "xpRequired": 500,
+      "rarityMult": 1
+    },
+    {
+      "xpRequired": 2500,
+      "rarityMult": 1.0499999523162842
+    },
+    {
+      "xpRequired": 5000,
+      "rarityMult": 1.100000023841858
+    },
+    {
+      "xpRequired": 10000,
+      "rarityMult": 1.149999976158142
+    },
+    {
+      "xpRequired": 25000,
+      "rarityMult": 1.2000000476837158
+    },
+    {
+      "xpRequired": 50000,
+      "rarityMult": 1.25
+    },
+    {
+      "xpRequired": 100000,
+      "rarityMult": 1.2999999523162842
+    },
+    {
+      "xpRequired": 250000,
+      "rarityMult": 1.350000023841858
+    },
+    {
+      "xpRequired": 500000,
+      "rarityMult": 1.399999976158142
+    },
+    {
+      "xpRequired": 1000000,
+      "rarityMult": 1.4500000476837158
+    },
+    {
+      "xpRequired": 2000000,
+      "rarityMult": 1.5
+    },
+    {
+      "xpRequired": 4000000,
+      "rarityMult": 1.5499999523162842
+    },
+    {
+      "xpRequired": 8000000,
+      "rarityMult": 1.600000023841858
+    },
+    {
+      "xpRequired": 15000000,
+      "rarityMult": 1.649999976158142
+    },
+    {
+      "xpRequired": 20000000,
+      "rarityMult": 1.7000000476837158
+    },
+    {
+      "xpRequired": 35000000,
+      "rarityMult": 1.75
+    },
+    {
+      "xpRequired": 60000000,
+      "rarityMult": 1.850000023841858
+    },
+    {
+      "xpRequired": 100000000,
+      "rarityMult": 2
+    },
+    {
+      "xpRequired": 150000000,
+      "rarityMult": 2.25
+    },
+    {
+      "xpRequired": 200000000,
+      "rarityMult": 2.5
+    },
+    {
+      "xpRequired": 250000000,
+      "rarityMult": 3
+    },
+    {
+      "xpRequired": 300000000,
+      "rarityMult": 3.5
+    },
+    {
+      "xpRequired": 325000000,
+      "rarityMult": 4
+    },
+    {
+      "xpRequired": 350000000,
+      "rarityMult": 4.5
+    },
+    {
+      "xpRequired": 400000000,
+      "rarityMult": 5
+    },
+    {
+      "xpRequired": 500000000,
+      "rarityMult": 6
+    },
+    {
+      "xpRequired": 600000000,
+      "rarityMult": 7
+    },
+    {
+      "xpRequired": 750000000,
+      "rarityMult": 8
+    },
+    {
+      "xpRequired": 1000000000,
+      "rarityMult": 9
+    },
+    {
+      "xpRequired": 1,
+      "rarityMult": 10
     }
   ]
 }

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -316,6 +316,7 @@ namespace EGG9000.Common.Services {
         }
 
         public static string GetE9KName(this Contract contract, bool toLower = true) {
+            if(contract is null) return "";
             return Regex.Replace((toLower ? contract.Name.ToLower() : contract.Name).Split(":").Last().Trim().Replace(" ", "-"), "[^a-zA-Z0-9-]", "");
         }
 

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -847,18 +847,16 @@ namespace EGG9000.Site.Controllers {
 
             if(id.Trim().All(x => x >= '0' && x <= '9')) {
                 return RedirectToAction("ViewUser", "MyFarms", new { discordId = id });
-            } else if(Regex.IsMatch(id.ToUpper(), "EI\\d{16}") && users.Any(u => u.EIDs.Contains(id))) {
-                return RedirectToAction("ViewUser", "MyFarms", new { discordId = (users.First(u => u.EIDs.Contains(id))).DiscordId });
+            } else if(Regex.IsMatch(id.ToUpper(), "EI\\d{16}") && users.Any(u => u.EIDs.Split(",").Contains(id) && u.DiscordId != default)) {
+                id = id.ToUpper();
+                var matchingEidUser = users.FirstOrDefault(u => u.EIDs.Split(",").Contains(id) && u.DiscordId != default);
+                if(matchingEidUser is null) return View(new List<DBUser>());
+                return RedirectToAction("ViewUser", "MyFarms", new { discordId = matchingEidUser.DiscordId});
             }
-
-            //var matchingUser2 = users.FirstOrDefault(x => x.DiscordUsername?.Contains(id) ?? false);
-            //if(matchingUser2 != null) {
-            //    return RedirectToAction("ViewUser", "MyFarms", new { discordId = matchingUser2.DiscordId });
-            //}
 
             id = id.ToLower().Trim();
             var matchingUsers = users.Where(x => 
-                (x.DiscordUsername ?? "").ToLower().Contains(id) || 
+                (x.DiscordUsername ?? "").ToLower().Contains(id) ||
                 (x.Usernames ?? "").ToLower().Split(",").Any(u => u.Contains(id))
             ).ToList();
 


### PR DESCRIPTION
- Ordering on CancellationToken on method to conform
- Remove code that sets Thread ID to 0, this causes weird shit on archives
- Fixed logic on `FindCoopForUser`
- Removed outdated `IAutoCompleteHandler` that was replaced with `Find Coop Spot` buttons
- Refactored `Task LLC`:
  - Embeds instead of messages
  - Ship coefficients now come from Menno's API, and are cached for 6 hours at a time
- Ported `Task MER` and `Craft` to Embeds instead of plaintext
- Updated `eiafx-config.json` to have up-to-date information, as well as new array from API
- Moved a bunch of static definitions from `ArtifactHelpers` to instead be pulled in from `eiafx-config`
- Updated Thread counts to be `975` instead of `900` for `ServerFunction.Primary`, as Discord will automatically start archiving old threads once a server has more than 970 - this should make it so that more threads are created in Main servers before the overflow servers are used.
- Fixed potential null-ref issues in SubscriptionCheck, which were throwing in bugsnag