### PR TITLE
Add guild to Merit for boosting so it logs

### DIFF
--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -569,8 +569,9 @@ namespace EGG9000.Bot.Services {
             var db = await _dbContextFactory.CreateDbContextAsync();
             var guild = message.Channel is SocketGuildChannel ? (message.Channel as SocketGuildChannel).Guild : null;
             if(((IMessage)message).Type == MessageType.UserPremiumGuildSubscription && guild.Id == _cpGuild.Id) {
+                var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guild.Id);
                 var cpGeneralChannel = guild.TextChannels.First(x => x.Id == 656455568353132546);
-                await MeritCommands.CreateMerit("Boosted the server!", db, _discord, message.Author, Guid.Empty);
+                await MeritCommands.CreateMerit("Boosted the server!", db, _discord, message.Author, Guid.Empty, guild: dbGuild);
                 await cpGeneralChannel.SendMessageAsync($"{message.Author.Mention} just boosted the server!");
             }
 


### PR DESCRIPTION
Back-fix the merit that gets added when users boost the server so that it appears in the merit log (same 'fix' that was implemented for the OCR merits).