### PR TITLE
Fix: Formatting + Silence of Co-op Created DM

### DIFF
--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -181,8 +181,8 @@ namespace EGG9000.Bot.Automated.Coops {
                     var user = users.FirstOrDefault(x => x.User.Id == xref.UserId);
                     if(xref.CoopSetting is null && user is not null) {
                         xref.CoopSetting = new CoopSetting(xref, user.User, dbguild);
-                        if(xref.CoopSetting.PingOnCoopCreated) {
-                            await SendDMWarning(_db, parentGuild.GetUser(user.User.DiscordId), coopThread, "Co-op has been created: ", coop);
+                        if(xref.CoopSetting.PingOnCoopCreated && !xref.JoinedCoop) {
+                            await SendDMWarning(_db, parentGuild.GetUser(user.User.DiscordId), coopThread, "Co-op has been created", coop);
                             xref.CoopSetting.PingOnCoopCreated = false;
                         }
                         xref.UpdateCoopSetting();


### PR DESCRIPTION
Fixes a double `: :` in the "Co-op has been created.." message:
<img width="717" height="117" alt="image" src="https://github.com/user-attachments/assets/e85903e5-b83e-4645-b0a2-b538e15d5c22" />

Also (attempts to) silence the message if the user has already joined the coop, as it doesn't make much sense to DM in that case, IMO.