### PR TITLE
Fix: Back-Ported Fixes from PG Branch

### DIFF
--- a/EGG9000.Bot/Automated/CleanAutomationLogs.cs
+++ b/EGG9000.Bot/Automated/CleanAutomationLogs.cs
@@ -1,0 +1,19 @@
+using EGG9000.Common.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Bot.Automated {
+    public class CleanAutomationLogs(IServiceProvider provider) : _UpdaterBase<CleanAutomationLogs>(TimeSpan.FromHours(12), TimeSpan.FromMinutes(5), provider) {
+        public async override Task Run(object state, CancellationToken cancellationToken) {
+            var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var cutoff = DateTimeOffset.UtcNow.AddDays(-7);
+            var deleted = await _db.AutomationLogs.Where(x => x.StartTime < cutoff).ExecuteDeleteAsync(cancellationToken);
+            _logger.LogInformation("Deleted {count} AutomationLogs older than {cutoff}", deleted, cutoff);
+        }
+    }
+}

--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -175,7 +175,13 @@ namespace EGG9000.Bot.Automated.Coops {
                                 coop.ThreadParentChannel = headerChannel.Id;
                                 coop.OverflowGuildId = headerChannel.Guild.Id;
                                 _logger.LogInformation("Thread created for {coopName} in {guild}", coop.Name, headerChannel.Guild.Name);
-                                await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+                                using var writeScope = _provider.CreateScope();
+                                var writeDb = writeScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                                await writeDb.Coops.Where(c => c.Id == coop.Id).ExecuteUpdateAsync(s => s
+                                    .SetProperty(c => c.Status, coop.Status)
+                                    .SetProperty(c => c.ThreadID, coop.ThreadID)
+                                    .SetProperty(c => c.ThreadParentChannel, coop.ThreadParentChannel)
+                                    .SetProperty(c => c.OverflowGuildId, coop.OverflowGuildId));
                                 guildWithOverflow.LastAccessed = DateTimeOffset.Now;
                                 var dbguild = dbguilds.FirstOrDefault(x => x.Id == guildWithOverflow.Guild.Id);
                                 var overflowGuild = coop.OverflowGuildId > 0 ? _client.GetGuild(coop.OverflowGuildId) : guildWithOverflow.Guild;

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -81,9 +81,9 @@ namespace EGG9000.Bot.Automated.Coops {
 
             var completedCoops = 0;
 #if DEBUG
-            var throttler = new SemaphoreSlim(10);
+            var throttler = new SemaphoreSlim(3);
 #else
-            var throttler = new SemaphoreSlim(10);
+            var throttler = new SemaphoreSlim(3);
 #endif
             var guildCoopGroups = coops.GroupBy(x => x.OverflowGuildId > 0 ? x.OverflowGuildId : x.GuildId).OrderBy(x => rand.Next());
             foreach(var guildCoops in guildCoopGroups) {

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -53,6 +53,7 @@ namespace EGG9000.Bot.Automated.Coops {
 #endif
         private readonly Dictionary<ulong, SocketTextChannel> _demeritChannels = [];
         private static Random rand = new Random();
+        private readonly SemaphoreSlim _writeSemaphore = new SemaphoreSlim(1, 1);
 
         public class UserX {
             public SocketGuildUser SocketGuildUser { get; set; }
@@ -80,11 +81,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
 
             var completedCoops = 0;
-#if DEBUG
-            var throttler = new SemaphoreSlim(3);
-#else
-            var throttler = new SemaphoreSlim(3);
-#endif
+            var throttler = new SemaphoreSlim(10);
             var guildCoopGroups = coops.GroupBy(x => x.OverflowGuildId > 0 ? x.OverflowGuildId : x.GuildId).OrderBy(x => rand.Next());
             foreach(var guildCoops in guildCoopGroups) {
                 if(cancellationToken.IsCancellationRequested) break;
@@ -250,7 +247,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 if(!coop.SuccessfullyStarted && statusReponse.Status.Success) {
                     coop.SuccessfullyStarted = true;
-                    await _db.SaveChangesAsync(CancellationToken.None);
+                    await QueuedSaveAsync(_db);
                 }
 
                 await CheckForCoopCreatorStillIn(coop, status);
@@ -315,7 +312,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
 
                 if(CheckForCreator(coop, coopDetails)) {
-                    await _db.SaveChangesAsync();
+                    await QueuedSaveAsync(_db);
                 }
 
 
@@ -377,7 +374,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     participant.AddXref(xref);
                 }
                 if(participantsInCoopButWithoutXref.Count > 0)
-                    await _db.SaveChangesAsync(CancellationToken.None);
+                    await QueuedSaveAsync(_db);
                 foreach(var participant in participantsInCoopButWithoutXref) {
                     if(coop.UserCoopsXrefs.Any(x => x.UserId == participant.DBUser.Id && x.WasAssigned && !x.JoinedCoop)) {
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account."));
@@ -486,13 +483,13 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(!coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = true;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!"));
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+                        await QueuedSaveAsync(_db);
                     }
 
                     if(status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = false;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish."));
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+                        await QueuedSaveAsync(_db);
                     }
 
                     if(!coop.Finished && status.Finished()) {
@@ -509,7 +506,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         coop.CoopCompleted = DateTimeOffset.UtcNow;
                         coop.Finished = true;
 
-                        await _db.SaveChangesAsync(CancellationToken.None);
+                        await QueuedSaveAsync(_db);
                         await HandleUnjoins(usersNotJoined, users, dbGuild, coop, _db, coopThread);
                     }
 
@@ -518,7 +515,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         coop.Status = CoopStatusEnum.CompletedAllCheckIn;
                         coop.ThreadArchived = true;
                         _queue.EnqueueLow(() => coopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay));
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+                        await QueuedSaveAsync(_db);
                     }
                 }
 
@@ -554,7 +551,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(unjoinedRole != null) {
                             await userStatus.DiscordUser.RemoveRoleAsync(unjoinedRole);
                         }
-                        await _db.SaveChangesAsync(CancellationToken.None);
+                        await QueuedSaveAsync(_db);
                     }
                 }
 
@@ -570,7 +567,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         xref.UpdateCoopSetting();
                     }
                 }
