### PR TITLE
Fix: Contract command unescaped

### DIFF
--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -375,7 +375,7 @@ namespace EGG9000.Bot.Commands {
                     await command.RespondAsync(content: "", embed: EmbedError("Non-subscribed account cannot be assigned to subscriber-only contract"));
                     return;
                 case PotentialCoopCode.AlreadyAssigned:
-                    await command.RespondAsync(content: "", embed: EmbedError("$User is already assigned a coop for contract {contract.Name}: <#{newCoopResponse.ReturnArgs[0]}>"));
+                    await command.RespondAsync(content: "", embed: EmbedError($"User is already assigned a coop for contract {contract.Name}: <#{newCoopResponse.ReturnArgs[0]}>"));
                     return;
                 case PotentialCoopCode.NoGrade:
                     await command.RespondAsync(content: "", embed: EmbedError("User does not have a grade set, and cannot be moved into a coop"));


### PR DESCRIPTION
`$` was misplaced:

<img width="599" height="211" alt="image" src="https://github.com/user-attachments/assets/937e469a-cc94-4a41-96af-31a191699b15" />
