### PR TITLE
Fix rounding being in the wrong spot

### DIFF
--- a/EGG9000.Bot/Automated/EventUpdater.cs
+++ b/EGG9000.Bot/Automated/EventUpdater.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -275,7 +276,7 @@ namespace EGG9000.Bot.Automated {
             if(Ended) title += $"\nEnded <t:{e.Ends.ToUnixTimeSeconds()}:R>";
             else title += $"\nEnds <t:{e.Ends.ToUnixTimeSeconds()}:R> (<t:{e.Ends.ToUnixTimeSeconds()}>)";
 
-            var color = Color.Blue;
+            var color = e.CcOnly ? new Color(uint.Parse("a932c7", NumberStyles.HexNumber)) : Color.Blue;
             if(CrossOut) color = Color.Red;
             else if(Ended) color = Color.DarkGrey;
 

--- a/EGG9000.Bot/Automated/EventUpdater.cs
+++ b/EGG9000.Bot/Automated/EventUpdater.cs
@@ -43,7 +43,7 @@ namespace EGG9000.Bot.Automated {
             await CheckShells(_db);
 
             var response = await ContractsAPI.GetPeriodicalsAsync();
-            var responseDateTime = DateTimeOffset.UtcNow.RoundToClosestFifteen();
+            var responseDateTime = DateTimeOffset.UtcNow;
             var recentEvents = await _db.Events.AsQueryable().Where(x => x.Ends > DateTimeOffset.Now.AddDays(-1)).ToListAsync(CancellationToken.None);
 
             if(response?.Events?.Events == null) {
@@ -81,7 +81,7 @@ namespace EGG9000.Bot.Automated {
                             await PostMessages(currentEvent, _db);
                         } else if (timeChange) {
                             _logger.LogInformation($"Time change for {currentEvent.Type}, of {currentEvent.Ends.Subtract(DateTimeOffset.UtcNow.AddSeconds(evt.SecondsRemaining)).TotalSeconds} seconds");
-                            currentEvent.Ends = responseDateTime.AddSeconds(evt.SecondsRemaining);
+                            currentEvent.Ends = responseDateTime.AddSeconds(evt.SecondsRemaining).RoundToClosestFifteen();
                             await UpdateMessages(currentEvent, _db);
                         }
                     }

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -26,7 +26,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 using static EGG9000.Common.Helpers.Prefarm;
 
 namespace EGG9000.Bot.Commands {
-    public static class MiscCommandsSlash {
+    public static class MiscCommandsSlash {  
         [SlashCommand(Description = "Track your EB since the last time you ran this command", AllowInDMs = true)]
         public static async Task TrackEB(FauxCommand command, ApplicationDbContext db, ILogger logger) {
             await command.DeferAsync();


### PR DESCRIPTION
I should not have been rounding the `responseDateTime` object - this was leading to almost constant "time change detections" - it should just be getting rounded when the event's End time is set.