-                await _db.SaveChangesAsync(CancellationToken.None);
+                await QueuedSaveAsync(_db);
 
                 timings.Set(5.1);
                 var pingsLeft = usersNeedingChannelPermissions.Distinct().Select(id => $"<@{id}>").ToList() ?? [];
@@ -595,7 +592,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                 }
                             });
                         coop.RolesAddedToThread = true;
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+                        await QueuedSaveAsync(_db);
                     } catch(Exception) {
                         _logger.LogInformation("Failed to compile role pings for {coop}", coopName);
                     }
@@ -643,7 +640,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     }
                 }
                 if(usersAdded.Count > 0) {
-                    await _db.SaveChangesAsync(CancellationToken.None);
+                    await QueuedSaveAsync(_db);
                 }
 
                 //Handle waiting on assigned
@@ -686,16 +683,16 @@ namespace EGG9000.Bot.Automated.Coops {
                             if(discordUser != null && !coop.Finished && coop.Status != CoopStatusEnum.Failed && coop.CoopEnds > DateTimeOffset.Now) {
                                 if(!userFarmDetails.Xref.JoinWarning24TillFinish && timeRemaining.TotalHours < 24 && userFarmDetails.Xref.CreatedOn < DateTimeOffset.Now.AddHours(-1)) {
                                     userFarmDetails.Xref.JoinWarning24TillFinish = true;
-                                    await _db.SaveChangesAsync(CancellationToken.None);
+                                    await QueuedSaveAsync(_db);
                                     await SendDMWarning(_db, discordUser, coopThread, $"reminder to join - co-op will be finished in under {Math.Ceiling(timeRemaining.TotalHours)} hours", coop);
                                 } else if(!userFarmDetails.Xref.JoinWarning24h && userFarmDetails.Xref.CreatedOn < DateTimeOffset.Now.AddHours(-24)) {
                                     userFarmDetails.Xref.JoinWarning24h = true;
                                     userFarmDetails.Xref.JoinWarning12h = true;
-                                    await _db.SaveChangesAsync(CancellationToken.None);
+                                    await QueuedSaveAsync(_db);
                                     await SendDMWarning(_db, discordUser, coopThread, $"reminder to join - 24h since added to co-op", coop);
                                 } else if(!userFarmDetails.Xref.JoinWarning12h && userFarmDetails.Xref.CreatedOn < DateTimeOffset.Now.AddHours(-12)) {
                                     userFarmDetails.Xref.JoinWarning12h = true;
-                                    await _db.SaveChangesAsync(CancellationToken.None);
+                                    await QueuedSaveAsync(_db);
                                     await SendDMWarning(_db, discordUser, coopThread, $"reminder to join - 12h since added to co-op", coop);
                                 }
 
@@ -712,7 +709,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                 if(farm.CoopId.Equals(coop.Name, StringComparison.OrdinalIgnoreCase)) {
                                     _queue.EnqueueLow(() => coopThread.SendMessageAsync($"{discordUser?.Mention ?? user.DiscordUsername}, it looks like your game thinks you have joined the co-op but the game's servers don't see you in the co-op. Please check with the other members of the co-op to verify they don't see you, if they don't then you will need to restart the contract and join again. After you do make sure the bot can see you in the co-op."));
                                     userFarmDetails.Xref.OutsideCoop = true;
-                                    await _db.SaveChangesAsync(CancellationToken.None);
+                                    await QueuedSaveAsync(_db);
                                 } else if(farm.CoopId.Length > 0 && farm.FarmType == Ei.FarmType.Contract) {
                                     // This should always happen so that no matter what, we're only sending one message
                                     userFarmDetails.Xref.OutsideCoop = true;
@@ -751,7 +748,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                     }
 
                                     // And we always want to save the DB
-                                    await _db.SaveChangesAsync(CancellationToken.None);
+                                    await QueuedSaveAsync(_db);
                                 }
                             }
                         } catch(Exception e) {
@@ -902,7 +899,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     coop.Status = CoopStatusEnum.Failed;
                     finalChannelUpdate = true;
                     coop.ThreadArchived = true;
-                    await _db.SaveChangesAsync(CancellationToken.None);
+                    await QueuedSaveAsync(_db);
 
                     await HandleUnjoins(usersNotJoined, users, dbGuild, coop, _db, coopThread);
                 }
