### PR TITLE
Add preprocessors for Emoji and Commands

### DIFF
--- a/EGG9000.Bot/Commands/FAQCommandSlash.cs
+++ b/EGG9000.Bot/Commands/FAQCommandSlash.cs
@@ -14,6 +14,8 @@ using EGG9000.Common.Helpers.Discord;
 using EGG9000.Common.Helpers;
 using System;
 using EGG9000.Bot.Helpers;
+using System.Reactive.Joins;
+using System.Text.RegularExpressions;
 
 namespace EGG9000.Bot.Commands {
     public static class FAQCommandSlash {
@@ -74,7 +76,7 @@ namespace EGG9000.Bot.Commands {
 
             var faqTopics = await db.QueryFAQTopicsAsync(guildObj, hasStaffPerms && withStaffPerms, query);
             if(faqTopics.Any()) {
-                var builder = FAQEmbedBuilder(guildObj.Id, withStaffPerms, query, isEphemeral, respondToMessage, faqTopics, faqTopics.First());
+                var builder = await FAQEmbedBuilder(_client, guildObj.Id, withStaffPerms, query, isEphemeral, respondToMessage, faqTopics, faqTopics.First());
                 await command.ModifyOriginalResponseAsync(x => { x.Embed = builder.EmbedBuilder.Build(); x.Components = builder.ComponentBuilder?.Build() ?? null; });
             } else {
                 await command.ModifyOriginalResponseAsync(x => { x.Embed = EmbedCustom(EmbedHelpers.EmbedType.Alert, "No Results", $"Could not find any FAQ topics for the term `{query}`"); });
@@ -100,10 +102,10 @@ namespace EGG9000.Bot.Commands {
             var faqTopics = await db.QueryFAQTopicsAsync(guildObj, hasStaffPerms && withStaffPerms, query);
             if(faqTopics.Count > 0 && faqTopics[targetIndex] != null) {
                 var targetItem = faqTopics[targetIndex];
-                var builder = FAQEmbedBuilder(guildId, withStaffPerms, query, isEphemeral, respondTo, faqTopics, targetItem);
+                var builder = await FAQEmbedBuilder(_client, guildId, withStaffPerms, query, isEphemeral, respondTo, faqTopics, targetItem);
                 await component.UpdateAsync(x => { x.Components = builder.ComponentBuilder?.Build(); x.Embed = builder.EmbedBuilder.Build(); });
             } else {
-                var faqCommand = await socketGuild.GetSlashCommandStringAsync("FAQ");
+                var faqCommand = await _client.GetSlashCommandStringAsync(socketGuild, "FAQ");
                 await component.RespondAsync(embed: EmbedError($"Could not find an FAQ topic at this index. Try running {faqCommand} again."), ephemeral: true);
             }
         }
@@ -147,13 +149,13 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var embed = FAQEmbedBuilder(guildId, withStaffPerms, query, isEphemeral, respondTo, faqTopics, faqTopics[targetIndex], runningUserDiscord).EmbedBuilder.Build();
+            var embed = (await FAQEmbedBuilder(_client, guildId, withStaffPerms, query, isEphemeral, respondTo, faqTopics, faqTopics[targetIndex], runningUserDiscord)).EmbedBuilder.Build();
             var messageRef = respondTo != ulong.MaxValue ? new MessageReference(respondTo, failIfNotExists: false) : null;
             await component.Channel.SendMessageAsync(embed: embed, messageReference: messageRef);
             await component.UpdateAsync(x => { x.Embed = EmbedSuccess("Posted."); x.Components = null; });
         }
 
-        public static FAQBuilder FAQEmbedBuilder(ulong guildId, bool withStaffPerms, string query, bool isEphemeral, ulong? respondTo, List<FAQTopic> faqTopics, FAQTopic currentItem, IGuildUser poster = null) {
+        public static async Task<FAQBuilder> FAQEmbedBuilder(DiscordHostedService _client, ulong guildId, bool withStaffPerms, string query, bool isEphemeral, ulong? respondTo, List<FAQTopic> faqTopics, FAQTopic currentItem, IGuildUser poster = null) {
             var builder = new FAQBuilder() {
                 ComponentBuilder = null
             };
@@ -169,6 +171,35 @@ namespace EGG9000.Bot.Commands {
             }
 
             var informationText = currentItem.Explanation;
+            var socketGuild = _client.Guilds.FirstOrDefault(g => g.Id == guildId);
+            if(socketGuild != null) {
+                var commandMatchRegex = @"\{\{command:([^\}]+)\}\}";
+                var commandMatches = Regex.Matches(informationText, commandMatchRegex);
+                Console.WriteLine("commandMatches count: " + commandMatches.Count);
+                foreach(Match commandMatch in commandMatches) {
+                    Console.WriteLine("commandMatch.Groups count: " + commandMatch.Groups.Count);
+                    if(commandMatch.Groups.Count < 2) continue;
+                    var commandName = commandMatch.Groups[1].Value;
+                    var commandString = await _client.GetSlashCommandStringAsync(socketGuild, commandName);
+                    // Replace the {{command:...}} with the commandString
+                    informationText = informationText.Replace(commandMatch.Value, commandString);
+                }
+
+                var emojiMatchRegex = @"\{\{emoji:([^\}]+)\}\}";
+                var emojiMatches = Regex.Matches(informationText, emojiMatchRegex);
+                var appEmojis = await _client.GetApplicationEmotesAsync();
+                foreach(Match emojiMatch in emojiMatches) {
+                    if(emojiMatch.Groups.Count < 2) continue;
+                    var emojiName = emojiMatch.Groups[1].Value;
+                    var emoji = appEmojis.FirstOrDefault(e => e.Name.ToLower() ==  emojiName.ToLower());
+                    emoji ??= socketGuild.Emotes.FirstOrDefault(e => e.Name.ToLower() == emojiName.ToLower());
+                    if(emoji is null) continue;
+                    var emojiString = $"<:{emoji.Name}:{emoji.Id}>";
+                    // Replace the {{emoji:...}} with the emojiString
+                    informationText = informationText.Replace(emojiMatch.Value, emojiString);
+                }
+            }
+
             if (informationText.Length >= 1024) {
                 informationText = string.Concat(informationText.AsSpan(0, 950), "...\n\n**_(Topic was cut-off due to Discord's `1024` character limit)_**");
             }

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -201,8 +201,8 @@ namespace EGG9000.Bot.Commands {
                     await command.RespondAsync($"{targetUser.Mention}, you have already accepted the rules. Please use the command `/register EI#####`, where EI##### is your Egg Inc ID, to find your ID please go to Settings, then Privacy & Data, and find the letters & numbers in the bottom center of the window.");
                     return;
                 } else if(dbUser.GuildId > 0) {
-                    var moveServerCommand = await guild.GetSlashCommandStringAsync("MoveServer");
-                    await command.RespondAsync($"{targetUser.Mention}, looks like you are registered with another server, if you would like to move to this server use the ${moveServerCommand} command.");
+                    var moveServerCommandString = await _client.GetSlashCommandStringAsync(guild, "MoveServer");
+                    await command.RespondAsync($"{targetUser.Mention}, looks like you are registered with another server, if you would like to move to this server use the ${moveServerCommandString} command.");
                     return;
                 } else {
 

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -163,9 +163,9 @@ namespace EGG9000.Common.Services {
                     return;
                 }
                 if(dbuser.GuildId != user.Guild.Id) {
-                    var moveServerCommand = await user.Guild.GetSlashCommandStringAsync("MoveServer");
+                    var moveServerCommandString = await _discord.GetSlashCommandStringAsync(user.Guild, "MoveServer");
                     await ChannelHelper.DetermineAndSend(db, _discord, dbguild, _discord.GetGuild(user.Guild.Id), GuildChannelType.Welcome, new() {
-                        Text = $"Welcome to the server {user.Mention}! Looks like you are currently registered with another server. If you would like to move to this server use the {moveServerCommand} command."
+                        Text = $"Welcome to the server {user.Mention}! Looks like you are currently registered with another server. If you would like to move to this server use the {moveServerCommandString} command."
                     }, _logger);
                     return;
                 }

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -356,9 +356,20 @@ namespace EGG9000.Common.Services {
             return commands;
         }
 
-        public static async Task<string> GetSlashCommandStringAsync(this SocketGuild guild, string slashCommandName) {
+        public static async Task<IReadOnlyCollection<SocketApplicationCommand>> GetCachedApplicationCommands(this DiscordHostedService discord) {
+            if(!commandCache.TryGetValue("GLOBAL", out IReadOnlyCollection<SocketApplicationCommand> commands)) {
+                commands = await discord.GetGlobalApplicationCommandsAsync();
+                commandCache.Set("GLOBAL", commands, TimeSpan.FromMinutes(10));
+            }
+            return commands;
+        }
+
+        public static async Task<string> GetSlashCommandStringAsync(this DiscordHostedService discord, SocketGuild guild, string slashCommandName) {
             var fixedSlashCommandName = slashCommandName.ToLower().Trim();
             var command = (await guild.GetCachedApplicationCommands())
+                .ToList().Where(c => c.Type == ApplicationCommandType.Slash)
+                .FirstOrDefault(c => c.Name.ToLower() == fixedSlashCommandName);
+            command ??= (await discord.GetCachedApplicationCommands())
                 .ToList().Where(c => c.Type == ApplicationCommandType.Slash)
                 .FirstOrDefault(c => c.Name.ToLower() == fixedSlashCommandName);
 

--- a/EGG9000.Site/Views/Admin/FAQCustomization.cshtml
+++ b/EGG9000.Site/Views/Admin/FAQCustomization.cshtml
@@ -146,6 +146,19 @@
                     <span style="font-size: 0.9rem; color: gray;">
                         The "answer" text a user should be displayed while searching for the topic on Discord.
                     </span>
+                    <span style="margin-bottom: 10px;">
+                        <br />
+                        <a href="javascript:void(0);" class="text-info" data-toggle="collapse" data-target="#preprocessorDescription" aria-expanded="false" aria-controls="preprocessorDescription">
+                            <span id="toggleText">Custom Preprocessor Information</span>
+                            <i class="fas fa-chevron-right" id="toggleIcon"></i>
+                        </a>
+                        <span class="collapse" id="preprocessorDescription">
+                            <span style="display: block; padding: 10px; border: 1px solid #ccc; background-color: #f9f9f9;" ng-non-bindable>
+                                <code>{{emoji:emoji_name}}</code> will insert any matching emoji from the server in question.<br/>
+                                <code>{{command:command_name}}</code> will insert a clickable command, if found - otherwise a discord in-line code block.<br/>
+                            </span>
+                        </span>
+                    </span>
                 </label>
                 <textarea rows="8" ng-disabled="isSubscribe" autocomplete="off" aria-autocomplete="none" spellcheck="false" class="form-control" ng-model="item.explanation"></textarea>
                 <div style="font-size: 0.9rem; margin-top: 5px;"


### PR DESCRIPTION
Adds two new custom pre-processors to FAQs which will allow for embedding of emojis and commands without knowing their IDs - or more usefully, to not have to change them if the commands or emojis are updated, and the IDs change.