### PR TITLE
Fix: Gateway + REST Split for Discord Middleware + Queuing

### DIFF
--- a/EGG9000.Bot/Automated/ArtifactCheaters.cs
+++ b/EGG9000.Bot/Automated/ArtifactCheaters.cs
@@ -86,7 +86,7 @@ namespace EGG9000.Bot.Automated {
                     var message = $"User <@{user.DiscordId}> may be cheating - the account `{identifier}` has `{outlierScore}` Crafting XP compared to the average of `{averageXp}`";
 #endif
 
-                    var response = await ChannelHelper.DetermineAndSend(_client, dbGuild, GuildChannelType.CheaterThread, new() { Text = message });
+                    var response = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() { Text = message });
 
                     outlier.CraftingWarningSent = true;
                     user.UpdateAccounts();
@@ -159,12 +159,12 @@ namespace EGG9000.Bot.Automated {
 
                     var (B64, Config) = await ArtifactHelpers.InventoryB64(outlier);
                     if(string.IsNullOrEmpty(B64)) {
-                        var sendResponse = await ChannelHelper.DetermineAndSend(_client, dbGuild, GuildChannelType.CheaterThread, new() {
+                        var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
                             Text = message
                         });
                     } else {
                         var image = new FileAttachment(new MemoryStream(Convert.FromBase64String(B64)), "Inventory.jpeg", "Inventory Image");
-                        var sendResponse = await ChannelHelper.DetermineAndSend(_client, dbGuild, GuildChannelType.CheaterThread, new() {
+                        var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
                             Text = message,
                             Embed = Commands.ArtifactCommands._inventoryEmbed(user, outlier),
                             File = image,

--- a/EGG9000.Bot/Automated/ContractUpdater.cs
+++ b/EGG9000.Bot/Automated/ContractUpdater.cs
@@ -194,7 +194,7 @@ namespace EGG9000.Bot.Automated {
                         await channel.DeleteAsync();
                     }
                     _logger.LogInformation("Deleting header channels for {contract} because the contract is expired.", guildContract.Contract.Name);
-                    await dbGuild.DeleteCoopThreadHeadersAsync(_client, guildContract.Contract, _logger);
+                    await dbGuild.DeleteCoopThreadHeadersAsync(_client.Gateway, guildContract.Contract, _logger);
                     guildContract.DeletedChannel = true;
 
                     //if(guildContract.Contract.MaxUsers > 1 && guildContract.GuildID == 656455567858073601 && guildContract.Created > DateTimeOffset.Now.AddMonths(-3) && !guildContract.HasScores) {

--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -191,13 +191,14 @@ namespace EGG9000.Bot.Automated.Coops {
                                         var db2 = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
                                         //var users = (await db2.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == coop.Id)).ToListAsync()).SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList();
                                         var xrefs = await db2.UserCoopXrefs.Include(x => x.User).AsQueryable().Where(x => x.CoopId == coop.Id).ToListAsync();
+                                        var coopToUpdate = await db2.Coops.FirstAsync(c => c.Id == coop.Id);
 
                                         var msg = await coopThread.SendMessageAsync($"Coop **{coop.Name}** for the contract **{guildContract.Contract.Name}** is ready for the following to join: {string.Join(", ", xrefs.Select(x => $"<@{x.User.DiscordId}>" + (x.User.EggIncAccounts.Count > 1 ? $"({x.User.EggIncAccounts.FirstOrDefault(e => e.Id == x.EggIncId)?.Backup.UserName ?? "Check website"})" : "")))}\n");
                                         var msg2 = await coopThread.SendMessageAsync("\u17B5");
                                         var msg3 = await coopThread.SendMessageAsync("\u17B5");
                                         var msg4 = await coopThread.SendMessageAsync("\u17B5");
                                         var msg5 = await coopThread.SendMessageAsync("\u17B5");
-                                        coop.UpdateMessagesId = JsonConvert.SerializeObject(new List<ulong> { msg.Id, msg2.Id, msg3.Id, msg4.Id, msg5.Id, });
+                                        coopToUpdate.UpdateMessagesId = JsonConvert.SerializeObject(new List<ulong> { msg.Id, msg2.Id, msg3.Id, msg4.Id, msg5.Id, });
                                         await db2.SaveChangesAsyncRetry(cancellationToken: cancellationToken);
                                     } finally {
                                         throttler.Release();
@@ -232,10 +233,6 @@ namespace EGG9000.Bot.Automated.Coops {
             }
 
             await MoveCreatorsToBlankCoop();
-        }
-
-        private async Task StartCoopAndCreateThread() {
-
         }
 
         private async Task MoveCreatorsToBlankCoop() {
@@ -423,6 +420,10 @@ namespace EGG9000.Bot.Automated.Coops {
                 category = categories.OrderBy(x => x.DiscordCategory.Position).FirstOrDefault(x => x.CurrentCount < 50);
             }
 #endif
+            if(category == null) {
+                _logger.LogError("No coop category with available space found in {server} for {contract} grade {grade}", OverflowSocketGuild.Name, GuildContract.Contract.GetE9KName(), PlayerGradeDetails.GetNameFromLeague(League));
+                return null;
+            }
             return await OverflowSocketGuild.CreateCoopThreadHeaderAsync(gradeRole, ultraRoles, contractEmbed, category.DiscordCategory, League, GuildContract.Contract, _logger);
         }
 

--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -38,7 +38,6 @@ using MassTransit;
 namespace EGG9000.Bot.Automated.Coops {
     public class CreateCoopThreads(IServiceProvider provider, ThreadsCoopStatusUpdater threadsCoopStatusUpdater) : _UpdaterBase<CreateCoopThreads>(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(0), provider) {
         private ThreadsCoopStatusUpdater _threadsCoopStatusUpdater = threadsCoopStatusUpdater;
-        private const double THREAD_CREATION_DELAY_MS = 6050;
 
         private readonly Dictionary<string, int> CoopsTimeoutCounter = new();
         private readonly Dictionary<CreatorInfo, DateTimeOffset> CreatorLastUsed = new();
@@ -168,7 +167,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                 _logger.LogWarning("Trying to create a new thread for {coop} already has a thread at {thread}", coop.Name, existingThread?.Name ?? "null");
                                 continue;
                             }
-                            var coopThread = await CreateThreadChannelAsync(coop.Name, headerChannel);
+                            var coopThread = await _queue.EnqueueLowAsync<IThreadChannel>(() => CreateThreadChannelAsync(coop.Name, headerChannel));
 
                             if(coopThread != null) {
                                 coop.Status = CoopStatusEnum.WaitingOnAssigned;
@@ -193,12 +192,17 @@ namespace EGG9000.Bot.Automated.Coops {
                                         var xrefs = await db2.UserCoopXrefs.Include(x => x.User).AsQueryable().Where(x => x.CoopId == coop.Id).ToListAsync();
                                         var coopToUpdate = await db2.Coops.FirstAsync(c => c.Id == coop.Id);
 
-                                        var msg = await coopThread.SendMessageAsync($"Coop **{coop.Name}** for the contract **{guildContract.Contract.Name}** is ready for the following to join: {string.Join(", ", xrefs.Select(x => $"<@{x.User.DiscordId}>" + (x.User.EggIncAccounts.Count > 1 ? $"({x.User.EggIncAccounts.FirstOrDefault(e => e.Id == x.EggIncId)?.Backup.UserName ?? "Check website"})" : "")))}\n");
-                                        var msg2 = await coopThread.SendMessageAsync("\u17B5");
-                                        var msg3 = await coopThread.SendMessageAsync("\u17B5");
-                                        var msg4 = await coopThread.SendMessageAsync("\u17B5");
-                                        var msg5 = await coopThread.SendMessageAsync("\u17B5");
-                                        coopToUpdate.UpdateMessagesId = JsonConvert.SerializeObject(new List<ulong> { msg.Id, msg2.Id, msg3.Id, msg4.Id, msg5.Id, });
+                                        var capturedThread = coopThread;
+                                        var introText = $"Coop **{coop.Name}** for the contract **{guildContract.Contract.Name}** is ready for the following to join: {string.Join(", ", xrefs.Select(x => $"<@{x.User.DiscordId}>" + (x.User.EggIncAccounts.Count > 1 ? $"({x.User.EggIncAccounts.FirstOrDefault(e => e.Id == x.EggIncId)?.Backup.UserName ?? "Check website"})" : "")))}\n";
+                                        var msgIds = await _queue.EnqueueLowAsync<List<ulong>>(async () => {
+                                            var m1 = await capturedThread.SendMessageAsync(introText);
+                                            var m2 = await capturedThread.SendMessageAsync("\u17B5");
+                                            var m3 = await capturedThread.SendMessageAsync("\u17B5");
+                                            var m4 = await capturedThread.SendMessageAsync("\u17B5");
+                                            var m5 = await capturedThread.SendMessageAsync("\u17B5");
+                                            return new List<ulong> { m1.Id, m2.Id, m3.Id, m4.Id, m5.Id };
+                                        });
+                                        coopToUpdate.UpdateMessagesId = JsonConvert.SerializeObject(msgIds);
                                         await db2.SaveChangesAsyncRetry(cancellationToken: cancellationToken);
                                     } finally {
                                         throttler.Release();
@@ -312,25 +316,18 @@ namespace EGG9000.Bot.Automated.Coops {
         }
 
         object __headerChannelLock = new object();
-        private async Task<SocketGuildChannel> GetHeaderChannelAndWait(List<HeaderChannelsForGuild> headerChannels, Coop coop) {
+        private Task<SocketGuildChannel> GetHeaderChannelAndWait(List<HeaderChannelsForGuild> headerChannels, Coop coop) {
             SocketGuildChannel headerChannel;
-            DateTimeOffset lastAccessed;
             lock(__headerChannelLock) {
                 var headerChannelsForGuild = headerChannels.First(x => x.GuildId == coop.GuildId);
                 var currentChannels = headerChannelsForGuild.HeaderChannels.Where(x => x.League == coop.League && x.ContractId == coop.ContractID).ToList();
                 var lastAccessedObject = headerChannelsForGuild.LastAccessed.Where(la => currentChannels.Any(x => x.ServerId == la.ServerId)).OrderBy(la => la.LastAccessed).First();
                 var serverHeaderChannel = currentChannels.First(x => x.ServerId == lastAccessedObject.ServerId);
                 headerChannel = serverHeaderChannel.HeaderChannel;
-                lastAccessed = lastAccessedObject.LastAccessed;
                 lastAccessedObject.LastAccessed = DateTimeOffset.Now;
             }
 
-            if(lastAccessed.AddMilliseconds(THREAD_CREATION_DELAY_MS) > DateTimeOffset.Now) {
-                var timeToDelay = lastAccessed.AddMilliseconds(THREAD_CREATION_DELAY_MS) - DateTimeOffset.Now;
-                _logger.LogInformation("Delaying for {delay} on {guild}", timeToDelay.Humanize(precision: 2).ShortenTime(), headerChannel?.Guild?.Name);
-                await Task.Delay(timeToDelay);
-            }
-            return headerChannel;
+            return Task.FromResult(headerChannel);
         }
 
         private async Task<List<HeaderChannelsForGuild>> GetOrCreateHeaderChannelsForCoops(ApplicationDbContext db, List<Coop> coops, List<Guild> guilds, List<GuildContract> guildContracts) {
@@ -424,7 +421,7 @@ namespace EGG9000.Bot.Automated.Coops {
                 _logger.LogError("No coop category with available space found in {server} for {contract} grade {grade}", OverflowSocketGuild.Name, GuildContract.Contract.GetE9KName(), PlayerGradeDetails.GetNameFromLeague(League));
                 return null;
             }
-            return await OverflowSocketGuild.CreateCoopThreadHeaderAsync(gradeRole, ultraRoles, contractEmbed, category.DiscordCategory, League, GuildContract.Contract, _logger);
+            return await _queue.EnqueueLowAsync<SocketGuildChannel>(() => OverflowSocketGuild.CreateCoopThreadHeaderAsync(gradeRole, ultraRoles, contractEmbed, category.DiscordCategory, League, GuildContract.Contract, _logger));
         }
 
         //private async Task<(IThreadChannel thread, SocketGuildChannel parentChannel)> TryCreateCoopThread(GuildContract guildContract, SocketGuild guild, Coop coop, List<OverflowServer> servers) {

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -312,13 +312,14 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 if(cancellationToken.IsCancellationRequested) return;
 
+                var customEggs = await _db.GetCustomEggsAsync();
 
                 if(coop.League == 0) {
                     //Fix if grade is set to 0
                     coop.League = (uint)status.Grade;
                 }
 
-                var coopDetails = new CoopDetails(coop, coop.Contract, coop.League, users, await _db.GetCustomEggsAsync(), _client, statusReponse.Status);
+                var coopDetails = new CoopDetails(coop, coop.Contract, coop.League, users, customEggs, _client, statusReponse.Status);
 
 
                 if(CheckForCreator(coop, coopDetails)) {
@@ -379,7 +380,10 @@ namespace EGG9000.Bot.Automated.Coops {
                     };
                     _db.Add(xref);
                     participant.AddXref(xref);
+                }
+                if(participantsInCoopButWithoutXref.Count > 0)
                     await _db.SaveChangesAsync(CancellationToken.None);
+                foreach(var participant in participantsInCoopButWithoutXref) {
                     if(coop.UserCoopsXrefs.Any(x => x.UserId == participant.DBUser.Id && x.WasAssigned && !x.JoinedCoop)) {
                         await coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account.");
                         await BoolSendDm(participant.DiscordUser, $"It looks like you might have joined the coop with the wrong account in {coopThread.Mention}.", _db);
@@ -417,12 +421,11 @@ namespace EGG9000.Bot.Automated.Coops {
                         var farm = user.Backup?.Farms?.FirstOrDefault(x => x.CoopId == coop.Name.ToLower());
                         if(farm != null) {
                             _bugSnag.Breadcrumbs.Leave($"User: {user.DiscordUser?.Id}, {user.Backup?.EggIncId}");
-                            user.FarmStats = farm.WithStats(user.Backup, coop, await _db.GetCustomEggsAsync());
+                            user.FarmStats = farm.WithStats(user.Backup, coop, customEggs);
                             user.SiloTime = awayTime * farm.SilosOwned;
                             var siloTimeHours = user.SiloTime / 60;
                             if(user.Xref is not null && user.Xref.SiloTimeHours != siloTimeHours) {
                                 user.Xref.SiloTimeHours = (float)siloTimeHours;
-                                await _db.SaveChangesAsync(CancellationToken.None);
                             }
                         }
                     }
@@ -1047,7 +1050,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     ;
 
 
-                    embedBuilder.WithAuthor(new EmbedAuthorBuilder().WithName($"{coop.Contract.Name} - Coop Code: {coop.Name}").WithIconUrl(EggIncStatics.GetEggByContract(coop.Contract, await _db.GetCustomEggsAsync()).image));
+                    embedBuilder.WithAuthor(new EmbedAuthorBuilder().WithName($"{coop.Contract.Name} - Coop Code: {coop.Name}").WithIconUrl(EggIncStatics.GetEggByContract(coop.Contract, customEggs).image));
 
 
                     var updates = UpdateInterval.TotalMinutes;

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -345,6 +345,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     var overflowGuildUser = guild.GetUser(participant.DBUser.DiscordId);
                     if(overflowGuildUser is not null && !overflowGuildUser.Roles.Any(x => x.Id == gradeRole.Id || x.Name.Contains("ULTRA")) && participant.CoopStatus?.UserName != "[departed]") {
                         var headChannel = guild.GetTextChannel(coopThread.CategoryId.Value);
+                        if(headChannel is null) continue;
                         if(!headChannel.PermissionOverwrites.Any(x => x.TargetId == overflowGuildUser.Id)) {
                             await headChannel.AddPermissionOverwriteAsync(overflowGuildUser, new OverwritePermissions(viewChannel: PermValue.Allow));
 
@@ -1572,6 +1573,7 @@ namespace EGG9000.Bot.Automated.Coops {
             foreach(var userStatus in userFarmDetails.Where(x => x.Xref?.CoopSetting?.PingOnFinished ?? false)) {
                 userStatus.Xref.CoopSetting.PingOnFinished = false;
                 userStatus.Xref.UpdateCoopSetting();
+                if(userStatus.DiscordUser is null) continue;
 
                 var dmResult = await BoolSendDm(userStatus.DiscordUser, $"The co-op {coopChannel.Mention} has finished.", db);
                 if(dmResult != DMResult.Success) {

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -124,7 +124,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     }, cancellationToken), DateTimeOffset.Now));
 
                     StillAlive();
-                    await Task.Delay(5000, cancellationToken);
+                    await Task.Delay(500, cancellationToken);
                 }
 
                 var watchdogCancellationSource = new CancellationTokenSource();
@@ -208,7 +208,7 @@ namespace EGG9000.Bot.Automated.Coops {
                 //Make sure the thread isn't archived before continuing
                 if(coopThread.IsArchived) {
                     try {
-                        await coopThread.ModifyAsync(t => t.Archived = false);
+                        await _queue.EnqueueLowAsync<bool>(async () => { await coopThread.ModifyAsync(t => t.Archived = false); return true; });
                     } catch(Exception) {
                         _logger.LogError("Could not un-archive thread for {coop}.", coop.Name);
                         return;
@@ -319,7 +319,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     coop.League = (uint)status.Grade;
                 }
 
-                var coopDetails = new CoopDetails(coop, coop.Contract, coop.League, users, customEggs, _client, statusReponse.Status);
+                var coopDetails = new CoopDetails(coop, coop.Contract, coop.League, users, customEggs, _client.Gateway, statusReponse.Status);
 
 
                 if(CheckForCreator(coop, coopDetails)) {
@@ -347,10 +347,12 @@ namespace EGG9000.Bot.Automated.Coops {
                         var headChannel = guild.GetTextChannel(coopThread.CategoryId.Value);
                         if(headChannel is null) continue;
                         if(!headChannel.PermissionOverwrites.Any(x => x.TargetId == overflowGuildUser.Id)) {
-                            await headChannel.AddPermissionOverwriteAsync(overflowGuildUser, new OverwritePermissions(viewChannel: PermValue.Allow));
+                            var capturedUser = overflowGuildUser;
+                            var capturedChannel = headChannel;
+                            _queue.EnqueueLow(() => capturedChannel.AddPermissionOverwriteAsync(capturedUser, new OverwritePermissions(viewChannel: PermValue.Allow)));
 
                             if(!coop.FinishedOrFailedOrExpired()) {
-                                await coopThread.SendMessageAsync($"Fixing permission for {overflowGuildUser.Mention}");
+                                _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Fixing permission for {overflowGuildUser.Mention}"));
                             }
                         }
 
@@ -386,10 +388,10 @@ namespace EGG9000.Bot.Automated.Coops {
                     await _db.SaveChangesAsync(CancellationToken.None);
                 foreach(var participant in participantsInCoopButWithoutXref) {
                     if(coop.UserCoopsXrefs.Any(x => x.UserId == participant.DBUser.Id && x.WasAssigned && !x.JoinedCoop)) {
-                        await coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account.");
+                        _queue.EnqueueLow(() => coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account."));
                         await BoolSendDm(participant.DiscordUser, $"It looks like you might have joined the coop with the wrong account in {coopThread.Mention}.", _db);
                     } else {
-                        await coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}> has joined the co-op");
+                        _queue.EnqueueLow(() => coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}> has joined the co-op"));
                     }
                 }
 
@@ -464,7 +466,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(coop.UserCoopsXrefs.Any(x => x.UserId == user.DBUser.Id && x.WasAssigned && !x.JoinedCoop)) {
                             await WrongAccountWarning(user, coopThread, _db, user.Backup.EggIncId);
                         } else {
-                            await coopThread.SendMessageAsync($"<@{user.DBUser.DiscordId}> has joined the co-op");
+                            _queue.EnqueueLow(() => coopThread.SendMessageAsync($"<@{user.DBUser.DiscordId}> has joined the co-op"));
                         }
                     }
                 }
@@ -491,26 +493,26 @@ namespace EGG9000.Bot.Automated.Coops {
 
                     if(!coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = true;
-                        await coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!");
+                        _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!"));
                         await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = false;
-                        await coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish.");
+                        _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish."));
                         await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(!coop.Finished && status.Finished()) {
                         if(waitingOn.Any()) {
                             coop.Status = CoopStatusEnum.Completed;
-                            await coopThread.SendMessageAsync($"Coop {coop.Name} is finished, and is waiting for users to check-in!");
+                            _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is finished, and is waiting for users to check-in!"));
                         } else {
                             finalChannelUpdate = true;
                             coop.Status = CoopStatusEnum.CompletedAllCheckIn;
                             coop.ThreadArchived = true;
-                            await coopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay);
-                            await coopThread.SendMessageAsync($"Coop {coop.Name} is finished!");
+                            _queue.EnqueueLow(() => coopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay));
+                            _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is finished!"));
                         }
                         coop.CoopCompleted = DateTimeOffset.UtcNow;
                         coop.Finished = true;
@@ -523,7 +525,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         finalChannelUpdate = true;
                         coop.Status = CoopStatusEnum.CompletedAllCheckIn;
                         coop.ThreadArchived = true;
-                        await coopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay);
+                        _queue.EnqueueLow(() => coopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay));
                         await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
                 }
@@ -609,15 +611,18 @@ namespace EGG9000.Bot.Automated.Coops {
                             currentContent = existingBotMessage.Content;
                             pingsPerCycle = (1500 - currentContent.Length) / 22;
                         } else {
-                            editPingsInto = await coopThread.SendMessageAsync("[Ping into]");
+                            editPingsInto = await _queue.EnqueueLowAsync(() => coopThread.SendMessageAsync("[Ping into]"));
                             deleteAfter = true;
                         }
                         while(pingsLeft.Count > 0) {
-                            await editPingsInto.ModifyAsync(m => m.Content = currentContent + " " + string.Join(" ", pingsLeft.Take(pingsPerCycle).ToList()));
+                            var pingsBatch = pingsLeft.Take(pingsPerCycle).ToList();
+                            var pingsMessage = editPingsInto;
+                            var capturedContent = currentContent;
+                            _queue.EnqueueLow(() => pingsMessage.ModifyAsync(m => m.Content = capturedContent + " " + string.Join(" ", pingsBatch)));
                             // Remove pingsPerCycle entries from pingsLeft
                             pingsLeft.RemoveRange(0, Math.Min(pingsPerCycle, pingsLeft.Count));
                         }
-                        if(deleteAfter) await editPingsInto.DeleteAsync();
+                        if(deleteAfter) _queue.EnqueueLow(() => editPingsInto.DeleteAsync());
                     } catch {
                         _logger.LogWarning("Failed to send/coalesce pings for {coop}", coopName);
                     }
@@ -698,7 +703,7 @@ namespace EGG9000.Bot.Automated.Coops {
                             if(!userFarmDetails.Xref.OutsideCoop && coop.GuildId == _CPGuildId && !coop.FinishedOrFailedOrExpired() && userFarmDetails.Farm is not null) {
                                 var farm = userFarmDetails.Farm;
                                 if(farm.CoopId.Equals(coop.Name, StringComparison.OrdinalIgnoreCase)) {
-                                    await coopThread.SendMessageAsync($"{discordUser?.Mention ?? user.DiscordUsername}, it looks like your game thinks you have joined the co-op but the game's servers don't see you in the co-op. Please check with the other members of the co-op to verify they don't see you, if they don't then you will need to restart the contract and join again. After you do make sure the bot can see you in the co-op.");
+                                    _queue.EnqueueLow(() => coopThread.SendMessageAsync($"{discordUser?.Mention ?? user.DiscordUsername}, it looks like your game thinks you have joined the co-op but the game's servers don't see you in the co-op. Please check with the other members of the co-op to verify they don't see you, if they don't then you will need to restart the contract and join again. After you do make sure the bot can see you in the co-op."));
                                     userFarmDetails.Xref.OutsideCoop = true;
                                     await _db.SaveChangesAsync(CancellationToken.None);
                                 } else if(farm.CoopId.Length > 0 && farm.FarmType == Ei.FarmType.Contract) {
@@ -732,9 +737,9 @@ namespace EGG9000.Bot.Automated.Coops {
                                             discordUser ??= _client.Guilds.First(g => g.Id == findGuild.Id).GetUser(userFarmDetails.Xref.User.DiscordId);
 
                                             var message = $"It looks like {discordUser?.Mention ?? user.DiscordUsername} has joined another co-op named {farm.CoopId}.";
-                                            await coopThread.SendMessageAsync(message);
+                                            _queue.EnqueueLow(() => coopThread.SendMessageAsync(message));
                                             var logMessage = $"Outside co-op detected for {discordUser?.Mention ?? user.DiscordUsername} they joined *{farm.CoopId}*, but were assigned to <#{coopThread.Id}>";
-                                            var response = ChannelHelper.DetermineAndSend(_client, findGuild, GuildChannelType.OutsideCoopLog, new() { Text = logMessage });
+                                            var response = ChannelHelper.DetermineAndSend(_client.Gateway, findGuild, GuildChannelType.OutsideCoopLog, new() { Text = logMessage });
                                         }
                                     }
 
@@ -843,7 +848,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     foreach(var u in usersWithStatus.Where(u => u.Status is not null && u.Status.TimeCheatDetected && u.Xref is not null && !u.Xref.TimeCheatReported).ToList()) {
                         var account = u.User?.EggIncAccounts?.FirstOrDefault(a => a.Id.ToLower() == u.Backup?.EggIncId.ToLower());
                         if(account is null || account.TimeCheatsMarkedClean) continue;
-                        await ChannelHelper.DetermineAndSend(_client, dbGuild, GuildChannelType.CheaterThread,
+                        await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread,
                             new() { Text = $"Time cheat detected for <@{u.User.DiscordId}> ({u.Backup?.UserName ?? "_No Username_"}) in the coop <#{coop.ThreadID}> (`{coop.Name}`)" }
                         );
                         u.Xref.TimeCheatReported = true; //Set the flag to prevent repetition
@@ -883,9 +888,9 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 if(coop.Status != CoopStatusEnum.Failed && status.Failed()) {
                     if(coop.Contract.GoodUntil > DateTimeOffset.UtcNow) {
-                        await coopThread.SendMessageAsync($"Co-op {coop.Name} failed to reach all the goals and the contract is still available for {(coop.Contract.GoodUntil - DateTimeOffset.UtcNow).Humanize()} if you want to restart and try again.");
+                        _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Co-op {coop.Name} failed to reach all the goals and the contract is still available for {(coop.Contract.GoodUntil - DateTimeOffset.UtcNow).Humanize()} if you want to restart and try again."));
                     } else {
-                        await coopThread.SendMessageAsync($"Co-op {coop.Name} failed to reach all the goals and the contract is no longer available.");
+                        _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Co-op {coop.Name} failed to reach all the goals and the contract is no longer available."));
                     }
                     coop.Status = CoopStatusEnum.Failed;
                     finalChannelUpdate = true;
@@ -906,15 +911,15 @@ namespace EGG9000.Bot.Automated.Coops {
                 var missingCount = coopDetails.CoopParticipants.Count(x => x.Xref is not null && x.CoopStatus is null);
 
                 if(missingCount == 0) {
-                    await HandlePingOnFull(_db, coopDetails.CoopParticipants, coopThread);
+                    await HandlePingOnFull(_db, coopDetails.CoopParticipants, coopThread, _queue);
                 }
 
                 if(status.ClearedForExit) {
-                    await HandlePingOnCheckedIn(_db, coopDetails.CoopParticipants, coopThread);
+                    await HandlePingOnCheckedIn(_db, coopDetails.CoopParticipants, coopThread, _queue);
                 }
 
                 if(coop.FinishedOrFailed()) {
-                    await HandleFinished(_db, coopDetails.CoopParticipants, coopThread);
+                    await HandleFinished(_db, coopDetails.CoopParticipants, coopThread, _queue);
                 }
 
                 timings.Set(7);
@@ -1005,7 +1010,10 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(coopThread.Name != coopname) {
                         for(var i = 0; i < 5; i++) {
                             try {
-                                await coopThread.ModifyAsync(x => x.Name = coopname);
+                                await _queue.EnqueueLowAsync<bool>(async () => {
+                                    await coopThread.ModifyAsync(x => x.Name = coopname);
+                                    return true;
+                                });
                                 break;
                             } catch(Exception) {
                                 _logger.LogInformation("Error updating thread name for {coopName}, delaying...", coop.Name);
@@ -1192,24 +1200,31 @@ namespace EGG9000.Bot.Automated.Coops {
             }
             if(string.IsNullOrWhiteSpace(coop.UpdateMessagesId)) {
                 var UpdateMessagesID = new List<ulong>();
+                var sentPosts = new List<IUserMessage>();
                 foreach(var msg in msgs) {
                     IUserMessage post;
                     if(msg == "@@@EMBED") {
-                        post = await coopChannel.SendMessageAsync(embed: embed);
+                        post = await _queue.EnqueueLowAsync(() => coopChannel.SendMessageAsync(embed: embed));
                     } else {
-                        post = await coopChannel.SendMessageAsync(msg);
+                        var msgCapture = msg;
+                        post = await _queue.EnqueueLowAsync(() => coopChannel.SendMessageAsync(msgCapture));
                     }
                     UpdateMessagesID.Add(post.Id);
-                    await post.PinAsync();
+                    sentPosts.Add(post);
                 }
                 coop.UpdateMessagesId = JsonConvert.SerializeObject(UpdateMessagesID);
-                try {
-                    var messages = await coopChannel.GetMessagesAsync().FlattenAsync();
-                    await coopChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage));
-                } catch(TimeoutException) {
-                    var messages = await coopChannel.GetMessagesAsync().FlattenAsync();
-                    await coopChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage));
-                }
+                var capturedChannel = coopChannel;
+                var capturedPosts = sentPosts;
+                _queue.EnqueueLow(async () => {
+                    foreach(var p in capturedPosts) await p.PinAsync();
+                    try {
+                        var messages = await capturedChannel.GetMessagesAsync().FlattenAsync();
+                        await capturedChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage));
+                    } catch(TimeoutException) {
+                        var messages = await capturedChannel.GetMessagesAsync().FlattenAsync();
+                        await capturedChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage));
+                    }
+                });
             } else {
                 var UpdateMessageIDs = JsonConvert.DeserializeObject<List<ulong>>(coop.UpdateMessagesId);
                 var NewUpdateMessageIDs = JsonConvert.DeserializeObject<List<ulong>>(coop.UpdateMessagesId);
@@ -1223,26 +1238,30 @@ namespace EGG9000.Bot.Automated.Coops {
                                 var post = (RestUserMessage)existingMessages.FirstOrDefault(x => x.Id == UpdateMessageIDs[i]);
                                 if(post == null) {
                                     if(msgs[i] == "@@@EMBED") {
-                                        post = (RestUserMessage)await coopChannel.SendMessageAsync(embed: embed);
+                                        post = (RestUserMessage)await _queue.EnqueueLowAsync(() => coopChannel.SendMessageAsync(embed: embed));
                                     } else {
-                                        post = (RestUserMessage)await coopChannel.SendMessageAsync(msgs[i]);
+                                        var msgCapture = msgs[i];
+                                        post = (RestUserMessage)await _queue.EnqueueLowAsync(() => coopChannel.SendMessageAsync(msgCapture));
                                     }
                                     NewUpdateMessageIDs.Remove(UpdateMessageIDs[i]);
                                     NewUpdateMessageIDs.Add(post.Id);
                                 } else {
+                                    var postCaptureModify = post;
                                     if(msgs[i] == "@@@EMBED") {
-                                        await post.ModifyWithTimeoutAsync(msg => { msg.Embed = embed; msg.Content = null; });
+                                        _queue.EnqueueLow(() => postCaptureModify.ModifyWithTimeoutAsync(msg => { msg.Embed = embed; msg.Content = null; }));
                                     } else {
                                         var changes = post.Content.CompareChanges(msgs[i]);
                                         if(changes > 0) {
-                                            await post.ModifyWithTimeoutAsync(msg => msg.Content = msgs[i]);
+                                            var msgCapture = msgs[i];
+                                            _queue.EnqueueLow(() => postCaptureModify.ModifyWithTimeoutAsync(msg => msg.Content = msgCapture));
                                         } else {
                                         }
                                     }
                                 }
                                 if(!post.IsPinned) {
                                     try {
-                                        await post.PinAsync();
+                                        var postCapturePin = post;
+                                        _queue.EnqueueLow(() => postCapturePin.PinAsync());
                                         pinnedMessages = true;
                                     } catch(JsonReaderException) {
                                         _logger.LogWarning("JsonReaderException when pinning message in coop {coop}", coop.Name);
@@ -1256,15 +1275,18 @@ namespace EGG9000.Bot.Automated.Coops {
                             }
                         } else {
                             if(msgs[i] == "@@@EMBED") {
-                                var post = await coopChannel.SendMessageAsync(embed: embed);
+                                var post = await _queue.EnqueueLowAsync(() => coopChannel.SendMessageAsync(embed: embed));
                                 NewUpdateMessageIDs.Add(post.Id);
                                 pinnedMessages = true;
-                                await post.PinAsync();
+                                var postCapture = post;
+                                _queue.EnqueueLow(() => postCapture.PinAsync());
                             } else {
-                                var post = await coopChannel.SendMessageAsync(msgs[i]);
+                                var msgCapture = msgs[i];
+                                var post = await _queue.EnqueueLowAsync(() => coopChannel.SendMessageAsync(msgCapture));
                                 NewUpdateMessageIDs.Add(post.Id);
                                 pinnedMessages = true;
-                                await post.PinAsync();
+                                var postCapture = post;
+                                _queue.EnqueueLow(() => postCapture.PinAsync());
                             }
                         }
 
@@ -1272,10 +1294,10 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(pinnedMessages) {
                         try {
                             var messages = await coopChannel.GetMessagesAsync().FlattenAsync();
-                            await coopChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage));
+                            _queue.EnqueueLow(() => coopChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage)));
                         } catch(TimeoutException) {
                             var messages = await coopChannel.GetMessagesAsync().FlattenAsync();
-                            await coopChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage));
+                            _queue.EnqueueLow(() => coopChannel.DeleteMessagesBatchAsync(messages.Where(x => x.Type == MessageType.ChannelPinnedMessage)));
                         }
                     }
 
@@ -1465,7 +1487,8 @@ namespace EGG9000.Bot.Automated.Coops {
                     var warningText = messages[index].Replace("@name", user.DiscordUser.Mention + (timeEmpty < 0 ? $" [Empty silos in {timeEmpty} hours {coopChannel.Mention}]" : $" [Silos have been empty for {timeEmpty} hours {coopChannel.Mention}]"));
                     var dmResult = await BoolSendDm(user.DiscordUser, warningText, _db);
                     if(dmResult != DMResult.Success) {
-                        await coopChannel.SendMessageAsync($"{warningText} {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}");
+                        var fallbackText = $"{warningText} {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}";
+                        _queue.EnqueueLow(() => coopChannel.SendMessageAsync(fallbackText));
                     }
                 }
                 sleepTracking.Add(currentSleep);
@@ -1487,7 +1510,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(needsDemerit && user.DBUser is not null) {
                         currentSleep.DemeritsGiven++;
                         if(user.DBUser.IsFreshEgg()) {
-                            await coopChannel.SendMessageAsync($"{user.DiscordUser?.Mention ?? user.DBUser.DiscordUsername}: You will start receiving demerits for this 7 days after joining the server. Your silos have been empty for {nextDemeritAt} hours.");
+                            _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"{user.DiscordUser?.Mention ?? user.DBUser.DiscordUsername}: You will start receiving demerits for this 7 days after joining the server. Your silos have been empty for {nextDemeritAt} hours."));
                         } else {
                             var demerit = new Demerit {
                                 When = DateTimeOffset.Now,
@@ -1504,8 +1527,10 @@ namespace EGG9000.Bot.Automated.Coops {
                             if(count >= 3) {
                                 demeritText = $"**{demeritText}**";
                             }
-                            await coopChannel.SendMessageAsync(demeritText);
-                            await demeritChannel.SendMessageAsync($"{demeritText} {coopChannel.Mention}");
+                            var coopChannelText = demeritText;
+                            var demeritChannelText = $"{demeritText} {coopChannel.Mention}";
+                            _queue.EnqueueLow(() => coopChannel.SendMessageAsync(coopChannelText));
+                            _queue.EnqueueLow(() => demeritChannel.SendMessageAsync(demeritChannelText));
                         }
                     }
                     user.Xref.HoursSleeping = (int)Math.Floor((DateTimeOffset.Now - currentSleep.SleepStart).TotalHours);
@@ -1532,12 +1557,12 @@ namespace EGG9000.Bot.Automated.Coops {
                 if(userFarmDetail.Xref.CreatedOn > DateTimeOffset.Now.AddHours(-18)) {
                     _db.Remove(userFarmDetail.Xref);
                     await _db.SaveChangesAsync();
-                    await coopChannel.SendMessageAsync($"Removed {userFarmDetail.DiscordUser?.GetCleanName() ?? user.DiscordUsername} without a demerit since they were added less than 18 hours before the co-op finished.");
+                    _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"Removed {userFarmDetail.DiscordUser?.GetCleanName() ?? user.DiscordUsername} without a demerit since they were added less than 18 hours before the co-op finished."));
                     continue;
                 }
 
                 if(user.Registered > DateTimeOffset.Now.AddDays(-7)) {
-                    await coopChannel.SendMessageAsync($"{userFarmDetail.DiscordUser?.Mention ?? user.DiscordUsername}, you failed to join this co-op. After your first week in this server you will get a demerit for failing to join an assigned co-op. Ask staff if you have any questions.");
+                    _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"{userFarmDetail.DiscordUser?.Mention ?? user.DiscordUsername}, you failed to join this co-op. After your first week in this server you will get a demerit for failing to join an assigned co-op. Ask staff if you have any questions."));
                     continue;
                 }
 
@@ -1546,30 +1571,32 @@ namespace EGG9000.Bot.Automated.Coops {
             }
         }
 
-        public static async Task HandlePingOnFull(ApplicationDbContext db, List<UserFarmDetails> userFarmDetails, IThreadChannel coopChannel) {
+        public static async Task HandlePingOnFull(ApplicationDbContext db, List<UserFarmDetails> userFarmDetails, IThreadChannel coopChannel, IDiscordQueue queue) {
             foreach(var userStatus in userFarmDetails.Where(x => x.Xref?.CoopSetting?.PingOnFull ?? false)) {
                 userStatus.Xref.CoopSetting.PingOnFull = false;
                 userStatus.Xref.UpdateCoopSetting();
 
                 var dmResult = await BoolSendDm(userStatus.DiscordUser, $"All users have joined the co-op {coopChannel.Mention}", db);
                 if(dmResult != DMResult.Success) {
-                    await coopChannel.SendMessageAsync($"{userStatus.DiscordUser.Mention} All users have joined the co-op {coopChannel.Mention} {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}");
+                    var capturedUser = userStatus.DiscordUser;
+                    queue.EnqueueLow(() => coopChannel.SendMessageAsync($"{capturedUser.Mention} All users have joined the co-op {coopChannel.Mention} {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}"));
                 }
             }
         }
-        public static async Task HandlePingOnCheckedIn(ApplicationDbContext db, List<UserFarmDetails> userFarmDetails, IThreadChannel coopChannel) {
+        public static async Task HandlePingOnCheckedIn(ApplicationDbContext db, List<UserFarmDetails> userFarmDetails, IThreadChannel coopChannel, IDiscordQueue queue) {
             foreach(var userStatus in userFarmDetails.Where(x => x.Xref?.CoopSetting?.PingOnEveryoneCheckedIn ?? false)) {
                 userStatus.Xref.CoopSetting.PingOnEveryoneCheckedIn = false;
                 userStatus.Xref.UpdateCoopSetting();
 
                 var dmResult = await BoolSendDm(userStatus.DiscordUser, $"The co-op {coopChannel.Mention} has finished and you are able to exit the co-op.", db);
                 if(dmResult != DMResult.Success) {
-                    await coopChannel.SendMessageAsync($"{userStatus.DiscordUser.Mention} The co-op {coopChannel.Mention} has finished and everyone is checked in. {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}");
+                    var capturedUser = userStatus.DiscordUser;
+                    queue.EnqueueLow(() => coopChannel.SendMessageAsync($"{capturedUser.Mention} The co-op {coopChannel.Mention} has finished and everyone is checked in. {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}"));
                 }
             }
         }
 
-        public static async Task HandleFinished(ApplicationDbContext db, List<UserFarmDetails> userFarmDetails, IThreadChannel coopChannel) {
+        public static async Task HandleFinished(ApplicationDbContext db, List<UserFarmDetails> userFarmDetails, IThreadChannel coopChannel, IDiscordQueue queue) {
             foreach(var userStatus in userFarmDetails.Where(x => x.Xref?.CoopSetting?.PingOnFinished ?? false)) {
                 userStatus.Xref.CoopSetting.PingOnFinished = false;
                 userStatus.Xref.UpdateCoopSetting();
@@ -1577,14 +1604,15 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 var dmResult = await BoolSendDm(userStatus.DiscordUser, $"The co-op {coopChannel.Mention} has finished.", db);
                 if(dmResult != DMResult.Success) {
-                    await coopChannel.SendMessageAsync($"{userStatus.DiscordUser.Mention} The co-op {coopChannel.Mention} has finished. {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}");
+                    var capturedUser = userStatus.DiscordUser;
+                    queue.EnqueueLow(() => coopChannel.SendMessageAsync($"{capturedUser.Mention} The co-op {coopChannel.Mention} has finished. {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}"));
                 }
             }
         }
 
         public async Task WrongAccountWarning(UserFarmDetails user, IThreadChannel coopThread, ApplicationDbContext _db, string WrongEIID) {
 
-            await coopThread.SendMessageAsync($"<@{user.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account.");
+            _queue.EnqueueLow(() => coopThread.SendMessageAsync($"<@{user.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account."));
             await BoolSendDm(user.DiscordUser, $"It looks like you might have joined the coop with the wrong account in {coopThread.Mention}.", _db);
 
         }
@@ -1594,7 +1622,8 @@ namespace EGG9000.Bot.Automated.Coops {
 
             var dmResult = await BoolSendDm(discordUser, $"{Message}: {coop.Name} for {EggIncStatics.GetEggByContract(coop.Contract, await db.GetCustomEggsAsync()).emoji} {coop.Contract.Name} - {coopChannel.Mention}", db);
             if(dmResult != DMResult.Success) {
-                await coopChannel.SendMessageAsync($"{discordUser.Mention} {Message}: {coop.Name} for {EggIncStatics.GetEggByContract(coop.Contract, await db.GetCustomEggsAsync()).emoji} {coop.Contract.Name} - {coopChannel.Mention} {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}");
+                var fallbackMessage = $"{discordUser.Mention} {Message}: {coop.Name} for {EggIncStatics.GetEggByContract(coop.Contract, await db.GetCustomEggsAsync()).emoji} {coop.Contract.Name} - {coopChannel.Mention} {(dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)")}";
+                _queue.EnqueueLow(() => coopChannel.SendMessageAsync(fallbackMessage));
             }
         }
 
@@ -1608,13 +1637,13 @@ namespace EGG9000.Bot.Automated.Coops {
             }
             var existingDemerit = await _db.Demerit.AnyAsync(x => x.ContractID == coop.ContractID && x.UserId == user.Id);
             if(existingDemerit || xref.JoinedCoop) {
-                await coopChannel.SendMessageAsync($"Removing {discordUser?.Mention ?? user.DiscordUsername} due to: {reason}");
+                _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"Removing {discordUser?.Mention ?? user.DiscordUsername} due to: {reason}"));
                 _db.Remove(xref);
                 await _db.SaveChangesAsync();
             } else {
                 _db.Remove(xref);
                 if(user.IsFreshEgg()) {
-                    await coopChannel.SendMessageAsync($"{discordUser.Mention ?? user.DiscordUsername}: You will start receiving demerits for this 7 days after joining the server. {reason} ");
+                    _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"{discordUser.Mention ?? user.DiscordUsername}: You will start receiving demerits for this 7 days after joining the server. {reason} "));
                 } else {
                     var demerit = new Demerit {
                         When = DateTimeOffset.Now,
@@ -1627,10 +1656,11 @@ namespace EGG9000.Bot.Automated.Coops {
                     await _db.SaveChangesAsync();
                     var count = await _db.Demerit.AsQueryable().Where(x => x.UserId == user.Id && x.When > DateTimeOffset.Now.AddMonths(-1)).CountAsync();
                     var demeritText = $"Demerit added to {discordUser?.Mention ?? user.DiscordUsername} for the reason: {demerit.Reason} ({count} demerits)";
-                    await coopChannel.SendMessageAsync(demeritText);
+                    _queue.EnqueueLow(() => coopChannel.SendMessageAsync(demeritText));
                     if(count >= 3)
                         demeritText = $"**{demeritText}**";
-                    await demeritChannel.SendMessageAsync(demeritText + $" {coopChannel.Mention}");
+                    var demeritChannelText = demeritText + $" {coopChannel.Mention}";
+                    _queue.EnqueueLow(() => demeritChannel.SendMessageAsync(demeritChannelText));
                 }
             }
 

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -1247,6 +1247,8 @@ namespace EGG9000.Bot.Automated.Coops {
                                         _logger.LogWarning("JsonReaderException when pinning message in coop {coop}", coop.Name);
                                     }
                                 }
+                            } catch(Discord.Net.HttpException httpEx) when(httpEx.DiscordCode == Discord.DiscordErrorCode.MissingPermissions) {
+                                _logger.LogWarning("Missing permissions to update message in coop {coop}", coop.Name);
                             } catch(Exception e) {
                                 _logger.LogError(e, "Error updating messages");
                                 _bugSnag.Notify(e);

--- a/EGG9000.Bot/Automated/EventUpdater.cs
+++ b/EGG9000.Bot/Automated/EventUpdater.cs
@@ -18,6 +18,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -173,7 +174,8 @@ namespace EGG9000.Bot.Automated {
 
                     if(channel.Name != newName && channel != null) {
                         _logger.LogInformation("Renaming game-events channel in {guild}: '{oldName}' -> '{newName}'", guild.Name, channel.Name, newName);
-                        await channel.ModifyAsync(x => x.Name = newName);
+                        var capturedNewName = newName;
+                        _queue.EnqueueLow(() => channel.ModifyAsync(x => x.Name = capturedNewName));
                     }
                     StillAlive();
                 }
@@ -206,7 +208,8 @@ namespace EGG9000.Bot.Automated {
 
                     if(ccChannel.Name != newName && ccChannel != null) {
                         _logger.LogInformation("Renaming subscriber-game-events channel in {guild}: '{oldName}' -> '{newName}'", guild.Name, ccChannel.Name, newName);
-                        await ccChannel.ModifyAsync(x => x.Name = newName);
+                        var capturedCcNewName = newName;
+                        _queue.EnqueueLow(() => ccChannel.ModifyAsync(x => x.Name = capturedCcNewName));
                     }
                 }
             }