@@ -1154,7 +1151,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
 
                 coop.LastUpdateToChannel = DateTimeOffset.Now;
-                await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+                await QueuedSaveAsync(_db);
 
 
                 var times = timings.Finished();
@@ -1537,7 +1534,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                 Details = JsonConvert.SerializeObject(new { FarmTimestemp = user.CoopStatus?.FarmInfo?.Timestamp, Silos = siloTimeHours })
                             };
                             _db.Demerit.Add(demerit);
-                            await _db.SaveChangesAsync();
+                            await QueuedSaveAsync(_db);
                             var count = await _db.Demerit.AsQueryable().Where(x => x.UserId == user.DBUser.Id && x.When > DateTimeOffset.Now.AddMonths(-1)).CountAsync();
                             var demeritText = $"Demerit added to {user.DiscordUser?.Mention ?? user.DBUser.DiscordUsername} for the reason: {demerit.Reason} ({count} demerits)";
                             if(count >= 3) {
@@ -1572,7 +1569,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 if(userFarmDetail.Xref.CreatedOn > DateTimeOffset.Now.AddHours(-18)) {
                     _db.Remove(userFarmDetail.Xref);
-                    await _db.SaveChangesAsync();
+                    await QueuedSaveAsync(_db);
                     _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"Removed {userFarmDetail.DiscordUser?.GetCleanName() ?? user.DiscordUsername} without a demerit since they were added less than 18 hours before the co-op finished."));
                     continue;
                 }
