### PR TITLE
Fix: Null Ref in ContractCommandsSlash

### DIFF
--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -24,7 +24,10 @@ namespace Ei {
             get {
                 if(_participants != null)
                     return _participants;
-                _participants = new List<Types.ContributionInfo>();
+                _participants = [];
+                if (Contributors == null || Contributors.Count == 0) {
+                    return _participants;
+                }
                 foreach(var p in Contributors) {
                     p.TimeLeftSeconds = SecondsRemaining;
                     _participants.Add(p);


### PR DESCRIPTION
This _should_ fix this issue:
<img width="708" height="348" alt="image" src="https://github.com/user-attachments/assets/7e56c2c8-24fe-4f39-9d13-ac1474bb24bd" />

I traced the line and call;
<img width="948" height="126" alt="image" src="https://github.com/user-attachments/assets/6709c2fe-57f8-48c7-ad27-7446802e845e" />

 The only thing I could find is that in a case where Contributors is null/empty, it runs into a no-ref in the DB call.
 
 
 If this is a case where the running code has differing line numbers, and this fix is superfluous, lmk.