### PR TITLE
Daveed changes

### DIFF
--- a/EGG9000.Bot/Automated/ContractUpdater.cs
+++ b/EGG9000.Bot/Automated/ContractUpdater.cs
@@ -187,7 +187,7 @@ namespace EGG9000.Bot.Automated {
                         await channel.DeleteAsync();
                     }
                     _logger.LogInformation("Deleting header channels for {contract} because the contract is expired.", guildContract.Contract.Name);
-                    await dbGuild.DeleteCoopThreadHeadersAsync(_client, guildContract.Contract);
+                    await dbGuild.DeleteCoopThreadHeadersAsync(_client, guildContract.Contract, _logger);
                     guildContract.DeletedChannel = true;
 
                     if(guildContract.Contract.MaxUsers > 1 && guildContract.GuildID == 656455567858073601 && guildContract.Created > DateTimeOffset.Now.AddMonths(-3) && !guildContract.HasScores) {

--- a/EGG9000.Bot/Automated/Coops/CoopReorder.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopReorder.cs
@@ -87,7 +87,7 @@ namespace EGG9000.Bot.Automated.Coops {
             //Wait on the Server's lock, timeout defined in DiscordHostedService
             _logger.LogInformation("Waiting on Semaphore lock for guild {guild}", guild.Name);
             var dtNow = DateTimeOffset.Now;
-            var ownershipAcquired = await guild.GetServerSemaphore().WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), cancellationToken);
+            var ownershipAcquired = await guild?.GetServerSemaphore()?.WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), cancellationToken);
             if(ownershipAcquired) {
                 _logger.LogInformation("Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.Now.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
             } else {

--- a/EGG9000.Bot/Automated/Coops/CoopReorder.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopReorder.cs
@@ -87,7 +87,7 @@ namespace EGG9000.Bot.Automated.Coops {
             //Wait on the Server's lock, timeout defined in DiscordHostedService
             _logger.LogInformation("Waiting on Semaphore lock for guild {guild}", guild.Name);
             var dtNow = DateTimeOffset.Now;
-            var ownershipAcquired = await guild?.GetServerSemaphore()?.WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), cancellationToken);
+            var ownershipAcquired = await guild.GetServerSemaphore().WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), cancellationToken);
             if(ownershipAcquired) {
                 _logger.LogInformation("Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.Now.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
             } else {

--- a/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/CoopStatusUpdater.cs
@@ -37,12 +37,6 @@ namespace EGG9000.Bot.Automated.Coops {
 #endif
         private readonly Dictionary<ulong, SocketTextChannel> _demeritChannels = [];
 
-
-        public class UserX {
-            public SocketGuildUser SocketGuildUser { get; set; }
-            public Guid DBUserId { get; set; }
-        }
-
         public async override Task Run(object state, CancellationToken cancellationToken) {
             using var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var users = (await _db.DBUsers.Where(x => x.GuildId > 0).AsQueryable().ToListAsync(CancellationToken.None)).SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList();

--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -7,6 +7,7 @@ using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
+using static EGG9000.Common.Helpers.CreateCoopsV2;
 
 using MassTransit.Initializers;
 using Microsoft.AspNetCore.Mvc;
@@ -192,13 +193,13 @@ namespace EGG9000.Bot.Automated.Coops {
             public int ChannelsLeft {
                 get {
                     if(Guild == null) return 0;
-                    return (ServerFunction == ServerFunction.Primary ? 450 : 495) - Guild.GetInUseChannelCount();
+                    return (ServerFunction == ServerFunction.Primary ? PrimaryMaxChannels : OverflowMaxChannels) - Guild.GetInUseChannelCount();
                 }
             }
             public int ThreadsLeft {
                 get {
                     if(Guild == null) return 0;
-                    return (ServerFunction == ServerFunction.Primary ? 975 : 995) - Guild.GetInUseThreadCount();
+                    return (ServerFunction == ServerFunction.Primary ? PrimaryMaxThreads : OverflowMaxThreads) - Guild.GetInUseThreadCount();
                 }
             }
 

--- a/EGG9000.Bot/Automated/LeaderboardUpdates.cs
+++ b/EGG9000.Bot/Automated/LeaderboardUpdates.cs
@@ -6,6 +6,7 @@ using EGG9000.Bot.Helpers;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Factories;
+using EGG9000.Common.Helpers;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -21,18 +22,11 @@ using static EGG9000.Common.Helpers.Prefarm;
 namespace EGG9000.Bot.Automated {
     public class LeaderboardUpdater(IServiceProvider provider) : _UpdaterBase<LeaderboardUpdater>(UpdateTime, delayedStart: TimeSpan.FromMinutes(5), provider) {
         public static readonly TimeSpan UpdateTime = TimeSpan.FromMinutes(60);
-        public static readonly List<UserX> _users;
-
-        public class UserX {
-            public SocketGuildUser SocketGuildUser { get; set; }
-            public Guid DBUserId { get; set; }
-        }
 
         private class BreakCooper {
             public LeaderboardUser User { get; set; }
             public CustomFarm Farm { get; set; }
         }
-
 
         public async override Task Run(object state, CancellationToken cancellationToken) {
             var timings = new TimingsFactory(_logger);
@@ -154,7 +148,8 @@ namespace EGG9000.Bot.Automated {
                             breakCooper.User.Account.BreakCoopWarningSent = true;
                             breakCooper.User.User.UpdateAccounts();
                         }
-                        await _db.SaveChangesAsync(CancellationToken.None);
+
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     //Handle users with suspiciously high Mystical Egg Ratios
@@ -179,7 +174,7 @@ namespace EGG9000.Bot.Automated {
                             merCheater.Account.MERWarningSent = true;
                             merCheater.User.UpdateAccounts();
                         }
-                        await _db.SaveChangesAsync(CancellationToken.None);
+                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     //Handle promotions

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -697,7 +697,7 @@ namespace EGG9000.Bot.Commands {
             }
             var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
             _logger.LogInformation("Deleting header channels for {} because the contract channel was deleted", guildContract.Contract.Name);
-            await dbGuild.DeleteCoopThreadHeadersAsync(_client, guildContract.Contract);
+            await dbGuild.DeleteCoopThreadHeadersAsync(_client, guildContract.Contract, _logger);
 
             guildContract.DeletedChannel = true;
             await db.SaveChangesAsync();

--- a/EGG9000.Bot/Jobs/SubscriptionsCheckJob.cs
+++ b/EGG9000.Bot/Jobs/SubscriptionsCheckJob.cs
@@ -64,7 +64,7 @@ namespace EGG9000.Bot.Jobs {
                 });
             }
 
-            await db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+            await db.SaveChangesAsyncRetry(retryCount: 2, cancellationToken: CancellationToken.None);
             _logger.LogInformation("Finished checking subscriptions");
         }
 

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -54,7 +54,7 @@ namespace EGG9000.Common.Services {
             if(guildContract is not null) {
                 var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
                 _logger.LogInformation("Deleting header channels for {contract} because discord report the contract channel was deleted", guildContract.Contract.Name);
-                await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract);
+                await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract, _logger);
                 guildContract.DeletedChannel = true;
                 await db.SaveChangesAsync();
                 return;

--- a/EGG9000.Common/Helpers/CreateCoopsV2.cs
+++ b/EGG9000.Common/Helpers/CreateCoopsV2.cs
@@ -14,6 +14,16 @@ using System.Threading.Tasks;
 
 namespace EGG9000.Common.Helpers {
     public class CreateCoopsV2 {
+
+        //Overflow moved from 500 -> 495 to account for any ghosting like we saw with Overflow 1
+        public const int PrimaryMaxChannels = 450;
+        public const int OverflowMaxChannels = 495;
+
+        //Leave above 970 so Discord does it's auto-pruning
+        //Overflow moved from 1000 -> 995 to account for any ghosting like we saw with Overflow 1
+        public const int PrimaryMaxThreads = 975;
+        public const int OverflowMaxThreads = 995;
+
         public static async Task<Coop> Start(List<UserByAccount> accounts, Contract contract, Ei.Contract.Types.PlayerGrade grade, SocketGuild guild, Words words, IServiceProvider provider, Guild dbguild, uint Group, bool allowAllGrades) {
             var db = provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
 

--- a/EGG9000.Common/Helpers/DBHelpers.cs
+++ b/EGG9000.Common/Helpers/DBHelpers.cs
@@ -6,17 +6,20 @@ using System.Threading.Tasks;
 namespace EGG9000.Common.Helpers {
     public static class DBHelpers {
 
+        /// <returns>
+        ///     A boolean representing whether or not the save operation was a success before the maximum number of retries was reached
+        ///     An int, representing the number of state entries written to the database, in the case of a sucess, -1 otherwise
+        /// </returns>
         public static async Task<(bool, int)> SaveChangesAsyncRetry(this ApplicationDbContext db, int retryCount = 1, CancellationToken cancellationToken = default) {
             var currentRetry = 0;
             while(true) {
                 try {
                     return (true, await db.SaveChangesAsync(cancellationToken));
                 } catch(Exception) {
+                    //If we reached max retry count, exit
+                    if(currentRetry++ > retryCount) return (false, -1);
                     //Slight delay between attempts
                     await Task.Delay(100, cancellationToken);
-                    //If we reached max retry count, exit
-                    if(currentRetry >= retryCount) return (false, currentRetry);
-                    currentRetry++;
                 }
             }
         }

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -60,22 +60,22 @@ namespace EGG9000.Common.Services {
             public Severity Severity { get; set; } = severity;
         }
 
-        public Task RestartAsync() {
+        public async Task RestartAsync() {
             if(ConnectionState != ConnectionState.Connected) {
                 throw new RestartDiscordExecption("Not connected yet - cannot restart.", Severity.Warning);
             }
 
             try {
                 //Logout subtasks
-                LogoutAsync();
-                StopAsync().Wait();
+                await LogoutAsync();
+                await StopAsync();
                 _logger.Log(LogLevel.Information, "Waiting on Discord Disconnect");
                 while(ConnectionState == ConnectionState.Connected) { }
                 _logger.Log(LogLevel.Information, "Discord Disconnected...");
 
                 //Log back in
-                LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]).Wait();
-                StartAsync().Wait();
+                await LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]);
+                await StartAsync();
                 _logger.Log(LogLevel.Information, "Waiting on Discord Connect");
                 while(ConnectionState != ConnectionState.Connected) { }
                 _logger.Log(LogLevel.Information, "Discord Ready");
@@ -83,7 +83,7 @@ namespace EGG9000.Common.Services {
                 throw new RestartDiscordExecption(ex.Message, Severity.Error);
             }
 
-            return Task.CompletedTask;
+            return;
         }
 
         //public Task StartAsync(CancellationToken cancellationToken) {
@@ -193,6 +193,12 @@ namespace EGG9000.Common.Services {
         public static List<DiscordSemahpore> GetSemaphores() {
             return _serverSemaphores;
         }
+        public static DiscordSemahpore AddSemaphore(SocketGuild guild) {
+            if(guild is null) return null;
+            if(_serverSemaphores.Any(s => s.Guild.Id == guild.Id)) return null;
+            _serverSemaphores.Add(new(guild, new(1, 1)));
+            return _serverSemaphores.First(s => s.Guild.Id == guild.Id);
+        }
         public static TimeSpan GetSemaphoreTimeout() {
             return _semaphoreTimeoutTime;
         }
@@ -205,7 +211,10 @@ namespace EGG9000.Common.Services {
     public static class DiscordExtensions {
 
         public static SemaphoreSlim GetServerSemaphore(this SocketGuild guild) {
-            return DiscordHostedService.GetSemaphores().FirstOrDefault(s => s.Guild == guild).Semaphore;
+            if(guild is null) return null;
+            var ss = DiscordHostedService.GetSemaphores().FirstOrDefault(s => s.Guild == guild);
+            ss ??= DiscordHostedService.AddSemaphore(guild);
+            return ss?.Semaphore ?? null;
         }
 
         public static List<IChannel> GetInUseChannels(this SocketGuild guild, SocketGuildChannel category = null) {
@@ -251,7 +260,7 @@ namespace EGG9000.Common.Services {
             //Wait on the Server's lock, timeout defined in DiscordHostedService
             logger.LogInformation("CreateCoopThreadHeaderAsync: Waiting on Semaphore lock for guild {guild}", guild.Name);
             var dtNow = DateTimeOffset.Now;
-            var ownershipAcquired = await guild.GetServerSemaphore().WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), CancellationToken.None);
+            var ownershipAcquired = await guild?.GetServerSemaphore()?.WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), CancellationToken.None);
             if(ownershipAcquired) {
                 logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.Now.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
             } else {
@@ -309,8 +318,13 @@ namespace EGG9000.Common.Services {
 
             foreach(var sg in guilds) {
                 var channels = sg.TextChannels.Where(c => c.Name.StartsWith(contract.GetE9KName().ToLower()) && Regex.IsMatch(c.Name, @"(-aaa|-aa|-a|-b|-c)$"));
+                
+                // Safety measure - there should never be more than 5 channels in the same guild,
+                // so if this happens, the pattern matching failed.
+                if(channels.Count() > 5) continue;
+
                 foreach(var channel in channels) {
-                    //await channel.DeleteAsync();
+                    await channel.DeleteAsync();
                 }
             }
         }

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -262,7 +262,7 @@ namespace EGG9000.Common.Services {
             //Wait on the Server's lock, timeout defined in DiscordHostedService
             logger.LogInformation("CreateCoopThreadHeaderAsync: Waiting on Semaphore lock for guild {guild}", guild.Name);
             var dtNow = DateTimeOffset.Now;
-            var ownershipAcquired = await guild?.GetServerSemaphore()?.WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), CancellationToken.None);
+            var ownershipAcquired = await guild.GetServerSemaphore().WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), CancellationToken.None);
             if(ownershipAcquired) {
                 logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.Now.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
             } else {

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -312,7 +312,7 @@ namespace EGG9000.Common.Services {
             return guild.GetChannel(channel.Id);
         }
 
-        public static async Task DeleteCoopThreadHeadersAsync(this Guild guild, DiscordSocketClient client, Contract contract) {
+        public static async Task DeleteCoopThreadHeadersAsync(this Guild guild, DiscordSocketClient client, Contract contract, ILogger logger) {
             List<SocketGuild> guilds = [
                 client.GetGuild(guild.DiscordSeverId),
                 .. guild.OverflowServers.Select(client.GetGuild).ToList()
@@ -320,16 +320,21 @@ namespace EGG9000.Common.Services {
 
             foreach(var sg in guilds) {
                 var channels = sg.TextChannels.Where(c => c.Name.StartsWith(contract.GetE9KName().ToLower()) && Regex.IsMatch(c.Name, @"(-aaa|-aa|-a|-b|-c)$"));
-                
+
                 // Safety measure - there should never be more than 5 channels in the same guild,
                 // so if this happens, the pattern matching failed.
-                if(channels.Count() > 5) continue;
+                if(channels.Count() > 5) {
+                    logger.LogError("Pattern matching failed for {guild} with the following channels: {channels} (They were not deleted)", sg.Name, String.Join(",", channels.Select(x => x.Name)));
+                    continue;
+                    
+                }
 
                 foreach(var channel in channels) {
                     await channel.DeleteAsync();
                 }
             }
         }
+
 
         public static string GetE9KName(this Contract contract, bool toLower = true) {
             if(contract is null || string.IsNullOrEmpty(contract.Name) ) return "unknown-contract";

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -18,6 +18,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using static Ei.ArtifactSpec.Types;
 
 namespace EGG9000.Common.Services {
     public class DiscordHostedService : DiscordSocketClient {
@@ -330,7 +331,7 @@ namespace EGG9000.Common.Services {
         }
 
         public static string GetE9KName(this Contract contract, bool toLower = true) {
-            if(contract is null) return "unknown-contract";
+            if(contract is null || string.IsNullOrEmpty(contract.Name) ) return "unknown-contract";
             return Regex.Replace((toLower ? contract.Name.ToLower() : contract.Name).Split(":").Last().Trim().Replace(" ", "-"), "[^a-zA-Z0-9-]", "");
         }
 

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -257,8 +257,10 @@ namespace EGG9000.Site.Controllers {
                 Guilds = _discord.Guilds.Where(x => x.Id == guildId || guild.OverflowServers.Contains(x.Id)).OrderBy(x => x.Id).Select(x => new GuildDetails {
                     Name = x.Name,
                     ThreadCount = x.GetInUseThreadCount(),
-                    ActiveCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.Contains("coops") && !c.Category.Name.Contains("finished")),
-                    FinishedCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.Contains("coops") && c.Category.Name.Contains("finished")),
+                    ActiveCoops = x.ThreadChannels.Where(t => !t.IsArchived && Regex.IsMatch(t.ParentChannel?.Name, @"(-aaa|-aa|-a|-b|-c)$")).Count(c => !c.Name.Contains("🏁") && !c.Name.Contains("🚩")),
+                    FinishedCoops = x.ThreadChannels.Where(t => !t.IsArchived && Regex.IsMatch(t.ParentChannel?.Name, @"(-aaa|-aa|-a|-b|-c)$")).Count(c => c.Name.Contains("🏁") || c.Name.Contains("🚩")),
+                    //ActiveCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.Contains("coops") && !c.Category.Name.Contains("finished")),
+                    //FinishedCoops = x.TextChannels.Where(c => c.Category != null).Count(c => c.Category.Name.Contains("coops") && c.Category.Name.Contains("finished")),
                 }).ToList(),
                 Guild = guild,
                 ContractsToScore = contractsToScore

--- a/EGG9000.Site/Views/Admin/Index.cshtml
+++ b/EGG9000.Site/Views/Admin/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@model EGG9000.Site.Controllers.AdminController.IndexViewModel
+@using static EGG9000.Common.Helpers.CreateCoopsV2;
 @{
 	ViewData["Title"] = "Admin";
 	var days = Model.Days?.Select(x => new object[] { x.Key.ToUnixTimeMilliseconds(), x.Value[0] });
@@ -50,10 +51,10 @@
 						int available;
 						if (first) {
 							first = false;
-							available = Math.Max(900 - guild.ThreadCount, 0);
+							available = Math.Max(PrimaryMaxThreads - guild.ThreadCount, 0);
 
 						} else {
-							available = Math.Max(1000 - guild.ThreadCount, 0);
+							available = Math.Max(OverflowMaxThreads - guild.ThreadCount, 0);
 
 						}
 						availableSum += available;


### PR DESCRIPTION
- Parameterize the number of channels and threads before a server is considered full, as the site and bot both use them
- Fix for Discord server semaphores being null
- Implement max-channel-count check on `DeleteHeaderChannels`
- Re-enable Header channel deletion on contract channel deletion
- Update counts for Finished/In-Progress coops on `site/Admin` index