@@ -1655,7 +1652,7 @@ namespace EGG9000.Bot.Automated.Coops {
             if(existingDemerit || xref.JoinedCoop) {
                 _queue.EnqueueLow(() => coopChannel.SendMessageAsync($"Removing {discordUser?.Mention ?? user.DiscordUsername} due to: {reason}"));
                 _db.Remove(xref);
-                await _db.SaveChangesAsync();
+                await QueuedSaveAsync(_db);
             } else {
                 _db.Remove(xref);
                 if(user.IsFreshEgg()) {
@@ -1669,7 +1666,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         Reason = reason
                     };
                     _db.Demerit.Add(demerit);
-                    await _db.SaveChangesAsync();
+                    await QueuedSaveAsync(_db);
                     var count = await _db.Demerit.AsQueryable().Where(x => x.UserId == user.Id && x.When > DateTimeOffset.Now.AddMonths(-1)).CountAsync();
                     var demeritText = $"Demerit added to {discordUser?.Mention ?? user.DiscordUsername} for the reason: {demerit.Reason} ({count} demerits)";
                     _queue.EnqueueLow(() => coopChannel.SendMessageAsync(demeritText));
@@ -1690,7 +1687,7 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(user.User.DiscordId == highestEB2.DBUser.DiscordId) continue; //Don't ping them if they are the highest EB
                         user.Xref.CoopSetting.PingOnHighestEB = false;
                         user.Xref.UpdateCoopSetting();
-                        await _db.SaveChangesAsync();
+                        await QueuedSaveAsync(_db);
                         await SendDMWarning(_db, user.DiscordUser, coopChannel, $"Highest EB ({highestEB2.DiscordUser?.GetCleanName()} at {highestEB2.Backup.EarningsBonus.ToEggString()}) has joined", coop);
                     }
                 }
@@ -1704,7 +1701,7 @@ namespace EGG9000.Bot.Automated.Coops {
                 foreach(var user in anybodyWithPingSetting) {
                     user.Xref.CoopSetting.PingOnCompleteOnCheckIn = false;
                     user.Xref.UpdateCoopSetting();
-                    await _db.SaveChangesAsync();
+                    await QueuedSaveAsync(_db);
                     await SendDMWarning(_db, user.DiscordUser, coopChannel, $"Your co-op will complete once everyone checks in.", coop);
                 }
             }
@@ -1745,6 +1742,15 @@ namespace EGG9000.Bot.Automated.Coops {
             }
 
             return null;
+        }
+
+        private async Task QueuedSaveAsync(ApplicationDbContext db) {
+            await _writeSemaphore.WaitAsync();
+            try {
+                await db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
+            } finally {
+                _writeSemaphore.Release();
+            }
         }
 
         public bool CheckForCreator(Coop coop, CoopDetails coopDetails) {

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -532,6 +532,48 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => x.Content = $"Join response- Status: {joinResponse.Status}, Banned: {joinResponse.Banned}, Success: {joinResponse.Success}");
         }
 
