### PR TITLE
Custom Egg Detection & Saving

### DIFF
--- a/EGG9000.Bot/Automated/ContractUpdater.cs
+++ b/EGG9000.Bot/Automated/ContractUpdater.cs
@@ -151,11 +151,15 @@ namespace EGG9000.Bot.Automated {
             if(guildContract.BoardingGroup < 3)
                 description += $"\n[View Upcoming Co-ops on egg9000.com](https://egg9000.com/Contract/Day1CoopsFillLate?GuildId={guild.Id}&ContractId={guildContract.ContractID})";
 
-            var embedBuilder = new EmbedBuilder()
-                .WithDescription(description)
-                .WithAuthor(
-                    new EmbedAuthorBuilder().WithName($"{guildContract.Contract.Name} - {guildContract.Contract.ID}")
-                    .WithIconUrl(EggIncStatics.GetEggById((int)guildContract.Contract.Details.Egg).image));
+            var embedBuilder = new EmbedBuilder().WithDescription(description);
+            var author = new EmbedAuthorBuilder().WithName($"{guildContract.Contract.Name} - {guildContract.Contract.ID}");
+            if(guildContract.Contract.Details.HasCustomEggId) {
+                author.WithIconUrl(guildContract.Contract.CustomEggs?.FirstOrDefault()?.Icon?.Url ?? EggIncStatics.GetEggById(1).image);
+            } else {
+                author.WithIconUrl(EggIncStatics.GetEggById((int)guildContract.Contract.Details.Egg).image);
+            }
+
+            embedBuilder.WithAuthor(author);
 
             var startIndex = grade == Ei.Contract.Types.PlayerGrade.GradeUnset ? 5 : (int)grade;
             var endIndex = grade == Ei.Contract.Types.PlayerGrade.GradeUnset ? 1 : (int)grade;

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -942,8 +942,16 @@ namespace EGG9000.Bot.Automated.Coops {
                 ))
                 .WithColor(color)
                 .WithTimestamp(DateTimeOffset.UtcNow)
-                .WithAuthor(new EmbedAuthorBuilder().WithName($"{coop.Contract.Name} - Coop Code: {coop.Name}").WithIconUrl(EggIncStatics.GetEggById((int)coop.Contract.Details.Egg).image))
                 ;
+
+                if(coop.Contract.Details.HasCustomEggId) {
+                    embedBuilder.WithAuthor(new EmbedAuthorBuilder().WithName($"{coop.Contract.Name} - Coop Code: {coop.Name}")
+                        .WithIconUrl(
+                            coop.Contract.CustomEggs?.FirstOrDefault()?.Icon?.Url ?? EggIncStatics.GetEggById(1).image
+                        ));
+                } else {
+                    embedBuilder.WithAuthor(new EmbedAuthorBuilder().WithName($"{coop.Contract.Name} - Coop Code: {coop.Name}").WithIconUrl(EggIncStatics.GetEggById((int)coop.Contract.Details.Egg).image));
+                }
 
 
                 var updates = UpdateInterval.TotalMinutes;

--- a/EGG9000.Bot/Automated/NewContracts.cs
+++ b/EGG9000.Bot/Automated/NewContracts.cs
@@ -78,7 +78,7 @@ namespace EGG9000.Bot.Automated {
                             egg = contractResponse.Egg.ToString(),
                             cc_only = contractResponse.CcOnly,
                             _response = json,
-                            custom_eggs = ""
+                            custom_eggs = JsonConvert.SerializeObject(new List<CustomEgg>())
                         };
                         _db.Contracts.Add(contract);
                         await _db.SaveChangesAsync(CancellationToken.None);