@@ -237,13 +240,19 @@ namespace EGG9000.Bot.Automated {
                     //Send to non-CCs without ping
                     if(eventChannel != null) {
                         var ultraNotification = customization?.Settings?.Notifications?.FirstOrDefault(x => x.MinValue == -1) ?? null;
-                        message = await eventChannel.SendFileIfExistsAsync(embedImage, text: ultraNotification != null ? $"<@&{ultraNotification.RoleID}>" : null, embed: embed);
+                        var capturedEmbedImage = embedImage;
+                        var capturedEmbed = embed;
+                        var capturedUltraPingText = ultraNotification != null ? $"<@&{ultraNotification.RoleID}>" : null;
+                        message = await _queue.EnqueueLowAsync(() => eventChannel.SendFileIfExistsAsync(capturedEmbedImage, text: capturedUltraPingText, embed: capturedEmbed));
                         _logger.LogDebug("PostMessages: sent CC event (no ping) to non-CC channel in {guild}, messageId={messageId}", guild.Name, message?.Id);
                     }
 
                     //If the CC event channel was found, that's where we'll ping for CC events
                     if(ccEventChannel != null) {
-                        var ccMessage = await ccEventChannel.SendFileIfExistsAsync(embedImage, text: notification != null ? $"<@&{notification.RoleID}>" : null, embed: embed);
+                        var capturedCcEmbedImage = embedImage;
+                        var capturedCcEmbed = embed;
+                        var capturedCcPingText = notification != null ? $"<@&{notification.RoleID}>" : null;
+                        var ccMessage = await _queue.EnqueueLowAsync(() => ccEventChannel.SendFileIfExistsAsync(capturedCcEmbedImage, text: capturedCcPingText, embed: capturedCcEmbed));
                         //Add the CC event channel message to the IDs
                         messageIds.Add(ccMessage.Id);
                         _logger.LogDebug("PostMessages: sent CC event (with ping={hasPing}) to CC channel in {guild}, messageId={messageId}",
@@ -252,7 +261,10 @@ namespace EGG9000.Bot.Automated {
                 } else {
                     //Only send to non-CC channel, with ping
                     if(eventChannel != null) {
-                        message = await eventChannel.SendFileIfExistsAsync(embedImage, text: notification != null ? $"<@&{notification.RoleID}>" : null, embed: embed);
+                        var capturedEmbedImage = embedImage;
+                        var capturedEmbed = embed;
+                        var capturedPingText = notification != null ? $"<@&{notification.RoleID}>" : null;
+                        message = await _queue.EnqueueLowAsync(() => eventChannel.SendFileIfExistsAsync(capturedEmbedImage, text: capturedPingText, embed: capturedEmbed));
                         _logger.LogDebug("PostMessages: sent event (with ping={hasPing}) to event channel in {guild}, messageId={messageId}",
                             notification != null, guild.Name, message?.Id);
                     }
@@ -278,6 +290,9 @@ namespace EGG9000.Bot.Automated {
             foreach(var dbguild in dbguilds) {
                 var customization = await _db.GetCustomizationAsync(dbguild, currentEvent);
                 var (embed, embedImage) = await GetEventEmbed(_db, currentEvent, customization, Ended, Crossout);
+                byte[] embedImageBytes = embedImage.HasValue ? ((MemoryStream)embedImage.Value.Stream).ToArray() : null;
+                string embedImageFileName = embedImage.HasValue ? embedImage.Value.FileName : null;
+                string embedImageDescription = embedImage.HasValue ? embedImage.Value.Description : null;
 
                 var guild = _client.Guilds.FirstOrDefault(x => x.Id == dbguild.DiscordSeverId);
                 if(guild == null) continue;
@@ -291,11 +306,15 @@ namespace EGG9000.Bot.Automated {
                                 var notification = customization.Settings.Notifications?
                                     .OrderByDescending(x => x.MinValue)
                                     .FirstOrDefault(x => (decimal)currentEvent.Multiplier >= x.MinValue && x.GuildID == dbguild.DiscordSeverId);
-                                await message.ModifyAsync(msg => {
-                                    msg.Embed = embed;
-                                    msg.Content = (notification != null && !currentEvent.CcOnly) ? $"<@&{notification.RoleID}>" : null;
-                                    msg.Attachments = embedImage.HasValue ? new List<FileAttachment> { embedImage.Value } : [];
-                                });
+                                var capturedMessage = message;
+                                var capturedEmbed = embed;
+                                var capturedEmbedImage = embedImageBytes != null ? new FileAttachment(new MemoryStream(embedImageBytes), embedImageFileName, embedImageDescription) : (FileAttachment?)null;
+                                var capturedContent = (notification != null && !currentEvent.CcOnly) ? $"<@&{notification.RoleID}>" : null;
+                                _queue.EnqueueLow(() => capturedMessage.ModifyAsync(msg => {
+                                    msg.Embed = capturedEmbed;
+                                    msg.Content = capturedContent;
+                                    msg.Attachments = capturedEmbedImage.HasValue ? new List<FileAttachment> { capturedEmbedImage.Value } : [];
+                                }));
                                 _logger.LogDebug("UpdateMessages [{reason}]: modified messageId={messageId} in event channel of {guild}",
                                     reason, mid, guild.Name);
                             }
@@ -314,11 +333,15 @@ namespace EGG9000.Bot.Automated {
                                 var notification = customization.Settings.Notifications?
                                     .OrderByDescending(x => x.MinValue)
                                     .FirstOrDefault(x => (decimal)currentEvent.Multiplier >= x.MinValue && x.GuildID == dbguild.DiscordSeverId);
-                                await message.ModifyAsync(msg => {
-                                    msg.Embed = embed;
-                                    msg.Content = notification != null ? $"<@&{notification.RoleID}>" : null;
-                                    msg.Attachments = embedImage.HasValue ? new List<FileAttachment> { embedImage.Value } : [];
-                                });
+                                var capturedMessage = message;
+                                var capturedEmbed = embed;
+                                var capturedEmbedImage = embedImageBytes != null ? new FileAttachment(new MemoryStream(embedImageBytes), embedImageFileName, embedImageDescription) : (FileAttachment?)null;
+                                var capturedContent = notification != null ? $"<@&{notification.RoleID}>" : null;
+                                _queue.EnqueueLow(() => capturedMessage.ModifyAsync(msg => {
+                                    msg.Embed = capturedEmbed;
+                                    msg.Content = capturedContent;
+                                    msg.Attachments = capturedEmbedImage.HasValue ? new List<FileAttachment> { capturedEmbedImage.Value } : [];
+                                }));
                                 _logger.LogDebug("UpdateMessages [{reason}]: modified messageId={messageId} in CC event channel of {guild}",
                                     reason, mid, guild.Name);
                             }
@@ -475,8 +498,9 @@ namespace EGG9000.Bot.Automated {
                         var channel = await _client.GetChannelAsync(GuildChannelType.LimitedTimeShells, guild);
                         if(channel is not null) {
                             var ShellsRole = dbguild.ChannelDetails.FirstOrDefault(x => x.ChannelType == GuildChannelType.LimitedTimeShellsRole)?.Id;
-
-                            var message = await channel.SendMessageAsync(ShellsRole.HasValue ? $"<@&{ShellsRole}>" : null, embed: embed);
+                            var capturedShellPingText = ShellsRole.HasValue ? $"<@&{ShellsRole}>" : null;
+                            var capturedEmbed = embed;
+                            var message = await _queue.EnqueueLowAsync(() => channel.SendMessageAsync(capturedShellPingText, embed: capturedEmbed));
 
                             messageIDs.Add((channel.Id, message.Id));
                             _logger.LogDebug("Posted shell message in {guild}, messageId={messageId}", guild.Name, message.Id);
@@ -491,7 +515,11 @@ namespace EGG9000.Bot.Automated {
                         var dbguild = dbguilds.First(x => x.ChannelDetails.Any(x => x.Id == channel?.Id));
                         var ShellsRole = dbguild.ChannelDetails.FirstOrDefault(x => x.ChannelType == GuildChannelType.LimitedTimeShellsRole)?.Id;
                         if(channel is not null) {
-                            await (channel as SocketTextChannel).ModifyMessageAsync(message.Item2, msg => { msg.Embed = embed; msg.Content = ShellsRole.HasValue ? $"<@&{ShellsRole}>" : null; });
+                            var capturedChannel = channel as SocketTextChannel;
+                            var capturedMessageId = message.Item2;
+                            var capturedEmbed = embed;
+                            var capturedShellRolePingText = ShellsRole.HasValue ? $"<@&{ShellsRole}>" : null;
+                            _queue.EnqueueLow(() => capturedChannel.ModifyMessageAsync(capturedMessageId, msg => { msg.Embed = capturedEmbed; msg.Content = capturedShellRolePingText; }));
                         }
                     }
                 }

--- a/EGG9000.Bot/Automated/LeaderboardUpdates.cs
+++ b/EGG9000.Bot/Automated/LeaderboardUpdates.cs
@@ -149,7 +149,8 @@ namespace EGG9000.Bot.Automated {
                                 $"({(dbCoop is not null? $"<#{dbCoop.ThreadID}> - `{dbCoop.Name}`" : $"`{breakCooper.Farm.CoopId}`")}) " +
                                 $"for {(guildContract is not null ? $"<#{guildContract.DiscordChannelId}>" : $"`{breakCooper.Farm.ContractId ?? "???"}`")}";
 
-                            var result = await ChannelHelper.DetermineAndSend(_client, dbguild, GuildChannelType.BreakCoopLog, new() { Text = message });
+                            var capturedMessage = message;
+                            _queue.EnqueueLow(() => ChannelHelper.DetermineAndSend(_client.Gateway, dbguild, GuildChannelType.BreakCoopLog, new() { Text = capturedMessage }));
 
                             breakCooper.User.Account.BreakCoopWarningSent = true;
                             breakCooper.User.User.UpdateAccounts();
@@ -175,7 +176,8 @@ namespace EGG9000.Bot.Automated {
                             var username = merCheater.Account.Name ?? merCheater.Account.Backup.UserName ?? "Unknown"; if(username == "") username = "Unknown";
                             var message = $"<@{merCheater.User.DiscordId}>{(merCheater.User.EggIncAccounts.Count > 1 ? $" ({username}) " : " ")} may be cheating. MER is higher than expected, at `{mer:n2}`, after `{(int)merCheater.Backup.NumPrestiges}` prestiges.";
 
-                            var result = await ChannelHelper.DetermineAndSend(_client, dbguild, GuildChannelType.CheaterThread, new() { Text = message });
+                            var capturedMerMessage = message;
+                            _queue.EnqueueLow(() => ChannelHelper.DetermineAndSend(_client.Gateway, dbguild, GuildChannelType.CheaterThread, new() { Text = capturedMerMessage }));
 
                             merCheater.Account.MERWarningSent = true;
                             merCheater.User.UpdateAccounts();
@@ -202,8 +204,9 @@ namespace EGG9000.Bot.Automated {
 
                         if(!dbUser.showEB && !string.IsNullOrEmpty(discordUser.Nickname) && discordUser.GetCleanName() != discordUser.Nickname && discordUser.Guild.OwnerId != discordUser.Id) {
                             try {
+                                var capturedUser = discordUser;
                                 _logger.LogInformation("Updating {user} to {newname}", discordUser.Nickname, discordUser.GetCleanName());
-                                await discordUser.ModifyAsync(x => x.Nickname = discordUser.GetCleanName());
+                                await _queue.EnqueueLowAsync<bool>(async () => { await capturedUser.ModifyAsync(x => x.Nickname = capturedUser.GetCleanName()); return true; });
                             } catch(Exception) {
                                 _logger.LogWarning("Unable to change name of {user}", discordUser.GetName());
                             }
@@ -258,20 +261,27 @@ namespace EGG9000.Bot.Automated {
             for(var i = 0; i < Math.Max(msgs.Count, table1.Count); i++) {
                 if(msgs.Count > i && table1.Count > i) {
                     if(table1[i] == "@@@EMBED") {
-                        await ((RestUserMessage)msgs[i]).ModifyAsync(msg => { msg.Embed = GetEmbed(guild, channel, msgs[0], dbguild); msg.Content = ""; });
+                        var capturedMsg = (RestUserMessage)msgs[i];
+                        var capturedEmbed = GetEmbed(guild, channel, msgs[0], dbguild);
+                        _queue.EnqueueLow(() => capturedMsg.ModifyAsync(msg => { msg.Embed = capturedEmbed; msg.Content = ""; }));
                     } else if(msgs[i].Content != table1[i]) {
-                        await ((RestUserMessage)msgs[i]).ModifyAsync(msg => { msg.Embed = null; msg.Content = table1[i]; });
+                        var capturedMsg = (RestUserMessage)msgs[i];
+                        var capturedContent = table1[i];
+                        _queue.EnqueueLow(() => capturedMsg.ModifyAsync(msg => { msg.Embed = null; msg.Content = capturedContent; }));
                     }
                 } else if(msgs.Count <= i) {
                     if(table1[i] == "@@@EMBED") {
                         if(msgs.Count > 0) {
-                            await channel.SendMessageAsync(embed: GetEmbed(guild, channel, msgs[0], dbguild));
+                            var capturedEmbed = GetEmbed(guild, channel, msgs[0], dbguild);
+                            _queue.EnqueueLow(() => channel.SendMessageAsync(embed: capturedEmbed));
                         }
                     } else {
-                        var msg = await channel.SendMessageAsync(table1[i]);
+                        var capturedContent = table1[i];
+                        _queue.EnqueueLow(() => channel.SendMessageAsync(capturedContent));
                     }
                 } else {
-                    await ((RestUserMessage)msgs[i]).ModifyAsync(msg => { msg.Content = "\u17B5"; msg.Embed = null; });
+                    var capturedMsg = (RestUserMessage)msgs[i];
+                    _queue.EnqueueLow(() => capturedMsg.ModifyAsync(msg => { msg.Content = "\u17B5"; msg.Embed = null; }));
                     //await ((RestUserMessage)msgs[i]).DeleteAsync();
                 }
             }

--- a/EGG9000.Bot/Automated/ManageOverflow.cs
+++ b/EGG9000.Bot/Automated/ManageOverflow.cs
@@ -63,7 +63,7 @@ namespace EGG9000.Bot.Automated {
                 }
                 await HandleChannelPermissionSyncs(mainServer, overflowServers, cancellationToken);
                 await HandleRoleSyncs(guild, mainServer, overflowServers, cancellationToken);
-                _client.RoleUpdated += _client_RoleUpdated;
+                _client.Gateway.RoleUpdated += _client_RoleUpdated;
 
 #if DEBUG
                 //continue;

--- a/EGG9000.Bot/Automated/ManageOverflow.cs
+++ b/EGG9000.Bot/Automated/ManageOverflow.cs
@@ -307,7 +307,7 @@ namespace EGG9000.Bot.Automated {
                     foreach(var overwrite in coopCategory.PermissionOverwrites) {
                         if(cancellationToken.IsCancellationRequested) { continue; }
                         StillAlive();
-                        var match = matches.FirstOrDefault(x => x.OverflowRole.Id == overwrite.TargetId);
+                        var match = matches.FirstOrDefault(x => x.OverflowRole?.Id == overwrite.TargetId);
                         if(match == null) {
                             if(overwrite.TargetType == PermissionTarget.Role) {
                                 await coopCategory.RemovePermissionOverwriteAsync(overflowServer.GetRole(overwrite.TargetId));

--- a/EGG9000.Bot/Automated/NewContracts.cs
+++ b/EGG9000.Bot/Automated/NewContracts.cs
@@ -194,7 +194,9 @@ namespace EGG9000.Bot.Automated {
 
                     var subscriptionContractCategory = await _client.GetCategoryAsync(GuildChannelType.SubscriptionContractCategory, guild);
                     var contractCategory = (contract.cc_only && subscriptionContractCategory is not null) ? subscriptionContractCategory : await _client.GetCategoryAsync(GuildChannelType.ContractCategory, guild);
-                    var contractChannel = await guild.CreateTextChannelAsync((contractResponse.MaxCoopSize > 1 ? "🐣" : "👤") + contractResponse.Identifier, x => { x.CategoryId = contractCategory.Id; x.Topic = ""; });
+                    var capturedCategoryId = contractCategory.Id;
+                    var capturedChannelName = (contractResponse.MaxCoopSize > 1 ? "🐣" : "👤") + contractResponse.Identifier;
+                    var contractChannel = await _queue.EnqueueLowAsync(() => guild.CreateTextChannelAsync(capturedChannelName, x => { x.CategoryId = capturedCategoryId; x.Topic = ""; }));
 
                     guildContract = new GuildContract {
                         ContractID = contract.ID,
@@ -224,7 +226,10 @@ namespace EGG9000.Bot.Automated {
                         var ultraMessageOut = $"The contract <#{contractChannel.Id}> has been released to <:ultra:1131045418319495369> Ultra Subscriber Players, and you have not completed this contract yet. The contract expires {DiscordHelpers.TimeStamper(validFor)}.";
 
                         foreach(var pingableUser in pingableUsers) {
-                            var dmResult = await BoolSendDm(_client.GetUser(pingableUser.DiscordId), ultraMessageOut, _db);
+                            var capturedPingUser = _client.GetUser(pingableUser.DiscordId);
+                            var capturedUltraMessage = ultraMessageOut;
+                            var capturedDb = _db;
+                            var dmResult = await _queue.EnqueueLowAsync(() => BoolSendDm(capturedPingUser, capturedUltraMessage, capturedDb));
                             if(dmResult != DMResult.Success) {
                                 _logger.LogInformation("Unable to send 'Ultra Contract Release' message to {username} {reason}.", pingableUser.DiscordUsername, dmResult == DMResult.CannotSendToUser ? "(DMs are blocked)" : "(Discord is not responding)");
                             }

--- a/EGG9000.Bot/Automated/ShipReturnDM.cs
+++ b/EGG9000.Bot/Automated/ShipReturnDM.cs
@@ -96,12 +96,18 @@ namespace EGG9000.Bot.Automated {
                             _logger.LogWarning("Too late to send ShipReturnDM to {user}, the ship returned {relativetime} ago", user.DiscordUsername, (DateTimeOffset.Now - shipReturnTime).Humanize().ShortenTime());
                         }
 
-                        var dmResult = await BoolSendDm(discordUser, message, _db);
+                        var capturedUser = discordUser;
+                        var capturedMessage = message;
+                        var capturedDb = _db;
+                        var dmResult = await _queue.EnqueueLowAsync(() => BoolSendDm(capturedUser, capturedMessage, capturedDb));
                         if(dmResult != DMResult.Success) {
                             var dbguild = await _db.Guilds.FirstAsync(x => x.DiscordSeverId == user.GuildId, CancellationToken.None);
                             var socketGuild = _client.Guilds.FirstOrDefault(g => g.Id ==  dbguild.Id);
-                            var response = await ChannelHelper.DetermineAndSend(_client, dbguild, GuildChannelType.WarningMessagesForUser, new() 
-                            { Text = $"<@{user.DiscordId}> you have elected to receive DMs for Ship Return status, but {(dmResult == DMResult.CannotSendToUser ? "have blocked the bot from sending you DMs" : "Discord is not responding")}" });
+                            var capturedDbGuild = dbguild;
+                            var capturedUserId = user.DiscordId;
+                            var capturedReason = dmResult == DMResult.CannotSendToUser ? "have blocked the bot from sending you DMs" : "Discord is not responding";
+                            _queue.EnqueueLow(() => ChannelHelper.DetermineAndSend(_client.Gateway, capturedDbGuild, GuildChannelType.WarningMessagesForUser, new()
+                            { Text = $"<@{capturedUserId}> you have elected to receive DMs for Ship Return status, but {capturedReason}" }));
                         }
                         await _db.SaveChangesAsync(CancellationToken.None);
                     } catch(Exception e) {

--- a/EGG9000.Bot/Automated/StaffCoopsMessage.cs
+++ b/EGG9000.Bot/Automated/StaffCoopsMessage.cs
@@ -39,7 +39,9 @@ namespace EGG9000.Bot.Automated {
                 var channel = guild.GetTextChannel(guildInfo.ChannelID);
                 var message = (RestUserMessage)await channel.GetMessageAsync(guildInfo.MessageID);
 
-                await message.ModifyAsync(x => x.Content = string.Join("\n", adminsWithChannels.Select(x => $"{x.Admin.DiscordUsername}: {string.Join(", ", x.Channels)}")));
+                var capturedContent = string.Join("\n", adminsWithChannels.Select(x => $"{x.Admin.DiscordUsername}: {string.Join(", ", x.Channels)}"));
+                var capturedMessage = message;
+                _queue.EnqueueLow(() => capturedMessage.ModifyAsync(x => x.Content = capturedContent));
             }
         }
 

--- a/EGG9000.Bot/Automated/_UpdaterBase.cs
+++ b/EGG9000.Bot/Automated/_UpdaterBase.cs
@@ -59,6 +59,7 @@ namespace EGG9000.Bot.Automated {
 
         protected Bugsnag.IClient _bugSnag;
         protected ILogger<T> _logger;
+        protected IDiscordQueue _queue;
         protected IDbContextFactory<ApplicationDbContext> _dbContextFactory;
 
         protected ulong _CPGuildId;
@@ -90,6 +91,7 @@ namespace EGG9000.Bot.Automated {
             _dbContextFactory = provider.GetService<IDbContextFactory<ApplicationDbContext>>();
             Instance = this;
             _bugSnag = provider.GetService<Bugsnag.IClient>();
+            _queue = provider.GetRequiredService<IDiscordQueue>();
             _provider = provider;
             _ = ulong.TryParse(_configuration.GetConnectionString("CPGuildId"), out _CPGuildId);
 

--- a/EGG9000.Bot/Automated/_UpdaterBase.cs
+++ b/EGG9000.Bot/Automated/_UpdaterBase.cs
@@ -153,6 +153,8 @@ namespace EGG9000.Bot.Automated {
                         Restarted = false;
                         await _client.SendDMToKendrome($"{GetType().Name} successfully restarted.");
                     }
+                } catch(OperationCanceledException) {
+                    _logger.LogInformation("Run cancelled");
                 } catch(Exception e) {
                     _bugSnag.Notify(e);
                     _logger.LogError(e, "Error during run: {Message}", e.Message);
@@ -193,7 +195,7 @@ namespace EGG9000.Bot.Automated {
         }
 
         private async Task LoopForCronExpression() {
-            while(!_cts.IsCancellationRequested) {
+            while(_cts?.IsCancellationRequested == false) {
                 try {
 
                     if(_nextRunFromCron < DateTimeOffset.Now) {

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -273,7 +273,9 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                     artifactFamilies = artifactFamilies.Where(x => x.name.Contains((string)arg.Data.Current.Value, StringComparison.OrdinalIgnoreCase));
                 }
 
-                await arg.RespondAsync(null, artifactFamilies.Select(c => new AutocompleteResult($"{c.name}", c.id)).Take(25).ToArray());
+                try {
+                    await arg.RespondAsync(null, artifactFamilies.Select(c => new AutocompleteResult($"{c.name}", c.id)).Take(25).ToArray());
+                } catch(TimeoutException) { }
             }
         }
         #endregion

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -27,7 +27,8 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
             private readonly DatabaseCache _cache = cache;
 
             public async Task Run(SocketAutocompleteInteraction arg, List<Guild> guilds) {
-                var guild = guilds.First(x => x.Id == arg.GuildId || x.OverflowServersJson.Contains(arg.GuildId.ToString()));
+                var guild = guilds.FirstOrDefault(x => x.Id == arg.GuildId || x.OverflowServersJson.Contains(arg.GuildId.ToString()));
+                if(guild is null) return;
                 var allusers = await _cache.GetDbUsers();
                 var users = allusers
                     .Where(
@@ -43,7 +44,7 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                 var results = new List<AutocompleteResult>();
                 foreach(var account in accounts.DistinctBy(x => x.Account.Id)) {
                     var name = account.Account.Backup?.UserName;
-                    results.Add(new AutocompleteResult($"{account.User.DiscordUsername} - {name ?? account.Account.Backup?.UserName ?? "(No Name)"} ({account.Account.Backup.EarningsBonus.ToEggString()})", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
+                    results.Add(new AutocompleteResult($"{account.User.DiscordUsername} - {name ?? account.Account.Backup?.UserName ?? "(No Name)"} ({account.Account.Backup?.EarningsBonus.ToEggString() ?? "?"})", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
                 }
                 await arg.RespondAsync(null, [.. results]);
             }
@@ -55,9 +56,12 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
             public async Task Run(SocketAutocompleteInteraction arg, List<Guild> guilds) {
                 var coop = await _db.Coops.Include(x => x.UserCoopsXrefs).ThenInclude(x => x.User).FirstOrDefaultAsync(x => x.ThreadID == arg.Channel.Id);
 
-                var eidsIn = coop.UserCoopsXrefs.Select(x => x.EggIncId).ToList();
-                if(coop is null || coop.FinishedOrFailedOrExpired() || eidsIn.Count == 0) {
+                if(coop is null || coop.FinishedOrFailedOrExpired()) {
                     return; //Needs to be used in an active coop channel with users in it
+                }
+                var eidsIn = coop.UserCoopsXrefs.Select(x => x.EggIncId).ToList();
+                if(eidsIn.Count == 0) {
+                    return;
                 }
 
                 //Filter users by current search
@@ -89,7 +93,8 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
             private readonly DatabaseCache _cache = cache;
 
             public async Task Run(SocketAutocompleteInteraction arg, List<Guild> guilds) {
-                var guild = guilds.First(x => x.Id == arg.GuildId || x.OverflowServersJson.Contains(arg.GuildId.ToString()));
+                var guild = guilds.FirstOrDefault(x => x.Id == arg.GuildId || x.OverflowServersJson.Contains(arg.GuildId.ToString()));
+                if(guild is null) return;
                 var allusers = await _cache.GetDbUsers();
                 var users = allusers
                     .Where(x => x.GuildId == guild.Id && x.DiscordId == arg.User.Id)
@@ -101,7 +106,7 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                 foreach(var account in accounts.DistinctBy(x => x.Account.Id)) {
                     if(account.User.EggIncAccounts.Count > 1) {
                         var name = account.Account.Backup?.UserName;
-                        results.Add(new AutocompleteResult($"{account.User.DiscordUsername} - {name ?? account.Account.Backup?.UserName ?? "(No Name)"} {account.Account.Backup.EarningsBonus.ToEggString()}", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
+                        results.Add(new AutocompleteResult($"{account.User.DiscordUsername} - {name ?? account.Account.Backup?.UserName ?? "(No Name)"} {account.Account.Backup?.EarningsBonus.ToEggString() ?? "?"}", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
                     } else {
                         results.Add(new AutocompleteResult($"{account.User.DiscordUsername}", $"{account.User.Id}|{account.User.EggIncAccounts.ToList().IndexOf(account.Account)}"));
                     }
@@ -196,7 +201,7 @@ namespace EGG9000.Bot.Commands.DiscordEnums {
                 if(!string.IsNullOrWhiteSpace((string)arg.Data.Current.Value)) {
                     users = users.Where(x => x.DiscordUsername.Contains((string)arg.Data.Current.Value, StringComparison.OrdinalIgnoreCase)).ToList();
                 }
-                await arg.RespondAsync(users.DistinctBy(x => x.EggIncId).ToList().Select(x => new AutocompleteResult(x.DiscordUsername + " - " + x.User.EggIncAccounts.FirstOrDefault(a => a.Id == x.EggIncId)?.Backup?.UserName ?? "(No Name)", x.UserId.ToString())));
+                await arg.RespondAsync(users.DistinctBy(x => x.EggIncId).Take(25).Select(x => new AutocompleteResult(x.DiscordUsername + " - " + (x.User?.EggIncAccounts.FirstOrDefault(a => a.Id == x.EggIncId)?.Backup?.UserName ?? "(No Name)"), x.UserId.ToString())));
             }
         }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -78,7 +78,7 @@ namespace EGG9000.Bot.Commands {
             }
 
             var customEggs = await db.GetCustomEggsAsync();
-            var details = new CoopDetails(coop, coop.Contract, coop.League, coop.UserCoopsXrefs.SelectMany(y => y.User.EggIncAccounts.Select(x => new UserWithBackup { Backup = x.Backup, User = y.User })).ToList(), customEggs, _client, status);
+            var details = new CoopDetails(coop, coop.Contract, coop.League, coop.UserCoopsXrefs.SelectMany(y => y.User.EggIncAccounts.Select(x => new UserWithBackup { Backup = x.Backup, User = y.User })).ToList(), customEggs, _client.Gateway, status);
 
             if(details is null || details.CoopParticipants is null || details.CoopParticipants.Count == 0) { // Edge cases were throwing when details was null
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Unable to locate user in co-op. Co-op may be, or may have been public, or user may no longer be assigned to coop."); });

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -138,14 +138,15 @@ namespace EGG9000.Bot.Commands {
 
         [SlashCommand(Description = "Makes a co-op public", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task MakePublic(FauxCommand command, ApplicationDbContext db) {
+            await command.DeferAsync();
             var coop = await db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
             if(coop == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find coop for channel {command.Channel.Name}"));
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find coop for channel {command.Channel.Name}"); });
                 return;
             }
 
             if(string.IsNullOrEmpty(coop.CreatorID)) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find creator for {command.Channel.Name}"));
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find creator for {command.Channel.Name}"); });
                 return;
             }
 
@@ -158,9 +159,9 @@ namespace EGG9000.Bot.Commands {
             }, coop.CreatorID);
 
             if(response.Success) {
-                await command.RespondAsync($"{coop.Name} is now public.");
+                await command.ModifyOriginalResponseAsync($"{coop.Name} is now public.");
             } else {
-                await command.RespondAsync($"{coop.Name} should now be public.");
+                await command.ModifyOriginalResponseAsync($"{coop.Name} should now be public.");
             }
         }
 
@@ -403,15 +404,16 @@ namespace EGG9000.Bot.Commands {
 
         [SlashCommand(Description = "Makes this co-op private", AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task MakePrivate(FauxCommand command, ApplicationDbContext db) {
+            await command.DeferAsync();
             var name = new Regex(@"\w+").Match(command.Channel.Name.ToLower()).Value;
             var coop = await db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
             if(coop == null) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find coop for this channel {command.Channel.Name}"));
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find coop for this channel {command.Channel.Name}"); });
                 return;
             }
 
             if(string.IsNullOrEmpty(coop.CreatorID)) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to find creator for {command.Channel.Name}"));
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find creator for {command.Channel.Name}"); });
                 return;
             }
 
@@ -424,9 +426,9 @@ namespace EGG9000.Bot.Commands {
             }, coop.CreatorID);
 
             if(response.Success) {
-                await command.RespondAsync($"{coop.Name} is now private.");
+                await command.ModifyOriginalResponseAsync($"{coop.Name} is now private.");
             } else {
-                await command.RespondAsync($"{coop.Name} should now be private.");
+                await command.ModifyOriginalResponseAsync($"{coop.Name} should now be private.");
             }
         }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -102,7 +102,7 @@ namespace EGG9000.Bot.Commands {
             var contract = await db.Contracts.FirstAsync(x => x.ID == coop.ContractID);
             await CreateCoopsV2.CreateCoopViaApi(coop.ContractID, (PlayerGrade)coop.League, coopName: "test" + new Random().Next(10000), contract.Details.LengthSeconds, xref.EggIncId, coop.AnyLeague);
 
-            await Task.Delay(2);
+            await Task.Delay(TimeSpan.FromSeconds(2));
             status = await ContractsAPI.GetCoopStatus(coop.ContractID, coop.Name, coop.CreatorID);
 
             if(status.Participants.Count == contract.MaxUsers) {
@@ -114,7 +114,7 @@ namespace EGG9000.Bot.Commands {
                     PlayerIdentifier = xref.EggIncId, Reason = KickPlayerCoopRequest.Types.Reason.Private, RequestingUserId = coop.CreatorID
                 }, coop.CreatorID);
 
-                await Task.Delay(2);
+                await Task.Delay(TimeSpan.FromSeconds(2));
                 status = await ContractsAPI.GetCoopStatus(coop.ContractID, coop.Name);
             }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -105,7 +105,7 @@ namespace EGG9000.Bot.Commands {
             await Task.Delay(TimeSpan.FromSeconds(2));
             status = await ContractsAPI.GetCoopStatus(coop.ContractID, coop.Name, coop.CreatorID);
 
-            if(status.Participants.Count == contract.MaxUsers) {
+            if(status?.Participants?.Count == contract.MaxUsers) {
                 logger.LogInformation("Attempting to fix {user} in {coop} by submitting kick request", dbuser.DiscordUsername, coop.Name);
                 var res3 = await ContractsAPI.Send(new Ei.KickPlayerCoopRequest {
                     ClientVersion = 24,
@@ -119,7 +119,7 @@ namespace EGG9000.Bot.Commands {
             }
 
 
-            if(status.Participants.Count < contract.MaxUsers) {
+            if(status?.Participants?.Count < contract.MaxUsers) {
                 logger.LogInformation("Successfully remove {user} from {coop}", dbuser.DiscordUsername, coop.Name);
                 var guild = _client.Guilds.First(x => x.Id == coop.OverflowGuildId);
                 var users = await db.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == coop.Id)).ToListAsync();

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -87,7 +87,7 @@ namespace EGG9000.Bot.Commands {
                 if(welcomeChannel.Id == command.Channel.Id) {
                     await command.DeleteOriginalResponseAsync();
                     var text = $"Welcome {command.User.Mention}, you have been moved to this server. You have the rank of {role?.Name} with an EB of {earningsBonus.ToEggString()}";
-                    var response = await ChannelHelper.DetermineAndSend(_client, dbguild, GuildChannelType.General, new() { Text = text });
+                    var response = await ChannelHelper.DetermineAndSend(_client.Gateway, dbguild, GuildChannelType.General, new() { Text = text });
                     await CleanWelcomeChannel(guild, _client, command.User);
                 } else {
                     await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess("Registration has been moved"); });
@@ -201,7 +201,7 @@ namespace EGG9000.Bot.Commands {
                 if(dbUser.GuildId == command.GuildId && dbUser.EggIncAccounts.Count > 0) {
                     await DiscordHelpers.CheckRoles(db, guild, (command.User as SocketGuildUser), dbUser, _client, null, []);
                     await command.DeleteOriginalResponseAsync();
-                    var response = await ChannelHelper.DetermineAndSend(_client, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = $"Welcome back {targetUser.Mention}!" });
+                    var response = await ChannelHelper.DetermineAndSend(_client.Gateway, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = $"Welcome back {targetUser.Mention}!" });
                     var activeRole = guild.Roles.FirstOrDefault(x => x.Id == 798284088967430144);
                     if(activeRole != null) {
                         await ((SocketGuildUser)targetUser).AddRoleAsync(activeRole);
@@ -217,7 +217,7 @@ namespace EGG9000.Bot.Commands {
                     return;
                 } else {
 
-                    var response = await ChannelHelper.DetermineAndSend(_client, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = $"Welcome back {targetUser.Mention}!" });
+                    var response = await ChannelHelper.DetermineAndSend(_client.Gateway, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = $"Welcome back {targetUser.Mention}!" });
 
                     var activeRole = guild.Roles.FirstOrDefault(x => x.Id == 798284088967430144);
                     if(activeRole != null) await ((SocketGuildUser)targetUser).AddRoleAsync(activeRole);
@@ -469,7 +469,7 @@ namespace EGG9000.Bot.Commands {
             //}
 
             var compiledMessage = $"Welcome {user.Mention}! {roleText}.{faqText}";
-            var response = await ChannelHelper.DetermineAndSend(_client, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = compiledMessage }, logger);
+            var response = await ChannelHelper.DetermineAndSend(_client.Gateway, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = compiledMessage }, logger);
             if(firstContactResponse == null) await command.Channel.SendMessageAsync(compiledMessage);
 
             //Only add the overflow role for the first registered account
@@ -896,7 +896,7 @@ namespace EGG9000.Bot.Commands {
 
             var discordBanMessage = "";
             var socketGuild = _client.GetGuild(command.GuildId ?? ulong.MaxValue);
-            var targetUser = socketGuild.GetUser(user.Id) ?? await _client.GetUserAsync(user.Id);
+            var targetUser = socketGuild.GetUser(user.Id) ?? await _client.Gateway.GetUserAsync(user.Id);
             var runningUser = socketGuild?.Users?.ToList().FirstOrDefault(u => u.Id == command.User.Id);
             if(runningUser is not null && runningUser.GuildPermissions.ToList().Contains(GuildPermission.BanMembers)) { //Check if running user has ban perms
                 var banObject = await socketGuild.GetBanAsync(targetUser);

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -160,7 +160,7 @@ namespace EGG9000.Bot.Commands {
             await Task.Delay(TimeSpan.FromSeconds(2));
             var status = await ContractsAPI.GetCoopStatus(coop.ContractID, coop.Name);
 
-            if(status.Participants.Count < contract.MaxUsers) {
+            if(status?.Participants?.Count < contract.MaxUsers) {
                 logger.LogInformation("Successfully remove {user} from {coop}", dbUser.DiscordUsername, coop.Name);
                 var guild = _client.Guilds.First(x => x.Id == coop.OverflowGuildId);
                 var users = await db.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == coop.Id)).ToListAsync();

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -157,7 +157,7 @@ namespace EGG9000.Bot.Commands {
             await CreateCoopsV2.CreateCoopViaApi(coop.ContractID, (Ei.Contract.Types.PlayerGrade)coop.League, coopName:"test" + new Random().Next(10000), contract.Details.LengthSeconds, xref.EggIncId, coop.AnyLeague);
 
 
-            await Task.Delay(2);
+            await Task.Delay(TimeSpan.FromSeconds(2));
             var status = await ContractsAPI.GetCoopStatus(coop.ContractID, coop.Name);
 
             if(status.Participants.Count < contract.MaxUsers) {

--- a/EGG9000.Bot/Program.cs
+++ b/EGG9000.Bot/Program.cs
@@ -92,6 +92,10 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
 
         services.AddMemoryCache();
 
+        services.AddSingleton<DiscordQueueService>();
+        services.AddSingleton<IDiscordQueue>(provider => provider.GetRequiredService<DiscordQueueService>());
+        services.AddHostedService(provider => provider.GetRequiredService<DiscordQueueService>());
+
         // Get connection string - supports both Docker secrets and local development
         var connectionString = DockerSecretsHelper.GetConfigOrSecret(
             hostContext.Configuration,
@@ -205,7 +209,7 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
         }
 
         services.AddSingleton<DiscordHostedService>();
-        services.AddSingleton<DiscordSocketClient>(provider => provider.GetService<DiscordHostedService>());
+        services.AddSingleton<DiscordSocketClient>(provider => provider.GetRequiredService<DiscordHostedService>().Gateway);
         services.AddSingleton<APILink>();
         services.AddHostedService(provider => provider.GetService<APILink>());
 

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -167,8 +167,10 @@ namespace EGG9000.Bot.Services {
         private async Task RunCommand(CommandFunctionBase command, IDiscordInteraction arg) {
             var sw = Stopwatch.StartNew();
             RunCommandTotal.Inc();
+            var semaphoreAcquired = false;
             try {
-                if(await _semaphoreSlim.WaitAsync(TimeSpan.FromSeconds(2.5))) {
+                semaphoreAcquired = await _semaphoreSlim.WaitAsync(TimeSpan.FromSeconds(2.5));
+                if(semaphoreAcquired) {
                     var parameters = new List<object>();
                     foreach(var parameterInfo in command.Parameters) {
                         if(parameterInfo.GetCustomAttributes<SlashParamAttribute>().Any()) {

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -264,7 +264,7 @@ namespace EGG9000.Bot.Services {
 
                 }
             } finally {
-                _semaphoreSlim.Release();
+                if(semaphoreAcquired) _semaphoreSlim.Release();
                 sw.Stop();
                 RunCommandDuration.Observe(sw.Elapsed.TotalSeconds);
             }

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -202,7 +202,7 @@ namespace EGG9000.Bot.Services {
                         } else if(parameterInfo.ParameterType == typeof(ApplicationDbContext)) {
                             parameters.Add(await _dbContextFactory.CreateDbContextAsync());
                         } else if(parameterInfo.ParameterType == typeof(DiscordSocketClient)) {
-                            parameters.Add(_discord);
+                            parameters.Add(_discord.Gateway);
                         } else if(parameterInfo.ParameterType == typeof(DiscordHostedService)) {
                             parameters.Add(_discord);
                         } else if(parameterInfo.ParameterType == typeof(APILink)) {
@@ -292,13 +292,13 @@ namespace EGG9000.Bot.Services {
         private async Task CreateCommands() {
             try {
 
-                _discord.SlashCommandExecuted += _discord_SlashCommandExecuted;
-                _discord.UserCommandExecuted += _discord_UserCommandExecuted;
-                _discord.MessageReceived += _discord_MessageReceived;
-                _discord.ButtonExecuted += _discord_ButtonExecuted;
-                _discord.SelectMenuExecuted += _discord_SelectMenuExecuted;
-                _discord.AutocompleteExecuted += _discord_AutocompleteExecuted;
-                _discord.ModalSubmitted += _discord_ModalSubmitted;
+                _discord.Gateway.SlashCommandExecuted += _discord_SlashCommandExecuted;
+                _discord.Gateway.UserCommandExecuted += _discord_UserCommandExecuted;
+                _discord.Gateway.MessageReceived += _discord_MessageReceived;
+                _discord.Gateway.ButtonExecuted += _discord_ButtonExecuted;
+                _discord.Gateway.SelectMenuExecuted += _discord_SelectMenuExecuted;
+                _discord.Gateway.AutocompleteExecuted += _discord_AutocompleteExecuted;
+                _discord.Gateway.ModalSubmitted += _discord_ModalSubmitted;
 
                 _ = _activeMonitorHostedService.SetActiveColorAsync();
 
@@ -362,7 +362,7 @@ namespace EGG9000.Bot.Services {
                     guildCommandProperties.Add(guildCommand.Build());
                 }
 
-                var globalCommands = await _discord.BulkOverwriteGlobalApplicationCommandsAsync([.. globalCommandProperties]);
+                var globalCommands = await _discord.Gateway.BulkOverwriteGlobalApplicationCommandsAsync([.. globalCommandProperties]);
                 _globalCommands.AddRange(globalCommands.Select(y => (y, (ulong)0)));
                 foreach(var guild in _discord.Guilds) {
                     _logger.LogInformation("Creating slash commands for {guild}", guild.Name);
@@ -573,7 +573,7 @@ namespace EGG9000.Bot.Services {
             var hasMeritAlready = dbUser.Merits.Any(m => m.Reason == meritText);
             if(hasMeritAlready) return;
 
-            await MeritCommands.CreateMerit(meritText, db, _discord, message.Author, null, guild: guild);
+            await MeritCommands.CreateMerit(meritText, db, _discord.Gateway, message.Author, null, guild: guild);
         }
 
         private async Task HandleScreenshotRegistration(SocketMessage message, SocketGuild guild, ApplicationDbContext db) {
@@ -634,7 +634,7 @@ namespace EGG9000.Bot.Services {
                 _logger.LogInformation("Detected boost message in CP guild from {user}", message.Author.Username);
                 var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guild.Id);
                 var cpGeneralChannel = guild.TextChannels.First(x => x.Id == 656455568353132546);
-                await MeritCommands.CreateMerit("Boosted the server!", db, _discord, message.Author, Guid.Empty, guild: dbGuild);
+                await MeritCommands.CreateMerit("Boosted the server!", db, _discord.Gateway, message.Author, Guid.Empty, guild: dbGuild);
                 await cpGeneralChannel.SendMessageAsync($"{message.Author.Mention} just boosted the server!");
             }
 
@@ -870,13 +870,13 @@ namespace EGG9000.Bot.Services {
         }
 
         public async Task StopAsync(CancellationToken cancellationToken) {
-            _discord.SlashCommandExecuted -= _discord_SlashCommandExecuted;
-            _discord.UserCommandExecuted -= _discord_UserCommandExecuted;
-            _discord.MessageReceived -= _discord_MessageReceived;
-            _discord.ButtonExecuted -= _discord_ButtonExecuted;
-            _discord.SelectMenuExecuted -= _discord_SelectMenuExecuted;
-            _discord.AutocompleteExecuted -= _discord_AutocompleteExecuted;
-            _discord.ModalSubmitted += _discord_ModalSubmitted;
+            _discord.Gateway.SlashCommandExecuted -= _discord_SlashCommandExecuted;
+            _discord.Gateway.UserCommandExecuted -= _discord_UserCommandExecuted;
+            _discord.Gateway.MessageReceived -= _discord_MessageReceived;
+            _discord.Gateway.ButtonExecuted -= _discord_ButtonExecuted;
+            _discord.Gateway.SelectMenuExecuted -= _discord_SelectMenuExecuted;
+            _discord.Gateway.AutocompleteExecuted -= _discord_AutocompleteExecuted;
+            _discord.Gateway.ModalSubmitted -= _discord_ModalSubmitted;
             _logger.LogInformation("Stopped listening to slash commands");
             if(_semaphoreSlim.CurrentCount > 0) {
                 _logger.LogInformation("Waiting on semaphore to shutdown");

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -239,10 +239,16 @@ namespace EGG9000.Bot.Services {
                 }
             } catch(UserNotInServerException unfe) {
                 RunCommandFailures.Inc();
-                await arg.RespondAsync(text: "", embed: EmbedError($"Could not convert the id `{unfe.User}` to a `SocketGlobalUser` instance.\nUser (<@{unfe.User}>) may not be in the server anymore."));
+                if(arg.HasResponded)
+                    await arg.ModifyOriginalResponseAsync(msg => { msg.Content = ""; msg.Embed = EmbedError($"Could not convert the id `{unfe.User}` to a `SocketGlobalUser` instance.\nUser (<@{unfe.User}>) may not be in the server anymore."); });
+                else
+                    await arg.RespondAsync(text: "", embed: EmbedError($"Could not convert the id `{unfe.User}` to a `SocketGlobalUser` instance.\nUser (<@{unfe.User}>) may not be in the server anymore."));
             } catch(InvalidOperationException) {
                 RunCommandFailures.Inc();
-                await arg.RespondAsync(text: "", embed: EmbedError("One or more parameters for your command were passed as plain-text instead of selectable options, and could not be parsed"));
+                if(arg.HasResponded)
+                    await arg.ModifyOriginalResponseAsync(msg => { msg.Content = ""; msg.Embed = EmbedError("One or more parameters for your command were passed as plain-text instead of selectable options, and could not be parsed"); });
+                else
+                    await arg.RespondAsync(text: "", embed: EmbedError("One or more parameters for your command were passed as plain-text instead of selectable options, and could not be parsed"));
             } catch(Exception e) {
                 RunCommandFailures.Inc();
                 try {

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -144,6 +144,7 @@ namespace EGG9000.Common.Services {
                         var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User.DiscordId == user.Id && x.Coop.OverflowGuildId == user.Guild.Id && !x.Coop.ThreadArchived && !x.AddedToChannel).ToListAsync();
                         foreach(var xref in xrefs) {
                             var coopChannel = xref.Coop.ThreadID != 0 ? (SocketThreadChannel)_discord.GetChannel(xref.Coop.ThreadID) : (SocketTextChannel)_discord.GetChannel(xref.Coop.DiscordChannelId);
+                            if(coopChannel is null) continue;
                             await coopChannel.AddPermissionOverwriteAsync(user, new OverwritePermissions(viewChannel: PermValue.Allow));
                             xref.AddedToChannel = true;
                             await coopChannel.SendMessageAsync($"Here is your co-op {user.Mention}! The co-op name to join is {xref.Coop.Name}");

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -65,24 +65,29 @@ namespace EGG9000.Common.Services {
         }
 
         private async Task HandleChannelDeleted(SocketChannel arg) {
-            var db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            var guildContract = await db.GuildContracts.Include(x => x.Contract).FirstOrDefaultAsync(x => x.DiscordChannelId == arg.Id);
-            if(guildContract is not null) {
-                var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
-                _logger.LogInformation("Deleting header channels for {contract} because discord report the contract channel was deleted", guildContract.Contract.Name);
-                await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract, _logger);
-                guildContract.DeletedChannel = true;
-                await db.SaveChangesAsync();
-                return;
-            }
-            var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id || x.DiscordChannelId == arg.Id);
-            if(coop is not null && coop.ThreadID != 0) {
-                _logger.LogInformation($"Marking thread archived due to channel deletion for {coop.Name}");
-                coop.ThreadArchived = true;
-                await db.SaveChangesAsync();
-            } else if(coop is not null && coop.DiscordChannelId != 0) {
-                coop.DeletedChannel = true;
-                await db.SaveChangesAsync();
+            try {
+                var db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                var guildContract = await db.GuildContracts.Include(x => x.Contract).FirstOrDefaultAsync(x => x.DiscordChannelId == arg.Id);
+                if(guildContract is not null) {
+                    var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
+                    _logger.LogInformation("Deleting header channels for {contract} because discord report the contract channel was deleted", guildContract.Contract.Name);
+                    await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract, _logger);
+                    guildContract.DeletedChannel = true;
+                    await db.SaveChangesAsync();
+                    return;
+                }
+                var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id || x.DiscordChannelId == arg.Id);
+                if(coop is not null && coop.ThreadID != 0) {
+                    _logger.LogInformation($"Marking thread archived due to channel deletion for {coop.Name}");
+                    coop.ThreadArchived = true;
+                    await db.SaveChangesAsync();
+                } else if(coop is not null && coop.DiscordChannelId != 0) {
+                    coop.DeletedChannel = true;
+                    await db.SaveChangesAsync();
+                }
+            } catch(Exception e) {
+                _bugsnag.Notify(e);
+                logger.LogError(e, "Error handling channel deletion for channel {channelId}", arg.Id);
             }
         }
 

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -37,10 +37,10 @@ namespace EGG9000.Common.Services {
 #endif
 
         public Task StartAsync(CancellationToken cancellationToken) {
-            _discord.UserJoined += Client_UserJoined;
-            _discord.UserLeft += Client_UserLeft;
-            _discord.ChannelDestroyed += _discord_ChannelDestroyed;
-            _discord.ThreadDeleted += _discord_ThreadDeleted;
+            _discord.Gateway.UserJoined += Client_UserJoined;
+            _discord.Gateway.UserLeft += Client_UserLeft;
+            _discord.Gateway.ChannelDestroyed += _discord_ChannelDestroyed;
+            _discord.Gateway.ThreadDeleted += _discord_ThreadDeleted;
             return Task.CompletedTask;
         }
 
@@ -71,7 +71,7 @@ namespace EGG9000.Common.Services {
                 if(guildContract is not null) {
                     var dbGuild = await db.Guilds.FirstOrDefaultAsync(g => g.Id == guildContract.GuildID);
                     _logger.LogInformation("Deleting header channels for {contract} because discord report the contract channel was deleted", guildContract.Contract.Name);
-                    await dbGuild.DeleteCoopThreadHeadersAsync(_discord, guildContract.Contract, _logger);
+                    await dbGuild.DeleteCoopThreadHeadersAsync(_discord.Gateway, guildContract.Contract, _logger);
                     guildContract.DeletedChannel = true;
                     await db.SaveChangesAsync();
                     return;
@@ -92,9 +92,10 @@ namespace EGG9000.Common.Services {
         }
 
         public Task StopAsync(CancellationToken cancellationToken) {
-            _discord.UserJoined -= Client_UserJoined;
-            _discord.UserLeft -= Client_UserLeft;
-            _discord.ChannelDestroyed -= _discord_ChannelDestroyed;
+            _discord.Gateway.UserJoined -= Client_UserJoined;
+            _discord.Gateway.UserLeft -= Client_UserLeft;
+            _discord.Gateway.ChannelDestroyed -= _discord_ChannelDestroyed;
+            _discord.Gateway.ThreadDeleted -= _discord_ThreadDeleted;
             return Task.CompletedTask;
         }
 
@@ -162,15 +163,15 @@ namespace EGG9000.Common.Services {
             var dbuser = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser is not null) {
                 if(dbuser.TempDisabled) {
-                    await ChannelHelper.DetermineAndSend(_discord, dbguild, GuildChannelType.Welcome, new() {
+                    await ChannelHelper.DetermineAndSend(_discord.Gateway, dbguild, GuildChannelType.Welcome, new() {
                         Text = $"Welcome to the server {user.Mention}! Looks like staff have previously disabled your account. Please wait for someone to reach out to discuss this."
                     }, _logger);
-                    await ChannelHelper.DetermineAndSend(_discord, dbguild, GuildChannelType.BannedUserThread, new() { Text = $"{user.Mention} just joined and is disabled." }, _logger);
+                    await ChannelHelper.DetermineAndSend(_discord.Gateway, dbguild, GuildChannelType.BannedUserThread, new() { Text = $"{user.Mention} just joined and is disabled." }, _logger);
                     return;
                 }
                 if(dbuser.GuildId != user.Guild.Id) {
                     var moveServerCommandString = await _discord.GetSlashCommandStringAsync(user.Guild, "MoveServer");
-                    await ChannelHelper.DetermineAndSend(_discord, dbguild, GuildChannelType.Welcome, new() {
+                    await ChannelHelper.DetermineAndSend(_discord.Gateway, dbguild, GuildChannelType.Welcome, new() {
                         Text = $"Welcome to the server {user.Mention}! Looks like you are currently registered with another server. If you would like to move to this server use the {moveServerCommandString} command."
                     }, _logger);
                     return;
@@ -189,7 +190,7 @@ namespace EGG9000.Common.Services {
                 var earningsBonus = dbuser.EggIncAccounts.Max(x => x.Backup.EarningsBonus);
                 var role = await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, [], _logger);
                 var roleText = role is not null ? $" You have been assigned the rank of {role?.Name} thanks to your EB of {earningsBonus.ToEggString()}" : "";
-                var response = await ChannelHelper.DetermineAndSend(_discord, dbguild, GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!{roleText}" }, _logger);
+                var response = await ChannelHelper.DetermineAndSend(_discord.Gateway, dbguild, GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!{roleText}" }, _logger);
                 await RegisterCommandsSlash.CleanWelcomeChannel(user.Guild, _discord, user);
                 return;
             }

--- a/EGG9000.Common/Database/DatabaseCache.cs
+++ b/EGG9000.Common/Database/DatabaseCache.cs
@@ -62,10 +62,14 @@ namespace EGG9000.Common.Database {
         }
         private Timer _timerActiveCoops;
         private async Task RefreshActiveCoopsCache() {
-            var db = await _dbContextFactory.CreateDbContextAsync();
-            _logger.LogInformation("Refreshing active coops cache");
-            var coops = await db.Coops.Include(x => x.Contract).Where(c => !c.Finished && !c.DeletedChannel && !c.ThreadArchived).ToListAsync();
-            _cachedActiveCoops = coops;
+            try {
+                var db = await _dbContextFactory.CreateDbContextAsync();
+                _logger.LogInformation("Refreshing active coops cache");
+                var coops = await db.Coops.Include(x => x.Contract).Where(c => !c.Finished && !c.DeletedChannel && !c.ThreadArchived).ToListAsync();
+                _cachedActiveCoops = coops;
+            } catch(Exception e) {
+                _logger.LogError(e, "Error refreshing active coops cache");
+            }
         }
     }
 }

--- a/EGG9000.Common/Helpers/Discord/ChannelHelper.cs
+++ b/EGG9000.Common/Helpers/Discord/ChannelHelper.cs
@@ -72,6 +72,7 @@ namespace EGG9000.Bot.Common.Helpers {
         }
 
         public static async Task<IUserMessage> SendCustomMessage(DiscordSocketClient _client, object target, CustomDiscordMessage message, ILogger logger = null) {
+            if(target is null) return null;
             if(target.GetType() == typeof(SocketThreadChannel)) {
                 var threadChannel = (SocketThreadChannel)target;
                 if(message.SendFile) {

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -286,9 +286,9 @@ namespace EGG9000.Bot.Helpers {
                     var index = random.Next(messages.Count);
 
                     //Attempt to find the "separate channel for rankup messages" channel, if it's been set
-                    var response = await ChannelHelper.DetermineAndSend(_client, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.AltRankup, new() { Text = messages[index] });
+                    var response = await ChannelHelper.DetermineAndSend(_client.Gateway, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.AltRankup, new() { Text = messages[index] });
                     //If it can't be found, use 'General' instead
-                    if(response == null) await ChannelHelper.DetermineAndSend(_client, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = messages[index] });
+                    if(response == null) await ChannelHelper.DetermineAndSend(_client.Gateway, db.Guilds.FirstOrDefault(g => g.Id == guild.Id), GuildChannelType.General, new() { Text = messages[index] });
                 }
 
                 return role;

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -169,7 +169,7 @@ namespace EGG9000.Bot.Helpers {
                 var eb = dbUser.EggIncAccounts.OrderByDescending(x => x.Backup?.EarningsBonus ?? 0).FirstOrDefault()?.Backup.EarningsBonus ?? 0;
 
                 if(role != existingRole) {
-                    logger.LogInformation("Role change for {user} in guild {guild} from {oldrole} to {newrole}, Positions {oldpos} {newpos}", discordUser.GetName(), guild.Name, existingRole?.Name ?? "None", role?.Name ?? "None", existingRole?.Position, role?.Position);
+                    logger?.LogInformation("Role change for {user} in guild {guild} from {oldrole} to {newrole}, Positions {oldpos} {newpos}", discordUser.GetName(), guild.Name, existingRole?.Name ?? "None", role?.Name ?? "None", existingRole?.Position, role?.Position);
                 }
 
                 if(role != null && existingRole != null && existingRole.Name != role.Name && role.Position > existingRole.Position) { //} && eb > dbUser.MaxEBForUser) {

--- a/EGG9000.Common/Helpers/FauxCommand.cs
+++ b/EGG9000.Common/Helpers/FauxCommand.cs
@@ -38,6 +38,7 @@ namespace EGG9000.Common.Services {
             _fake = fake;
         }
 
+        public static FauxCommand CreateFake() => new(fake: true);
 
         public static implicit operator FauxCommand(SocketSlashCommand command) {
             return new FauxCommand(command);
@@ -67,7 +68,7 @@ namespace EGG9000.Common.Services {
         }
 
         public Task RespondWithFilesAsync(IEnumerable<FileAttachment> attachments, string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null, PollProperties poll = null, MessageFlags flags = MessageFlags.None) {
-            throw new NotImplementedException();
+            throw new NotSupportedException(nameof(RespondWithFilesAsync));
         }
 
         public async Task RespondWithFileAsync(FileAttachment attachment, string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null) {
@@ -97,7 +98,7 @@ namespace EGG9000.Common.Services {
         }
 
         public Task RespondWithModalAsync(Modal modal, RequestOptions options = null) {
-            throw new NotImplementedException();
+            throw new NotSupportedException(nameof(RespondWithModalAsync));
         }
 
         public async Task<IUserMessage> GetOriginalResponseAsync(RequestOptions options = null) {
@@ -154,7 +155,7 @@ namespace EGG9000.Common.Services {
                     return await _socketCommandBase.GetOriginalResponseAsync();
                 }
             }
-            throw new NotImplementedException();
+            throw new NotSupportedException(nameof(RespondWithFilesAsyncGettingMessage));
         }
 
         public async Task RespondWithFilesAsync(IEnumerable<FileAttachment> attachments, string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null, PollProperties poll = null) =>
@@ -168,7 +169,7 @@ namespace EGG9000.Common.Services {
                     return await _socketCommandBase.FollowupWithFilesAsync(attachments, text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options, poll, flags);
                 else 
                     return await _socketCommandBase.FollowupAsync(text, embeds, isTTS, ephemeral, allowedMentions, components, embed, options, poll, flags);
-            throw new NotImplementedException();
+            throw new NotSupportedException(nameof(FollowUpAsync));
         }
 
         public async Task<IUserMessage> FollowupAsync(string text = null, Embed[] embeds = null, bool isTTS = false, bool ephemeral = false, AllowedMentions allowedMentions = null, MessageComponent components = null, Embed embed = null, RequestOptions options = null, PollProperties poll = null, MessageFlags flags = MessageFlags.None) {
@@ -214,11 +215,7 @@ namespace EGG9000.Common.Services {
         }
 
         public class FauxApplicationCommandData {
-            public ulong Id {
-                get {
-                    throw new NotImplementedException();
-                }
-            }
+            public ulong Id => throw new NotSupportedException(nameof(Id));
 
             public string Name { get; set; }
 
@@ -260,17 +257,9 @@ namespace EGG9000.Common.Services {
             }
         }
 
-        public string Token {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public string Token => throw new NotSupportedException(nameof(Token));
 
-        public int Version {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public int Version => throw new NotSupportedException(nameof(Version));
 
         public bool HasResponded {
             get {
@@ -286,21 +275,13 @@ namespace EGG9000.Common.Services {
             }
         }
 
-        public string UserLocale {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public string UserLocale => throw new NotSupportedException(nameof(UserLocale));
 
-        public string GuildLocale {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public string GuildLocale => throw new NotSupportedException(nameof(GuildLocale));
 
         public bool IsDMInteraction {
             get {
-                return _socketCommandBase?.IsDMInteraction ?? throw new NotImplementedException();
+                return _socketCommandBase?.IsDMInteraction ?? throw new NotSupportedException(nameof(IsDMInteraction));
             }
         }
 
@@ -322,11 +303,7 @@ namespace EGG9000.Common.Services {
             }
         }
 
-        public ulong ApplicationId {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public ulong ApplicationId => throw new NotSupportedException(nameof(ApplicationId));
 
         public DateTimeOffset CreatedAt {
             get {
@@ -334,53 +311,17 @@ namespace EGG9000.Common.Services {
             }
         }
 
-        IDiscordInteractionData IDiscordInteraction.Data {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        IDiscordInteractionData IDiscordInteraction.Data => throw new NotSupportedException(nameof(IDiscordInteraction.Data));
 
-        public IReadOnlyCollection<IEntitlement> Entitlements {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public IReadOnlyCollection<IEntitlement> Entitlements => throw new NotSupportedException(nameof(Entitlements));
 
-        //public IReadOnlyDictionary<ApplicationIntegrationType, ulong> IntegrationOwners {
-        //    get {
-        //        throw new NotImplementedException();
-        //    }
-        //}
+        public GuildPermissions Permissions => throw new NotSupportedException(nameof(Permissions));
 
-        //public InteractionContextType? ContextType {
-        //    get {
-        //        throw new NotImplementedException();
-        //    }
-        //}
+        public IReadOnlyDictionary<ApplicationIntegrationType, ulong> IntegrationOwners => throw new NotSupportedException(nameof(IntegrationOwners));
 
-        public GuildPermissions Permissions {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public InteractionContextType? ContextType => throw new NotSupportedException(nameof(ContextType));
 
-        public IReadOnlyDictionary<ApplicationIntegrationType, ulong> IntegrationOwners {
-            get {
-                throw new NotImplementedException();
-            }
-        }
-
-        public InteractionContextType? ContextType {
-            get {
-                throw new NotImplementedException();
-            }
-        }
-
-        public ulong AttachmentSizeLimit {
-            get {
-                throw new NotImplementedException();
-            }
-        }
+        public ulong AttachmentSizeLimit => throw new NotSupportedException(nameof(AttachmentSizeLimit));
 
         [GeneratedRegex(@"^/(\w+)")]
         private static partial Regex CommandRegex();

--- a/EGG9000.Common/Helpers/NasaHelper.cs
+++ b/EGG9000.Common/Helpers/NasaHelper.cs
@@ -179,7 +179,7 @@ public static partial class NasaHelper {
             logger.LogWarning("Failed to get Custom Message for APOD ID: {apodId}", apod.ID);
             return false;
         }
-        var sentMessage = await DetermineAndSend(client, details.Guild, GuildChannelType.NasaApod, customMessage, logger);
+        var sentMessage = await DetermineAndSend(client.Gateway, details.Guild, GuildChannelType.NasaApod, customMessage, logger);
         if (sentMessage != null) {
             apod.PostedToEntries = [
                 .. apod.PostedToEntries,
@@ -205,7 +205,7 @@ public static partial class NasaHelper {
         var customInteractionBasedMessage = new CustomInteractionBasedDiscordMessage(customMessage) {
             Ephemeral = true,
         };
-        var sentMessage = await SendCustomMessage(client, command, customInteractionBasedMessage, logger);
+        var sentMessage = await SendCustomMessage(client.Gateway, command, customInteractionBasedMessage, logger);
         return sentMessage != null;
     }
 

--- a/EGG9000.Common/Helpers/Prefarm.cs
+++ b/EGG9000.Common/Helpers/Prefarm.cs
@@ -428,11 +428,15 @@ namespace EGG9000.Common.Helpers {
             if(status is not null) {
                 foreach(var participant in status.Participants) {
 
-                    //Try and match UUID
-                    var backup = backups.Where(x => x.Backup is not null).FirstOrDefault(x => x.Backup.Farms.Any(farm => farm.ReportedUUIDs is not null && farm.ReportedUUIDs.Any(uuid => uuid == participant.Uuid)));
+                    //Try and match UUID (skip if UUID is empty to avoid false positives)
+                    var backup = !string.IsNullOrEmpty(participant.Uuid)
+                        ? backups.Where(x => x.Backup is not null).FirstOrDefault(x => x.Backup.Farms.Any(farm => farm.ReportedUUIDs is not null && farm.ReportedUUIDs.Any(uuid => uuid == participant.Uuid)))
+                        : null;
                     //UserWithBackup backup = null;
                     if(backup is not null) {
-                        var thisXref = coop.UserCoopsXrefs.FirstOrDefault(x => x.UserId == backup.User.Id && x.EggIncId == backup.Backup.EggIncId);
+                        var thisXref = coop?.UserCoopsXrefs.FirstOrDefault(x => x.UserId == backup.User.Id && x.EggIncId == backup.Backup.EggIncId);
+                        // UUID matched a backup but the exact account's xref wasn't found (e.g. multi-account user, stale backup) - fall back to EggIncId
+                        thisXref ??= coop?.UserCoopsXrefs.FirstOrDefault(x => x.EggIncId == participant.GetID());
                         coopParticipants.Add(new UserFarmDetails(coop, thisXref, participant, contract, backup, customEggs, discord, league));
                     } else {
                         if(participant.UserName == "[departed]") continue;

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -3,6 +3,7 @@
 using Discord;
 using Discord.Net.Rest;
 using Discord.Net.WebSockets;
+using Discord.Rest;
 using Discord.WebSocket;
 
 using EGG9000.Common.Contracts;
@@ -29,13 +30,16 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace EGG9000.Common.Services {
-    public class DiscordHostedService : DiscordSocketClient {
+    public class DiscordHostedService {
         public bool IsReady { get; private set; }
         private readonly Microsoft.Extensions.Configuration.IConfiguration _configuration;
         private readonly ApplicationDbContext _db;
         private readonly IMemoryCache _cache;
         private readonly IServiceProvider _provider;
         private readonly ILogger<DiscordHostedService> _logger;
+
+        private readonly DiscordSocketClient _gateway;
+        private readonly DiscordRestClient _rest;
 
         //private static readonly WebProxy proxy = new WebProxy("http://localhost", 8888);
 
@@ -49,7 +53,28 @@ namespace EGG9000.Common.Services {
         };
         private static readonly List<DiscordSemaphore> _serverSemaphores = [];
         private static readonly TimeSpan _semaphoreTimeoutTime = TimeSpan.FromMinutes(1);
-        public DiscordHostedService(Microsoft.Extensions.Configuration.IConfiguration Configuration, IMemoryCache cache, IServiceProvider provider, ILogger<DiscordHostedService> logger) : base(config) {
+
+        // The gateway socket client, for use by CommandService and extension methods
+        public DiscordSocketClient Gateway => _gateway;
+
+        // Forwarding properties so _UpdaterBase and background jobs (_client.Guilds, _client.GetGuild etc.) work unchanged
+        public IReadOnlyCollection<SocketGuild> Guilds => _gateway.Guilds;
+        public SocketGuild GetGuild(ulong id) => _gateway.GetGuild(id);
+        public SocketUser GetUser(ulong id) => _gateway.GetUser(id);
+        public IChannel GetChannel(ulong id) => _gateway.GetChannel(id);
+        public ConnectionState ConnectionState => _gateway.ConnectionState;
+        public Task SendDMToKendrome(string message) => _gateway.SendDMToKendrome(message);
+
+        // REST client, for callers that need guild/member lookups not available on the socket client
+        public DiscordRestClient Rest => _rest;
+
+        // Application emotes - used by NewContracts.cs and FAQCommandSlash.cs
+        public Task<IReadOnlyCollection<Emote>> GetApplicationEmotesAsync() => _gateway.GetApplicationEmotesAsync();
+
+        // Async channel lookup by raw ID - used by ContractUpdater.cs and CreateCoopThreads.cs
+        public Task<IChannel> GetChannelAsync(ulong id) => (_gateway as IDiscordClient).GetChannelAsync(id);
+
+        public DiscordHostedService(Microsoft.Extensions.Configuration.IConfiguration Configuration, IMemoryCache cache, IServiceProvider provider, ILogger<DiscordHostedService> logger) {
 #if DEBUG
             ServicePointManager.ServerCertificateValidationCallback = delegate { return true; };
 #endif
@@ -58,19 +83,23 @@ namespace EGG9000.Common.Services {
             _provider = provider;
             _logger = logger;
 
-            Log += PrintLog;
-            Ready += DiscordHostedService_Ready;
-            LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]).Wait();
-            StartAsync().Wait();
+            _gateway = new DiscordSocketClient(config);
+            _rest = new DiscordRestClient();
+
+            _gateway.Log += PrintLog;
+            _gateway.Ready += DiscordHostedService_Ready;
+            _gateway.LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]).Wait();
+            _gateway.StartAsync().Wait();
+            _rest.LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]).Wait();
 
             _logger.Log(LogLevel.Information, "Waiting on Discord Connect");
-            while(ConnectionState != ConnectionState.Connected) { }
+            while(_gateway.ConnectionState != ConnectionState.Connected) { }
             _logger.Log(LogLevel.Information, "Discord Ready");
 
             _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
             _cache = cache;
 
-            foreach(var guild in Guilds) {
+            foreach(var guild in _gateway.Guilds) {
                 _serverSemaphores.Add(new DiscordSemaphore(guild, new(1, 1)));
             }
         }
@@ -81,23 +110,23 @@ namespace EGG9000.Common.Services {
         }
 
         public async Task RestartAsync() {
-            if(ConnectionState != ConnectionState.Connected) {
+            if(_gateway.ConnectionState != ConnectionState.Connected) {
                 throw new RestartDiscordException("Not connected yet - cannot restart.", Severity.Warning);
             }
 
             try {
                 //Logout subtasks
-                await LogoutAsync();
-                await StopAsync();
+                await _gateway.LogoutAsync();
+                await _gateway.StopAsync();
                 _logger.Log(LogLevel.Information, "Waiting on Discord Disconnect");
-                while(ConnectionState == ConnectionState.Connected) { }
+                while(_gateway.ConnectionState == ConnectionState.Connected) { }
                 _logger.Log(LogLevel.Information, "Discord Disconnected...");
 
                 //Log back in
-                await LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]);
-                await StartAsync();
+                await _gateway.LoginAsync(TokenType.Bot, _configuration["ConnectionStrings:Token"]);
+                await _gateway.StartAsync();
                 _logger.Log(LogLevel.Information, "Waiting on Discord Connect");
-                while(ConnectionState != ConnectionState.Connected) { }
+                while(_gateway.ConnectionState != ConnectionState.Connected) { }
                 _logger.Log(LogLevel.Information, "Discord Ready");
             } catch(Exception ex) {
                 throw new RestartDiscordException(ex.Message, Severity.Error);
@@ -120,9 +149,9 @@ namespace EGG9000.Common.Services {
 
         private Task DiscordHostedService_Ready() {
             IsReady = true;
-            SetGameAsync("").Wait();
+            _gateway.SetGameAsync("").Wait();
 
-            foreach(var guild in Guilds) {
+            foreach(var guild in _gateway.Guilds) {
                 _logger.Log(LogLevel.Information, "Download guild users for {Guild}", guild.Name);
 
                 guild.DownloadUsersAsync().Wait();
@@ -211,7 +240,7 @@ namespace EGG9000.Common.Services {
                 if(channelDetail == null || channelDetail.Id == 0)
                     return default;
 
-                return (T)Convert.ChangeType(GetChannel(channelDetail.Id), typeof(T));
+                return (T)Convert.ChangeType(_gateway.GetChannel(channelDetail.Id), typeof(T));
             } catch(Exception e) {
                 _logger.LogError(e, "Error getting channel or category");
                 return default;
@@ -384,7 +413,7 @@ namespace EGG9000.Common.Services {
 
         public static async Task<IReadOnlyCollection<SocketApplicationCommand>> GetCachedApplicationCommands(this DiscordHostedService discord) {
             if(!commandCache.TryGetValue("GLOBAL", out IReadOnlyCollection<SocketApplicationCommand> commands)) {
-                commands = await discord.GetGlobalApplicationCommandsAsync();
+                commands = await discord.Gateway.GetGlobalApplicationCommandsAsync();
                 commandCache.Set("GLOBAL", commands, TimeSpan.FromMinutes(10));
             }
             return commands;
@@ -420,7 +449,7 @@ namespace EGG9000.Common.Services {
         public static async Task<Emote> CreateCustomEggEmoji(this DiscordHostedService _client, Ei.CustomEgg newEgg, Emote? emoteToReplace) {
 #pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
             var emojiName = newEgg.GetEmojiName();
-            var existingEmotes = await _client.GetApplicationEmotesAsync();
+            var existingEmotes = await _client.Gateway.GetApplicationEmotesAsync();
             // Download the image from aux
             var imageUrl = newEgg.Icon.Url.ToString();
             byte[] imageBytes;
@@ -457,12 +486,12 @@ namespace EGG9000.Common.Services {
             var discordImage = new Image(imageStream);
 
             // Upload the image as a GuildEmote
-            var newAppEmote = await _client.CreateApplicationEmoteAsync(emojiName, discordImage);
+            var newAppEmote = await _client.Gateway.CreateApplicationEmoteAsync(emojiName, discordImage);
 
             if(emoteToReplace != null && newAppEmote != null) {
-                var appEmote = await _client.GetApplicationEmoteAsync(emoteToReplace.Id);
+                var appEmote = await _client.Gateway.GetApplicationEmoteAsync(emoteToReplace.Id);
                 if(appEmote is not null) {
-                    await _client.DeleteApplicationEmoteAsync(emoteToReplace.Id, options: new RequestOptions() {
+                    await _client.Gateway.DeleteApplicationEmoteAsync(emoteToReplace.Id, options: new RequestOptions() {
                         RetryMode = RetryMode.RetryRatelimit | RetryMode.RetryTimeouts
                     });
                 }

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -242,7 +242,9 @@ namespace EGG9000.Common.Services {
 
     public static class DiscordExtensions {
         public static async Task SendDMToKendrome(this DiscordSocketClient _discord, string message) {
-            var kendromedmchannel = await _discord.GetUser(248865520756064257).CreateDMChannelAsync();
+            var kendromeUser = _discord.GetUser(248865520756064257);
+            if(kendromeUser is null) return;
+            var kendromedmchannel = await kendromeUser.CreateDMChannelAsync();
             if(kendromedmchannel is not null) {
                 await kendromedmchannel.SendMessageAsync(message);
             }

--- a/EGG9000.Common/Services/DiscordQueueOptions.cs
+++ b/EGG9000.Common/Services/DiscordQueueOptions.cs
@@ -1,0 +1,29 @@
+namespace EGG9000.Common.Services {
+    public class DiscordQueueOptions {
+        public TierOptions High { get; set; } = new() {
+            MinWorkers = 3,
+            MaxWorkers = 10,
+            ScaleUpThreshold = 50,
+            ScaleDownThreshold = 5,
+            BatchPauseMs = 0,
+            ScaleCheckIntervalMs = 5000
+        };
+        public TierOptions Low { get; set; } = new() {
+            MinWorkers = 2,
+            MaxWorkers = 20,
+            ScaleUpThreshold = 500,
+            ScaleDownThreshold = 50,
+            BatchPauseMs = 100,
+            ScaleCheckIntervalMs = 5000
+        };
+
+        public class TierOptions {
+            public int MinWorkers { get; set; }
+            public int MaxWorkers { get; set; }
+            public int ScaleUpThreshold { get; set; }
+            public int ScaleDownThreshold { get; set; }
+            public int BatchPauseMs { get; set; }
+            public int ScaleCheckIntervalMs { get; set; }
+        }
+    }
+}

--- a/EGG9000.Common/Services/DiscordQueueService.cs
+++ b/EGG9000.Common/Services/DiscordQueueService.cs
@@ -1,0 +1,159 @@
+using Bugsnag;
+
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Services {
+    public class DiscordQueueService : IDiscordQueue, IHostedService {
+        private record QueueItem(Func<Task> Operation);
+
+        private readonly Channel<QueueItem> _high = Channel.CreateUnbounded<QueueItem>(new() { SingleReader = false });
+        private readonly Channel<QueueItem> _low = Channel.CreateUnbounded<QueueItem>(new() { SingleReader = false });
+
+        private readonly IOptionsMonitor<DiscordQueueOptions> _optsMon;
+        private readonly ILogger<DiscordQueueService> _logger;
+        private readonly IClient _bugsnag;
+
+        private readonly List<(Task Task, CancellationTokenSource Cts)> _highWorkers = [];
+        private readonly List<(Task Task, CancellationTokenSource Cts)> _lowWorkers = [];
+        private readonly SemaphoreSlim _scaleLock = new(1, 1);
+        private CancellationTokenSource _serviceCts;
+
+        public int HighDepth => _high.Reader.Count;
+        public int LowDepth => _low.Reader.Count;
+
+        public DiscordQueueService(IOptionsMonitor<DiscordQueueOptions> optsMon, ILogger<DiscordQueueService> logger, IClient bugsnag) {
+            _optsMon = optsMon;
+            _logger = logger;
+            _bugsnag = bugsnag;
+        }
+
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            _serviceCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var ct = _serviceCts.Token;
+            var opts = _optsMon.CurrentValue;
+
+            await _scaleLock.WaitAsync(cancellationToken);
+            try {
+                for(var i = 0; i < opts.High.MinWorkers; i++) SpinUpWorker(_high, _highWorkers, opts.High.BatchPauseMs, ct);
+                for(var i = 0; i < opts.Low.MinWorkers; i++) SpinUpWorker(_low, _lowWorkers, opts.Low.BatchPauseMs, ct);
+            } finally {
+                _scaleLock.Release();
+            }
+
+            _ = Task.Run(() => ScaleMonitor(_high, _highWorkers, true, ct), ct);
+            _ = Task.Run(() => ScaleMonitor(_low, _lowWorkers, false, ct), ct);
+
+            _logger.LogInformation("DiscordQueueService started - HIGH: {h} workers, LOW: {l} workers", opts.High.MinWorkers, opts.Low.MinWorkers);
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            _serviceCts?.Cancel();
+            _high.Writer.Complete();
+            _low.Writer.Complete();
+            List<Task> allWorkerTasks;
+            await _scaleLock.WaitAsync(cancellationToken);
+            try {
+                foreach(var w in _highWorkers) { w.Cts.Cancel(); w.Cts.Dispose(); }
+                foreach(var w in _lowWorkers) { w.Cts.Cancel(); w.Cts.Dispose(); }
+                allWorkerTasks = [.. _highWorkers.Select(w => w.Task), .. _lowWorkers.Select(w => w.Task)];
+                _highWorkers.Clear();
+                _lowWorkers.Clear();
+            } finally {
+                _scaleLock.Release();
+            }
+            await Task.WhenAll(allWorkerTasks).WaitAsync(cancellationToken);
+        }
+
+        public void EnqueueHigh(Func<Task> operation) {
+            if (!_high.Writer.TryWrite(new QueueItem(operation)))
+                _logger.LogWarning("DiscordQueue HIGH dropped item - service is stopped");
+        }
+
+        public void EnqueueLow(Func<Task> operation) {
+            if (!_low.Writer.TryWrite(new QueueItem(operation)))
+                _logger.LogWarning("DiscordQueue LOW dropped item - service is stopped");
+        }
+
+        public Task<T> EnqueueHighAsync<T>(Func<Task<T>> operation, CancellationToken ct = default) => EnqueueWithResult(_high, operation, ct);
+        public Task<T> EnqueueLowAsync<T>(Func<Task<T>> operation, CancellationToken ct = default) => EnqueueWithResult(_low, operation, ct);
+
+        private Task<T> EnqueueWithResult<T>(Channel<QueueItem> channel, Func<Task<T>> operation, CancellationToken ct) {
+            var tcs = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var reg = ct.Register(static s => ((TaskCompletionSource<T>)s!).TrySetCanceled(), tcs);
+            tcs.Task.ContinueWith(_ => reg.Dispose(), TaskScheduler.Default);
+            if (!channel.Writer.TryWrite(new QueueItem(async () => {
+                try {
+                    tcs.TrySetResult(await operation());
+                } catch(Exception ex) {
+                    tcs.TrySetException(ex);
+                }
+            }))) {
+                reg.Dispose();
+                tcs.TrySetException(new InvalidOperationException("DiscordQueueService is stopped; cannot enqueue."));
+            }
+            return tcs.Task;
+        }
+
+        private void SpinUpWorker(Channel<QueueItem> channel, List<(Task Task, CancellationTokenSource Cts)> workers, int pauseMs, CancellationToken serviceCt) {
+            var cts = CancellationTokenSource.CreateLinkedTokenSource(serviceCt);
+            var task = Task.Run(() => WorkerLoop(channel, pauseMs, cts.Token), serviceCt);
+            workers.Add((task, cts));
+        }
+
+        private async Task WorkerLoop(Channel<QueueItem> channel, int pauseMs, CancellationToken ct) {
+            try {
+                await foreach(var item in channel.Reader.ReadAllAsync(ct)) {
+                    try {
+                        await item.Operation();
+                    } catch(Exception ex) {
+                        _logger.LogError(ex, "DiscordQueue worker error");
+                        _bugsnag?.Notify(ex);
+                    }
+                    if(pauseMs > 0 && !ct.IsCancellationRequested)
+                        await Task.Delay(pauseMs, ct);
+                }
+            } catch(OperationCanceledException) { }
+        }
+
+        private async Task ScaleMonitor(Channel<QueueItem> channel, List<(Task Task, CancellationTokenSource Cts)> workers, bool isHigh, CancellationToken ct) {
+            while(!ct.IsCancellationRequested) {
+                try {
+                    var opts = _optsMon.CurrentValue;
+                    var tier = isHigh ? opts.High : opts.Low;
+                    await Task.Delay(tier.ScaleCheckIntervalMs, ct);
+
+                    var depth = channel.Reader.Count;
+                    await _scaleLock.WaitAsync(ct);
+                    try {
+                        if(depth > tier.ScaleUpThreshold && workers.Count < tier.MaxWorkers) {
+                            var serviceCt = _serviceCts.Token;
+                            SpinUpWorker(channel, workers, tier.BatchPauseMs, serviceCt);
+                            _logger.LogInformation("DiscordQueue {tier} scaled UP to {count} workers (depth={depth})", isHigh ? "HIGH" : "LOW", workers.Count, depth);
+                        } else if(depth < tier.ScaleDownThreshold && workers.Count > tier.MinWorkers) {
+                            var last = workers[^1];
+                            workers.RemoveAt(workers.Count - 1);
+                            last.Cts.Cancel();
+                            last.Cts.Dispose();
+                            _logger.LogInformation("DiscordQueue {tier} scaled DOWN to {count} workers (depth={depth})", isHigh ? "HIGH" : "LOW", workers.Count, depth);
+                        }
+                    } finally {
+                        _scaleLock.Release();
+                    }
+                } catch(OperationCanceledException) {
+                    break;
+                } catch(Exception ex) {
+                    _logger.LogError(ex, "ScaleMonitor error");
+                }
+            }
+        }
+    }
+}

--- a/EGG9000.Common/Services/IDiscordQueue.cs
+++ b/EGG9000.Common/Services/IDiscordQueue.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Services {
+    public interface IDiscordQueue {
+        int HighDepth { get; }
+        int LowDepth { get; }
+        void EnqueueHigh(Func<Task> operation);
+        void EnqueueLow(Func<Task> operation);
+        Task<T> EnqueueHighAsync<T>(Func<Task<T>> operation, CancellationToken ct = default);
+        Task<T> EnqueueLowAsync<T>(Func<Task<T>> operation, CancellationToken ct = default);
+    }
+}


### PR DESCRIPTION
#232 and #233 need to be merged before this one, as the fixes incremented on themselves.

Adds a priority based queue for all gateway interactions (prioritizing what really _does_ need to be real-time), and splitting what could be REST instead, to do that. This should hopefully produce much better reliability for channel updates, and interactions.