### PR TITLE
MessageCommand Groundwork

### DIFF
--- a/EGG9000.Bot/Commands/ContextMessageCommands.cs
+++ b/EGG9000.Bot/Commands/ContextMessageCommands.cs
@@ -16,7 +16,7 @@ namespace EGG9000.Bot.Commands {
 
         /*[MessageCommand(Name = "Reply as E9K", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task ReplyAsE9K(SocketMessageCommand command) {
-            command.
+            command.RespondWithModalAsync()
         }*/
     }
 }

--- a/EGG9000.Bot/Commands/ContextMessageCommands.cs
+++ b/EGG9000.Bot/Commands/ContextMessageCommands.cs
@@ -1,0 +1,22 @@
+
+using Discord.WebSocket;
+using EGG9000.Common.Commands;
+using System.Threading.Tasks;
+using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
+
+namespace EGG9000.Bot.Commands {
+    public static class ContextMessageCommands {
+        [MessageCommand(Name = "Test Reply", AdminOnly = StaffOnlyLevel.Admin)]
+        public static async Task TestReply(SocketMessageCommand command) {
+            await command.RespondAsync(
+                "",
+                embed: EmbedSuccess($"Test reply from MessageCommand\ncommand.Data.Message.Id;: {command.Data.Message.Id}")
+            );
+        }
+
+        /*[MessageCommand(Name = "Reply as E9K", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
+        public static async Task ReplyAsE9K(SocketMessageCommand command) {
+            command.
+        }*/
+    }
+}

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -1,6 +1,5 @@
 ﻿
 using Discord;
-using Discord.Rest;
 using Discord.WebSocket;
 using EGG9000.Bot.Automated;
 using EGG9000.Bot.Automated.Coops;
@@ -29,7 +28,6 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -148,6 +146,10 @@ namespace EGG9000.Bot.Services {
                             parameters.Add(GetParam(parameterInfo, arg));
                             continue;
                         }