--- a/EGG9000.Bot/Automated/NewContracts.cs
+++ b/EGG9000.Bot/Automated/NewContracts.cs
@@ -5,6 +5,7 @@ using EGG9000.Common.Contracts;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
+using Ei;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using static EGG9000.Bot.Helpers.DiscordHelpersExt;
@@ -43,6 +45,7 @@ namespace EGG9000.Bot.Automated {
                 var existingContracts = await _db.Contracts.Include(x => x.GuildContracts).ToListAsync(CancellationToken.None);
 
                 var contracts = contractsResponse.Contracts.Contracts.ToList();
+                var customEggs = contractsResponse.Contracts.CustomEggs.ToList();
 
                 CheckUpdateInterval(existingContracts);
 
@@ -54,6 +57,8 @@ namespace EGG9000.Bot.Automated {
                     var dbguilds = await _db.Guilds.AsQueryable().ToListAsync(CancellationToken.None);
 
                     var json = JsonConvert.SerializeObject(contractResponse);
+
+                    var matchingCustomEggs = customEggs.Where(ce => ce.Identifier == contractResponse.Identifier || ce.Value == (int)contractResponse.Egg).ToList();
 
                     if(contract == null) {
                         contract = new Contract {
@@ -72,7 +77,8 @@ namespace EGG9000.Bot.Automated {
                             length_seconds = contractResponse.LengthSeconds,
                             egg = contractResponse.Egg.ToString(),
                             cc_only = contractResponse.CcOnly,
-                            _response = json
+                            _response = json,
+                            custom_eggs = ""
                         };
                         _db.Contracts.Add(contract);
                         await _db.SaveChangesAsync(CancellationToken.None);
@@ -99,6 +105,7 @@ namespace EGG9000.Bot.Automated {
                         contract.egg = contractResponse.Egg.ToString();
                         contract.cc_only = contractResponse.CcOnly;
                         contract._response = json;
+                        contract.custom_eggs = JsonConvert.SerializeObject(matchingCustomEggs);
                         await _db.SaveChangesAsync(CancellationToken.None);
                     }
 

--- a/EGG9000.Common/Database/Entities/Contracts.cs
+++ b/EGG9000.Common/Database/Entities/Contracts.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Ei;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -23,6 +24,10 @@ namespace EGG9000.Common.Database.Entities {
         public string _response { get; set; }
 
         public bool HadTwoRewards { get; set; }
+
+        public string custom_eggs { get; set; }
+
+        public List<CustomEgg> CustomEggs => JsonConvert.DeserializeObject<List<CustomEgg>>(custom_eggs);
 
         [NotMapped]
         private Ei.Contract _details { get; set; }

--- a/EGG9000.Common/Database/Entities/Contracts.cs
+++ b/EGG9000.Common/Database/Entities/Contracts.cs
@@ -27,6 +27,7 @@ namespace EGG9000.Common.Database.Entities {
 
         public string custom_eggs { get; set; }
 
+        [NotMapped]
         public List<CustomEgg> CustomEggs => JsonConvert.DeserializeObject<List<CustomEgg>>(custom_eggs);
 
         [NotMapped]

--- a/EGG9000.Common/Migrations/20240701135235_ContractCustomEggs.Designer.cs
+++ b/EGG9000.Common/Migrations/20240701135235_ContractCustomEggs.Designer.cs
@@ -4,6 +4,7 @@ using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240701135235_ContractCustomEggs")]
+    partial class ContractCustomEggs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EGG9000.Common/Migrations/20240701135235_ContractCustomEggs.cs
+++ b/EGG9000.Common/Migrations/20240701135235_ContractCustomEggs.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    public partial class ContractCustomEggs : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "custom_eggs",
+                table: "Contracts",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "custom_eggs",
+                table: "Contracts");
+        }
+    }
+}

--- a/EGG9000.Site/Views/Home/Coop.cshtml
+++ b/EGG9000.Site/Views/Home/Coop.cshtml
@@ -96,7 +96,11 @@
 						<div class="ProgressLine"></div>
 						<div class="GoalText @(i == 1 && Model.GoalDetails.Count > 2 ? "GoalTextMiddle" : "")">
 							@Model.GoalDetails[i].Goal.TargetAmount.ToEggString()
-							<img src="/images/Egg_@((int)Model.Contract?.Details.Egg).png" class="Emoji" />
+							@if (Model.Contract.Details.HasCustomEggId) {
+								<img src="@Model.Contract.CustomEggs?.FirstOrDefault()?.Icon?.Url ?? @("/images/Egg_1.png")" class="Emoji"/>	
+							} else {
+								<img src="/images/Egg_@((int)Model.Contract?.Details.Egg).png" class="Emoji" />
+							}
 							<br />
 							<span style="white-space: nowrap">@Html.Raw(EmojiToImage(EggIncStatics.GetReward(Model.GoalDetails[i].Goal)))</span>
 						</div>
@@ -141,7 +145,14 @@
 							<th title="Chicken Count" class="right">🐔</th>
 							<th title="Habs Filled Percent" class="right">🏠</th>
 							<th title="Shipping Used Capacity" class="right">🚚</th>
-							<th title="Current Contribution" class="right"><img src="/images/Egg_@((int)Model.Contract?.Details.Egg).png" class="Emoji" /></th>
+							<th title="Current Contribution" class="right">
+								@if (Model.Contract.Details.HasCustomEggId) {
+									<img src="@Model.Contract.CustomEggs?.FirstOrDefault()?.Icon?.Url ?? @("/images/Egg_1.png")" class="Emoji" />
+								}
+								else {
+									<img src="/images/Egg_@((int)Model.Contract?.Details.Egg).png" class="Emoji" />
+								}
+							</th>
 							<th title="Hourly Rate" class="right">Rate</th>
 							@if (Model.CoopStatus.SecondsRemaining > 0) {
 								<th title="Projected Amount" class="right text-nowrap">📈</th>

--- a/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
@@ -1016,7 +1016,12 @@
             @if (farm.FarmType == Ei.FarmType.Home) {
                 <h4 class="card-header"><img src="/images/Egg_@((int)farm.EggType).png" /> Home Farm</h4>
             } else if (farm.ContractId != null) {
-                <h4 class="card-header"><img src="/images/Egg_@((int)farm.EggType).png" /> @Model.Contracts.FirstOrDefault(x => x.ID == farm.ContractId)?.Name</h4>
+                var contract = Model.Contracts.FirstOrDefault(x => x.ID == farm.ContractId);
+                if(contract.Details.HasCustomEggId) {
+                    <h4 class="card-header"><img src="@contract.CustomEggs?.FirstOrDefault()?.Icon.Url ?? @("/images/Egg_1.png")" /> @Model.Contracts.FirstOrDefault(x => x.ID == farm.ContractId)?.Name</h4>
+                } else {
+                    <h4 class="card-header"><img src="/images/Egg_@((int)farm.EggType).png" /> @Model.Contracts.FirstOrDefault(x => x.ID == farm.ContractId)?.Name</h4>
+                }
             } else {
                 <h4 class="card-header">Error Finding Contract @farm.ContractId</h4>
             }


### PR DESCRIPTION
**Will require a DB update**.
Detect and save information about custom eggs when new contracts are pulled from the API, to be used in Icon display, both on the site and in Threads.
