### PR TITLE
Ensuring that temprole can't be used to elevate permissions

### DIFF
--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -204,8 +204,8 @@ namespace EGG9000.Bot.Commands {
             }
 
             var maxRolePosition = ((SocketGuildUser) command.User).Roles.Max(role => role.Position);
-            if(role.Position > maxRolePosition) {
-                await command.RespondAsync("You cannot assign roles higher than your own");
+            if(role.Position >= maxRolePosition) {
+                await command.RespondAsync("You cannot assign roles higher or equal than your own");
                 return;
             }
 

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -203,6 +203,12 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
+            var maxRolePosition = ((SocketGuildUser) command.User).Roles.Max(role => role.Position);
+            if(role.Position > maxRolePosition) {
+                await command.RespondAsync("You cannot assign roles higher than your own");
+                return;
+            }
+
             await command.DeferAsync();
             var userids = users.Select(x => x.Id);
             var existingTempRoles = await db.TemporaryRoles.Where(x => x.RoleId == role.Id && x.Expires > DateTimeOffset.Now && userids.Contains(x.UserId)).ToListAsync();


### PR DESCRIPTION
I don't know how to test this, but I'm pretty sure that my comparison is correct per a quick search for the semantics of SocketRole.Position