+        [SlashCommand(Description = "Database load, cache sizes, and process memory", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "a")]
+        public static async Task DbLoad(FauxCommand command, ApplicationDbContext db) {
+            await command.DeferAsync(ephemeral: true);
+
+            var sw = Stopwatch.StartNew();
+            await db.Database.ExecuteSqlRawAsync("SELECT 1");
+            var pingMs = sw.ElapsedMilliseconds;
+
+            var proc = System.Diagnostics.Process.GetCurrentProcess();
+            var workingMb = proc.WorkingSet64 / 1_048_576.0;
+            var gcHeapMb = GC.GetTotalMemory(false) / 1_048_576.0;
+
+            var cacheCount = db._cache is MemoryCache mc ? mc.Count : -1;
+
+            var trackerEntries = db.ChangeTracker.Entries().ToList();
+            var pending = trackerEntries.Count(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted);
+
+            var activeCoops = await db.Coops.CountAsync(x => !x.Finished && x.CoopEnds > DateTimeOffset.UtcNow);
+            var dbUsers = await db.DBUsers.CountAsync();
+            var contracts = await db.Contracts.CountAsync();
+            var events = await db.Events.CountAsync();
+            var autoLogs = await db.AutomationLogs.CountAsync(x => x.StartTime > DateTimeOffset.UtcNow.AddDays(-1));
+
+            var rows = new List<List<FixedWidthCell>> {
+                new() { new("DB Ping"), new($"{pingMs} ms", CellAlignment.Right) },
+                new() { new("Working Set"), new($"{workingMb:F1} MB", CellAlignment.Right) },
+                new() { new("GC Heap"), new($"{gcHeapMb:F1} MB", CellAlignment.Right) },
+                new() { new("GC (0/1/2)"), new($"{GC.CollectionCount(0)} / {GC.CollectionCount(1)} / {GC.CollectionCount(2)}", CellAlignment.Right) },
+                new() { new("Cache"), new(cacheCount >= 0 ? $"{cacheCount}" : "n/a", CellAlignment.Right) },
+                new() { new("Tracked"), new($"{trackerEntries.Count}", CellAlignment.Right) },
+                new() { new("Pending"), new($"{pending}", CellAlignment.Right) },
+                null,
+                new() { new("DBUsers"), new($"{dbUsers:N0}", CellAlignment.Right) },
+                new() { new("Active Coops"), new($"{activeCoops:N0}", CellAlignment.Right) },
+                new() { new("Contracts"), new($"{contracts:N0}", CellAlignment.Right) },
+                new() { new("Events"), new($"{events:N0}", CellAlignment.Right) },
+                new() { new("AutoLogs 24h"), new($"{autoLogs:N0}", CellAlignment.Right) },
+            };
+
+            await command.RespondAsync($"```\n{GetTable(rows)}```", ephemeral: true);
+        }
+
         [SlashCommand(Description = "Active Co-op Stats", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task CoopStats(FauxCommand command, ApplicationDbContext db) {
             await command.DeferAsync();

--- a/EGG9000.Bot/Program.cs
+++ b/EGG9000.Bot/Program.cs
@@ -131,6 +131,8 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
 #endif
 
         services.AddSingleton<DatabaseCache>();
+        services.AddHostedService<UserCacheRefreshService>();
+        services.AddHostedService<ActiveCoopsCacheRefreshService>();
         services.AddSingleton<Words>();
         services.Configure<APILinkOptions>(x => x.ReportUpdatedClientVersion = true);
 
@@ -237,6 +239,7 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
         services.AddHostedService<HandleGradeChanges>();
         services.AddHostedService<RefreshNasaApod>();
         services.AddHostedService<UpdateBackups>();
+        services.AddHostedService<CleanAutomationLogs>();
 
         services.AddSingleton<CoopsBeingCreatedService>();
         services.AddSingleton<JobService>();

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -87,7 +87,7 @@ namespace EGG9000.Common.Services {
                 }
             } catch(Exception e) {
                 _bugsnag.Notify(e);
-                logger.LogError(e, "Error handling channel deletion for channel {channelId}", arg.Id);
+                _logger.LogError(e, "Error handling channel deletion for channel {channelId}", arg.Id);
             }
         }
 

--- a/EGG9000.Common/Database/DatabaseCache.cs
+++ b/EGG9000.Common/Database/DatabaseCache.cs
@@ -23,26 +23,23 @@ namespace EGG9000.Common.Database {
             _logger = logger;
             var db = dbContextFactory.CreateDbContext();
             _lastCacheUpdateUser = DateTimeOffset.UtcNow;
-            _cachedUsers = db.DBUsers.ToList();
+            _cachedUsers = db.DBUsers.AsNoTracking().ToList();
 
             RefreshActiveCoopsCache().Wait();
-            _timerActiveCoops = new Timer(async _ => await RefreshActiveCoopsCache(), null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
-            _timerUsers = new Timer(async _ => await RefreshUserCache(), null, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(60));
         }
 
         private volatile List<DBUser> _cachedUsers;
         private DateTimeOffset _lastCacheUpdateUser;
-        private Timer _timerUsers;
 
         public List<DBUser> GetCachedUsers() => _cachedUsers;
         public Task<List<DBUser>> GetDbUsers() => Task.FromResult(_cachedUsers);
 
-        private async Task RefreshUserCache() {
+        public async Task RefreshUserCache() {
             try {
                 var db = await _dbContextFactory.CreateDbContextAsync();
                 var currentCacheTime = _lastCacheUpdateUser;
                 _lastCacheUpdateUser = DateTimeOffset.UtcNow;
-                var updatedUsers = await db.DBUsers.Where(u => u.LastModified > currentCacheTime || u.CreateOn > currentCacheTime).ToListAsync();
+                var updatedUsers = await db.DBUsers.AsNoTracking().Where(u => u.LastModified > currentCacheTime || u.CreateOn > currentCacheTime).ToListAsync();
                 _logger.LogInformation("Refreshing DBUser cache, found {Count} updated users. (Last cache update {LastCacheUpdate})", updatedUsers.Count, (_lastCacheUpdateUser - currentCacheTime).Humanize());
                 var newList = new List<DBUser>(_cachedUsers);
                 newList.RemoveAll(u => updatedUsers.Any(uu => uu.Id == u.Id));
@@ -57,12 +54,11 @@ namespace EGG9000.Common.Database {
         public List<Coop> ActiveCoopsWithFiveMinuteDelay() {
             return _cachedActiveCoops;
         }
-        private Timer _timerActiveCoops;
-        private async Task RefreshActiveCoopsCache() {
+        public async Task RefreshActiveCoopsCache() {
             try {
                 var db = await _dbContextFactory.CreateDbContextAsync();
                 _logger.LogInformation("Refreshing active coops cache");
-                var coops = await db.Coops.Include(x => x.Contract).Where(c => !c.Finished && !c.DeletedChannel && !c.ThreadArchived).ToListAsync();
+                var coops = await db.Coops.AsNoTracking().Include(x => x.Contract).Where(c => !c.Finished && !c.DeletedChannel && !c.ThreadArchived).ToListAsync();
                 _cachedActiveCoops = coops;
             } catch(Exception e) {
                 _logger.LogError(e, "Error refreshing active coops cache");

--- a/EGG9000.Common/Database/DatabaseCacheRefreshServices.cs
+++ b/EGG9000.Common/Database/DatabaseCacheRefreshServices.cs
@@ -1,0 +1,19 @@
+using EGG9000.Common.Services;
+
+using Microsoft.Extensions.Logging;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Database {
+    public class UserCacheRefreshService(DatabaseCache cache, ILogger<UserCacheRefreshService> logger)
+        : PeriodicBackgroundService(TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(60), logger) {
+        protected override Task DoWorkAsync(CancellationToken cancellationToken) => cache.RefreshUserCache();
+    }
+
+    public class ActiveCoopsCacheRefreshService(DatabaseCache cache, ILogger<ActiveCoopsCacheRefreshService> logger)
+        : PeriodicBackgroundService(TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5), logger) {
+        protected override Task DoWorkAsync(CancellationToken cancellationToken) => cache.RefreshActiveCoopsCache();
+    }
+}

--- a/EGG9000.Common/Helpers/NasaHelper.cs
+++ b/EGG9000.Common/Helpers/NasaHelper.cs
@@ -141,12 +141,12 @@ public static partial class NasaHelper {
         return $"NasaApodExplanation:Apod:{apodId}";
     }
 
-    public static async Task<CustomDiscordMessage> GetCustomMessage(this NasaApod apod, ApplicationDbContext db, ILogger logger) {
+    public static Task<CustomDiscordMessage> GetCustomMessage(this NasaApod apod, ApplicationDbContext db, ILogger logger) {
         var apodEmbed = apod.GetEmbedBuilder();
-        return new CustomDiscordMessage {
+        return Task.FromResult(new CustomDiscordMessage {
             Embed = apodEmbed.Build(),
             Components = apod.CreateEphemeralExplanationButton()
-        };
+        });
 
 
         /*

--- a/EGG9000.Common/Services/APILink.cs
+++ b/EGG9000.Common/Services/APILink.cs
@@ -367,13 +367,14 @@ namespace EGG9000.Common.Services {
             }
         }
 
-        public async Task StartAsync(CancellationToken cancellationToken) {
+        public Task StartAsync(CancellationToken cancellationToken) {
             //if(_settings.AsyncLoadCache) {
             //    //_logger.LogInformation("Async Loading Users");
             //    _ = GetUsers();
             //} else {
             //    await GetUsers();
             //}
+            return Task.CompletedTask;
         }
 
         //public async Task GetUsers() {

--- a/EGG9000.Common/Services/DiscordHostedService.cs
+++ b/EGG9000.Common/Services/DiscordHostedService.cs
@@ -324,10 +324,10 @@ namespace EGG9000.Common.Services {
 
             //Wait on the Server's lock, timeout defined in DiscordHostedService
             logger.LogInformation("CreateCoopThreadHeaderAsync: Waiting on Semaphore lock for guild {guild}", guild.Name);
-            var dtNow = DateTimeOffset.Now;
+            var dtNow = DateTimeOffset.UtcNow;
             var ownershipAcquired = await guild.GetServerSemaphore().WaitAsync(DiscordHostedService.GetSemaphoreTimeout(), CancellationToken.None);
             if(ownershipAcquired) {
-                logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.Now.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
+                logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} unlocked after {timespan}.", guild.Name, TimeSpan.FromSeconds(DateTimeOffset.UtcNow.ToUnixTimeSeconds() - dtNow.ToUnixTimeSeconds()).Humanize());
             } else {
                 logger.LogInformation("CreateCoopThreadHeaderAsync: Semaphore for guild {guild} timed out after after {unlockTime} minutes.", guild.Name, DiscordHostedService.GetSemaphoreTimeout().TotalMinutes);
             }

--- a/EGG9000.Common/Services/PeriodicBackgroundService.cs
+++ b/EGG9000.Common/Services/PeriodicBackgroundService.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Services {
+    public abstract class PeriodicBackgroundService : BackgroundService {
+        private readonly TimeSpan _interval;
+        private readonly TimeSpan _initialDelay;
+        protected readonly ILogger _logger;
+
+        protected PeriodicBackgroundService(TimeSpan interval, TimeSpan initialDelay, ILogger logger) {
+            _interval = interval;
+            _initialDelay = initialDelay;
+            _logger = logger;
+        }
+
+        protected abstract Task DoWorkAsync(CancellationToken cancellationToken);
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
+            try {
+                if(_initialDelay > TimeSpan.Zero) {
+                    await Task.Delay(_initialDelay, stoppingToken);
+                }
+
+                using var timer = new PeriodicTimer(_interval);
+                while(true) {
+                    try {
+                        await DoWorkAsync(stoppingToken);
+                    } catch(OperationCanceledException) when(stoppingToken.IsCancellationRequested) {
+                        break;
+                    } catch(Exception e) {
+                        _logger.LogError(e, "{Service} tick failed", GetType().Name);
+                    }
+
+                    if(!await timer.WaitForNextTickAsync(stoppingToken)) {
+                        break;
+                    }
+                }
+            } catch(OperationCanceledException) { }
+        }
+    }
+}

--- a/EGG9000.Site/Controllers/EIIDTest.cs
+++ b/EGG9000.Site/Controllers/EIIDTest.cs
@@ -10,8 +10,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 
-using NuGet.Protocol;
-
 using SixLabors.Fonts;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing.Processing;

--- a/EGG9000.Site/EGG9000.Site.csproj
+++ b/EGG9000.Site/EGG9000.Site.csproj
@@ -84,7 +84,7 @@
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.2" />
     <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />

--- a/EGG9000.Site/EGG9000.Site.csproj
+++ b/EGG9000.Site/EGG9000.Site.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <Configurations>Debug;Release;DEV9002;DEV9001</Configurations>
+    <!-- NU1701: Microsoft.Build has no net9.0 target; pulled in by CodeGeneration.Design (design-time only) -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
   <!--<Target Name="PrePublish" BeforeTargets="Publish">
     <Exec Command=".\prepublish.bat" />
@@ -65,7 +67,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Build" Version="18.4.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.3">
       <PrivateAssets>all</PrivateAssets>
@@ -73,14 +74,16 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>build</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NLog" Version="5.2.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.2" />
     <PackageReference Include="NLog.Targets.GraylogHttp" Version="2.0.1" />
     <PackageReference Include="NLog.Targets.Syslog" Version="7.0.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.2" />
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageReference Include="NuGet.Versioning" Version="7.3.1" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -207,6 +207,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
     services.AddHostedService<APILink>(provider => provider.GetService<APILink>());
     services.AddHostedService<NewCoopChecker>();
     services.AddSingleton<DatabaseCache>();
+    services.AddHostedService<UserCacheRefreshService>();
+    services.AddHostedService<ActiveCoopsCacheRefreshService>();
 
     services.Configure<ForwardedHeadersOptions>(options => {
         options.ForwardedHeaders =

--- a/EGG9000.Site/Services/NewCoopChecker.cs
+++ b/EGG9000.Site/Services/NewCoopChecker.cs
@@ -1,10 +1,10 @@
-﻿using EGG9000.Common.Database;
+using EGG9000.Common.Database;
+using EGG9000.Common.Services;
 
 using Humanizer;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using System;
@@ -14,55 +14,21 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace EGG9000.Site.Services {
-    public class NewCoopChecker : IHostedService, IDisposable {
+    public class NewCoopChecker(IServiceScopeFactory factory, ILogger<NewCoopChecker> logger)
+        : PeriodicBackgroundService(TimeSpan.FromSeconds(30), TimeSpan.Zero, logger) {
         public static bool WaitingOnCoops = false;
-        
-        private readonly ILogger<NewCoopChecker> _logger;
-        private readonly IServiceScopeFactory _factory;
-        private Timer _timer = null;
 
-        public NewCoopChecker(ILogger<NewCoopChecker> logger, IServiceScopeFactory factory) {
-            _logger = logger;
-            _factory = factory;
-            Console.WriteLine("NewCoopChecker started");
-        }
-
-        public void Dispose() {
-            _timer?.Dispose();
-        }
-
-        public Task StartAsync(CancellationToken cancellationToken) {
-            _logger.LogInformation("Timed Hosted Service running.");
-
-            _timer = new Timer(DoWorkAsync, null, TimeSpan.Zero,
-                TimeSpan.FromSeconds(30));
-
-            return Task.CompletedTask;
-        }
-
-        private async void DoWorkAsync(object state) {
-            var sw = new Stopwatch();
-            sw.Start();
-            using (var scope = _factory.CreateScope()) {
-                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-                var coopCount = await db.Coops.Where(x => x.Status == Common.Database.Entities.CoopStatusEnum.WaitingOnThread).CountAsync();
-                if(coopCount > 20 && WaitingOnCoops == false)
-                    WaitingOnCoops = true;
-                else if(coopCount < 10 && WaitingOnCoops == true)
-                    WaitingOnCoops = false;
-
-                _logger.LogInformation(
-                    "NewCoopChecker Hosted Service is working. Count: {Count}, Time: {sw}", coopCount, TimeSpan.FromTicks(sw.ElapsedTicks).Humanize());
-                sw.Stop();
-            }
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken) {
-            _logger.LogInformation("NewCoopChecker Hosted Service is stopping.");
-
-            _timer?.Change(Timeout.Infinite, 0);
-
-            return Task.CompletedTask;
+        protected override async Task DoWorkAsync(CancellationToken cancellationToken) {
+            var sw = Stopwatch.StartNew();
+            using var scope = factory.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var coopCount = await db.Coops.Where(x => x.Status == Common.Database.Entities.CoopStatusEnum.WaitingOnThread).CountAsync(cancellationToken);
+            if(coopCount > 20 && WaitingOnCoops == false)
+                WaitingOnCoops = true;
+            else if(coopCount < 10 && WaitingOnCoops == true)
+                WaitingOnCoops = false;
+            sw.Stop();
+            _logger.LogInformation("NewCoopChecker Hosted Service is working. Count: {Count}, Time: {sw}", coopCount, TimeSpan.FromTicks(sw.ElapsedTicks).Humanize());
         }
     }
 }


### PR DESCRIPTION
- Replaced shared-context SaveChangesAsync in CreateCoopThreads with per-coop ExecuteUpdateAsync on fresh scope
   - Root cause of minutes-long pauses
- Added `AsNoTracking()` to all cache reads
- Moved cache refresh to dedicated hosted services on PeriodicTimer (no more timer stacking)
- New `PeriodicBackgroundService` base class prevents task overlap structurally
   - `NewCoopChecker` migrated to it
- New `CleanAutomationLogs` task prunes rows older than 7 days every 12h
- Removed unused/heavy NuGet packages from Site