+                        if(parameterInfo.GetCustomAttributes<MessageParamAttribute>().Any()) {
+                            parameters.Add(GetMessageParam(parameterInfo, arg));
+                            continue;
+                        }
                         if(parameterInfo.GetCustomAttributes<ComponentDataAttribute>().Any()) {
                             string[] data;
                             if(arg is SocketModal modal) {
@@ -235,7 +237,7 @@ namespace EGG9000.Bot.Services {
 
 
 
-        private static FauxSocketSlashCommandDataOption FindOption(string name, IList<FauxSocketSlashCommandDataOption> options) {
+        private static FauxSocketCommandDataOption FindOption(string name, IList<FauxSocketCommandDataOption> options) {
             var foundOption = options.FirstOrDefault(x => x.Name == name);
             if(foundOption != null) {
                 return foundOption;
@@ -409,7 +411,52 @@ namespace EGG9000.Bot.Services {
             }
         }
 
+        private static readonly List<Type> ImplementedMessageParamTypes = [
+            typeof(string),
+            typeof(uint),
+            typeof(int),
+        ];
 
+        private async static Task<object> GetMessageParam(ParameterInfo parameterInfo, IDiscordInteraction arg) {
+            if(arg is FauxCommand) {
+                return null;
+            } else {
+                var name = parameterInfo.Name;
+
+                if(!ImplementedMessageParamTypes.Contains(parameterInfo.ParameterType)) {
+                    throw new NotImplementedException($"Parameter type of {parameterInfo.ParameterType} is not handled as a MessageParam yet.");
+                }
+
+                var messageParamAttrib = parameterInfo.GetCustomAttribute<MessageParamAttribute>();
+                var textInputBuilder =
+                    new TextInputBuilder()
+                        .WithLabel(messageParamAttrib.Label ?? name)
+                        .WithRequired(messageParamAttrib?.Required ?? true)
+                        .WithStyle(messageParamAttrib.TextInputStyle);
+
+                // TODO: Right now since this is just string, uint, and int, we don't need a custom parser for default value types -> string
+                // But if we expand the MessageParamAttribute supported types in the future, we will need a forward and backward parser between
+                // newly implemented types and string, both so we can provide a default value, and parse the value back to the correct type
+                // after accepting it from the user - for right now, .ToString() is "good enough"
+                if(parameterInfo.HasDefaultValue) textInputBuilder.WithValue(parameterInfo.DefaultValue.ToString());
+
+                if(!string.IsNullOrEmpty(messageParamAttrib.Placeholder)) textInputBuilder.WithPlaceholder(messageParamAttrib.Placeholder);
+                if(messageParamAttrib.MinLength is not null) textInputBuilder.WithMinLength(messageParamAttrib.MinLength!.Value);
+                if(messageParamAttrib.MaxLength is not null) textInputBuilder.WithMaxLength(messageParamAttrib.MaxLength!.Value);
+
+                var modalPromptForInput =
+                    new ModalBuilder()
+                    .WithTitle($"Argument - `{messageParamAttrib.Label ?? name}`")
+                    .AddTextInput(textInputBuilder)
+                    .Build();
+
+                // TODO: Figure out how to send the modal and extract the value without having to spawn a secondary interaction????
+                // await arg.RespondWithModalAsync(modalPromptForInput);
+
+                // Cast the input back from Discord into the type of parameterInfo.ParameterType
+                return null;
+            }
+        }
 
         private static object GetParam(ParameterInfo parameterInfo, IDiscordInteraction arg) {
             if(arg is FauxCommand) {

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -136,18 +136,23 @@ namespace EGG9000.Bot.Services {
         }
 
 
-        private async Task RunCommand(CommandFunctionBase command, IDiscordInteraction arg) {
+        private async Task RunCommand(CommandFunctionBase command, IDiscordInteraction arg, List<object> processedParams = null) {
             //_ = arg.DeferAsync();
             if(await _semaphoreSlim.WaitAsync(TimeSpan.FromSeconds(2.5))) {
                 try {
-                    var parameters = new List<object>();
+                    var parameters = processedParams ?? [];
                     foreach(var parameterInfo in command.Parameters) {
                         if(parameterInfo.GetCustomAttributes<SlashParamAttribute>().Any()) {
                             parameters.Add(GetParam(parameterInfo, arg));
                             continue;
                         }
                         if(parameterInfo.GetCustomAttributes<MessageParamAttribute>().Any()) {
-                            parameters.Add(GetMessageParam(parameterInfo, arg));
+                            var param = GetMessageParam(parameterInfo, arg);
+                            if (param != null) {
+                                parameters.Add(param);
+                                await RunCommand(command, arg, parameters);
+                                return;
+                            }
                             continue;
                         }
                         if(parameterInfo.GetCustomAttributes<ComponentDataAttribute>().Any()) {

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -46,6 +46,7 @@ namespace EGG9000.Bot.Services {
         private readonly DiscordHostedService _discord;
         private List<SlashCommandFunction> _slashCommandFunctions;
         private List<UserCommandFunction> _userCommandFunctions;
+        private List<MessageCommandFunction> _messageCommandFunctions;
         private List<ComponentCommandFunction> _componentCommandFunctions;
         private List<ModalCommandFunction> _modalFunctions;
         private readonly APILink _apilink;
@@ -125,6 +126,17 @@ namespace EGG9000.Bot.Services {
             }
         }
 
+        private async Task _discord_MessageCommandExecuted(SocketMessageCommand arg) {
+            try {
+                var command = _messageCommandFunctions.First(x => x.Name == arg.Data.Name || x.Details.Name == arg.Data.Name);
+                if(command == null) return;
+                _ = Task.Run(() => RunCommand(command, arg));
+            } catch(Exception e) {
+                _bugsnag.Notify(e);
+                await arg.RespondAsync(text: "", embed: EmbedExceptionFrame(e));
+            }
+        }
+
 
         private async Task RunCommand(CommandFunctionBase command, IDiscordInteraction arg) {
             //_ = arg.DeferAsync();
@@ -157,6 +169,8 @@ namespace EGG9000.Bot.Services {
                         } else if(parameterInfo.ParameterType == typeof(SocketModal)) {
                             parameters.Add(arg);
                         } else if(parameterInfo.ParameterType == typeof(SocketUserCommand)) {
+                            parameters.Add(arg);
+                        } else if(parameterInfo.ParameterType == typeof(SocketMessageCommand)) {
                             parameters.Add(arg);
                         } else if(parameterInfo.ParameterType == typeof(ApplicationDbContext)) {
                             parameters.Add(await _dbContextFactory.CreateDbContextAsync());
@@ -243,6 +257,7 @@ namespace EGG9000.Bot.Services {
 
                 _discord.SlashCommandExecuted += _discord_SlashCommandExecuted;
                 _discord.UserCommandExecuted += _discord_UserCommandExecuted;
+                _discord.MessageCommandExecuted += _discord_MessageCommandExecuted;
                 _discord.MessageReceived += _discord_MessageReceived;
                 _discord.ButtonExecuted += _discord_ButtonExecuted;
                 _discord.SelectMenuExecuted += _discord_SelectMenuExecuted;
@@ -293,14 +308,14 @@ namespace EGG9000.Bot.Services {
                 }
 
                 foreach(var command in _userCommandFunctions) {
-                    var guildCommand = new UserCommandBuilder {
+                    var userCommand = new UserCommandBuilder {
                         DefaultMemberPermissions = GuildPermission.UseApplicationCommands
                     };
-                    guildCommand.WithName(command.Details.Name ?? command.Name);
+                    userCommand.WithName(command.Details.Name ?? command.Name);
                     command.Name = command.Details.Name ?? command.Name;
 
                     if(command.Details.AdminOnly != StaffOnlyLevel.None) {
-                        guildCommand.DefaultMemberPermissions = command.Details.AdminOnly switch {
+                        userCommand.DefaultMemberPermissions = command.Details.AdminOnly switch {
                             StaffOnlyLevel.Admin => (GuildPermission.Administrator | GuildPermission.ManageChannels | GuildPermission.ManageRoles),
                             StaffOnlyLevel.CluckingCoordinator => GuildPermission.ManageChannels,
                             StaffOnlyLevel.FarmHand => GuildPermission.CreatePrivateThreads,
@@ -309,7 +324,27 @@ namespace EGG9000.Bot.Services {
                         };
                     }
 
-                    guildCommandProperties.Add(guildCommand.Build());
+                    guildCommandProperties.Add(userCommand.Build());
+                }
+
+                foreach(var command in _messageCommandFunctions) {
+                    var messageCommand = new MessageCommandBuilder {
+                        DefaultMemberPermissions = GuildPermission.UseApplicationCommands
+                    };
+                    messageCommand.WithName(command.Details.Name ?? command.Name);
+                    command.Name = command.Details?.Name ?? command.Name;
+
+                    if(command.Details.AdminOnly != StaffOnlyLevel.None) {
+                        messageCommand.DefaultMemberPermissions = command.Details.AdminOnly switch {
+                            StaffOnlyLevel.Admin => (GuildPermission.Administrator | GuildPermission.ManageChannels | GuildPermission.ManageRoles),
+                            StaffOnlyLevel.CluckingCoordinator => GuildPermission.ManageChannels,
+                            StaffOnlyLevel.FarmHand => GuildPermission.CreatePrivateThreads,
+                            StaffOnlyLevel.ChickenTender => GuildPermission.ModerateMembers,
+                            _ => GuildPermission.UseApplicationCommands
+                        };
+                    }
+
+                    guildCommandProperties.Add(messageCommand.Build());
                 }
 
                 var globalCommands = await _discord.BulkOverwriteGlobalApplicationCommandsAsync([..globalCommandProperties]);
@@ -784,23 +819,30 @@ namespace EGG9000.Bot.Services {
             var t = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
                       .SelectMany(t => t.GetMethods())
                       .Where(m => m.GetCustomAttributes(typeof(UserCommandAttribute), false).Length > 0);
+
             _userCommandFunctions = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
-                      .SelectMany(t => t.GetMethods())
-                      .Where(m => m.GetCustomAttributes(typeof(UserCommandAttribute), false).Length > 0)
-                      .Select(x => new UserCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<UserCommandAttribute>(), Parameters = x.GetParameters() })
-                      .ToList();
+                .SelectMany(t => t.GetMethods())
+                    .Where(m => m.GetCustomAttributes(typeof(UserCommandAttribute), false).Length > 0)
+                    .Select(x => new UserCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<UserCommandAttribute>(), Parameters = x.GetParameters() })
+                    .ToList();
+
+            _messageCommandFunctions = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
+                .SelectMany(t => t.GetMethods())
+                    .Where(m => m.GetCustomAttributes(typeof(MessageCommandAttribute), false).Length > 0)
+                    .Select(x => new MessageCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<MessageCommandAttribute>(), Parameters = x.GetParameters() })
+                    .ToList();
 
             _componentCommandFunctions = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
                 .SelectMany(t => t.GetMethods())
-                      .Where(m => m.GetCustomAttributes(typeof(ComponentCommandAttribute), false).Length > 0)
-                      .Select(x => new ComponentCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<ComponentCommandAttribute>(), Parameters = x.GetParameters() })
-                      .ToList();
+                    .Where(m => m.GetCustomAttributes(typeof(ComponentCommandAttribute), false).Length > 0)
+                    .Select(x => new ComponentCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<ComponentCommandAttribute>(), Parameters = x.GetParameters() })
+                    .ToList();
 
             _modalFunctions = AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes())
                 .SelectMany(t => t.GetMethods())
-                      .Where(m => m.GetCustomAttributes(typeof(ModalAttribute), false).Length > 0)
-                      .Select(x => new ModalCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<ModalAttribute>(), Parameters = x.GetParameters() })
-                      .ToList();
+                    .Where(m => m.GetCustomAttributes(typeof(ModalAttribute), false).Length > 0)
+                    .Select(x => new ModalCommandFunction { Name = x.Name.ToLower(), MethodInfo = x, Details = x.GetCustomAttribute<ModalAttribute>(), Parameters = x.GetParameters() })
+                    .ToList();
 
             CreateCommands().ConfigureAwait(false);
             return Task.CompletedTask;
@@ -809,6 +851,7 @@ namespace EGG9000.Bot.Services {
         public async Task StopAsync(CancellationToken cancellationToken) {
             _discord.SlashCommandExecuted -= _discord_SlashCommandExecuted;
             _discord.UserCommandExecuted -= _discord_UserCommandExecuted;
+            _discord.MessageCommandExecuted -= _discord_MessageCommandExecuted;
             _discord.MessageReceived -= _discord_MessageReceived;
             _discord.ButtonExecuted -= _discord_ButtonExecuted;
             _discord.SelectMenuExecuted -= _discord_SelectMenuExecuted;

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -417,7 +417,7 @@ namespace EGG9000.Bot.Services {
             typeof(int),
         ];
 
-        private async static Task<object> GetMessageParam(ParameterInfo parameterInfo, IDiscordInteraction arg) {
+        private static async Task<object> GetMessageParam(ParameterInfo parameterInfo, IDiscordInteraction arg) {
             if(arg is FauxCommand) {
                 return null;
             } else {

--- a/EGG9000.Common/Helpers/FauxCommand.cs
+++ b/EGG9000.Common/Helpers/FauxCommand.cs
@@ -15,6 +15,7 @@ namespace EGG9000.Common.Services {
         SocketMessage _originalMessage;
         SocketSlashCommand _socketSlashCommand;
         SocketUserCommand _socketUserCommand;
+        SocketMessageCommand _socketMessageCommand;
         SocketCommandBase _socketCommandBase;
 
         RestUserMessage _message;
@@ -24,6 +25,7 @@ namespace EGG9000.Common.Services {
             _originalMessage = message;
             _guildid = guildid;
         }
+
         public FauxCommand(SocketSlashCommand command) {
             _socketSlashCommand = command;
             _socketCommandBase = command;
@@ -34,12 +36,21 @@ namespace EGG9000.Common.Services {
             _socketCommandBase = command;
         }
 
+        public FauxCommand(SocketMessageCommand command) {
+            _socketMessageCommand = command;
+            _socketCommandBase = command;
+        }
+
 
         public static implicit operator FauxCommand(SocketSlashCommand command) {
             return new FauxCommand(command);
         }
 
         public static implicit operator FauxCommand(SocketUserCommand command) {
+            return new FauxCommand(command);
+        }
+
+        public static implicit operator FauxCommand(SocketMessageCommand command) {
             return new FauxCommand(command);
         }
 
@@ -126,12 +137,17 @@ namespace EGG9000.Common.Services {
                 if(_socketUserCommand is not null)
                     return new FauxApplicationCommandData {
                         Name = _socketUserCommand.Data.Name,
-                        Options = _socketUserCommand.Data.Options.Select(x => new FauxSocketSlashCommandDataOption(x)).ToList()
+                        Options = _socketUserCommand.Data.Options.Select(x => new FauxSocketCommandDataOption(x)).ToList()
+                    };
+                if(_socketMessageCommand is not null)
+                    return new FauxApplicationCommandData {
+                        Name = _socketMessageCommand.Data.Name,
+                        Options = _socketMessageCommand.Data.Options.Select(x => new FauxSocketCommandDataOption(x)).ToList()
                     };
                 if(_socketSlashCommand is not null)
                     return new FauxApplicationCommandData {
                         Name = _socketSlashCommand.Data.Name,
-                        Options = _socketSlashCommand.Data.Options.Select(x => new FauxSocketSlashCommandDataOption(x)).ToList()
+                        Options = _socketSlashCommand.Data.Options.Select(x => new FauxSocketCommandDataOption(x)).ToList()
                     };
                 var commandText = new Regex(@"^/(\w+)").Match(_originalMessage.Content).Groups[1].Value.ToLower();
 
@@ -139,19 +155,19 @@ namespace EGG9000.Common.Services {
                     var eggincid = new Regex(@"E[I1]\d+").Match(_originalMessage.Content).Value;
                     return new FauxApplicationCommandData {
                         Name = commandText,
-                        Options = new List<FauxSocketSlashCommandDataOption>() {
-                            new FauxSocketSlashCommandDataOption() { 
-                                Name = "eggincid", 
-                                Type = ApplicationCommandOptionType.String, 
+                        Options = [
+                            new FauxSocketCommandDataOption() {
+                                Name = "eggincid",
+                                Type = ApplicationCommandOptionType.String,
                                 Value = eggincid
                             }
-                        }
+                        ]
                     };
                 }
 
                 
 
-                return new FauxApplicationCommandData { Name = commandText, Options = new List<FauxSocketSlashCommandDataOption>() };
+                return new FauxApplicationCommandData { Name = commandText, Options = [] };
             }
         }
 
@@ -164,25 +180,25 @@ namespace EGG9000.Common.Services {
 
             public string Name { get; set; }
 
-            public IList<FauxSocketSlashCommandDataOption> Options {
+            public IList<FauxSocketCommandDataOption> Options {
                 get; set;
             }
         }
 
-        public class FauxSocketSlashCommandDataOption {
+        public class FauxSocketCommandDataOption {
             public string Name { get; set; }
             public ApplicationCommandOptionType Type { get; set; }
             public object Value { get; set; }
-            public List<FauxSocketSlashCommandDataOption> Options { get; set; }
+            public List<FauxSocketCommandDataOption> Options { get; set; }
 
-            public FauxSocketSlashCommandDataOption() {
+            public FauxSocketCommandDataOption() {
 
             }
-            public FauxSocketSlashCommandDataOption(IApplicationCommandInteractionDataOption option) {
+            public FauxSocketCommandDataOption(IApplicationCommandInteractionDataOption option) {
                 Name = option.Name;
                 Type = option.Type;
                 Value = option.Value;
-                Options = option.Options?.Select(x => new FauxSocketSlashCommandDataOption(x)).ToList() ?? new List<FauxSocketSlashCommandDataOption>();
+                Options = option.Options?.Select(x => new FauxSocketCommandDataOption(x)).ToList() ?? new List<FauxSocketCommandDataOption>();
             }
         }
 

--- a/EGG9000.Common/Services/CommandAttributes.cs
+++ b/EGG9000.Common/Services/CommandAttributes.cs
@@ -21,6 +21,11 @@ namespace EGG9000.Common.Commands {
         public StaffOnlyLevel AdminOnly;
     }
     [AttributeUsage(AttributeTargets.Method)]
+    public class MessageCommandAttribute : System.Attribute {
+        public string Name = "";
+        public StaffOnlyLevel AdminOnly;
+    }
+    [AttributeUsage(AttributeTargets.Method)]
     public class SlashCommandAttribute : System.Attribute {
         public string Description = "";
         public StaffOnlyLevel AdminOnly = StaffOnlyLevel.None;
@@ -53,6 +58,9 @@ namespace EGG9000.Common.Commands {
     }
     public class UserCommandFunction : CommandFunctionBase {
         public UserCommandAttribute Details { get; set; }
+    }
+    public class MessageCommandFunction : CommandFunctionBase {
+        public MessageCommandAttribute Details { get; set; }
     }
     public class ComponentCommandFunction : CommandFunctionBase {
         public ComponentCommandAttribute Details { get; set; }

--- a/EGG9000.Common/Services/CommandAttributes.cs
+++ b/EGG9000.Common/Services/CommandAttributes.cs
@@ -1,4 +1,5 @@
-﻿using Discord.WebSocket;
+﻿using Discord;
+using Discord.WebSocket;
 
 using System;
 using System.Collections.Generic;
@@ -46,6 +47,16 @@ namespace EGG9000.Common.Commands {
         public Type AutocompleteHandler;
         public bool PositiveOnly = false;
         public int StringMaxLength = 6000;
+    }
+
+    [AttributeUsage(AttributeTargets.Parameter)]
+    public class MessageParamAttribute : System.Attribute {
+        public string? Label = null;
+        public string Placeholder = "";
+        public TextInputStyle TextInputStyle = TextInputStyle.Short;
+        public int? MinLength = null;
+        public int? MaxLength = null;
+        public bool? Required = null;
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]

--- a/EGG9000.Common/Services/CommandAttributes.cs
+++ b/EGG9000.Common/Services/CommandAttributes.cs
@@ -51,7 +51,7 @@ namespace EGG9000.Common.Commands {
 
     [AttributeUsage(AttributeTargets.Parameter)]
     public class MessageParamAttribute : System.Attribute {
-        public string? Label = null;
+        public string Label = null;
         public string Placeholder = "";
         public TextInputStyle TextInputStyle = TextInputStyle.Short;
         public int? MinLength = null;


### PR DESCRIPTION
Similar to the `[UserCommand]` attribute we have, this adds one for `[MessageCommand]`, which as it implies, runs on messages. No actual commands in this PR, just the groundwork for them.