### PR TITLE
Chore: Remove wild usage of Razor in Bot

### DIFF
--- a/EGG9000.Bot/Commands/ContractSettings.cs
+++ b/EGG9000.Bot/Commands/ContractSettings.cs
@@ -13,8 +13,6 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
-using RazorEngine.Compilation.ImpromptuInterface.InvokeExt;
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -312,7 +310,6 @@ namespace EGG9000.Bot.Commands {
             var builder = new ComponentBuilder().WithSelectMenu($"MCSRedoLeggacies:{index},{dbuser.DiscordId}", GetRedoLeggacyOptions(account, dbuser));
 
             if(account.RedoLeggacySelection == RedoLeggacyOption.YesThreshold) {
-                builder.WithContext($"Redo leggacy contracts under {account.RedoScoreThreshold} CS");
                 builder.WithButton("Change CS Threshold", $"RLThreshModal:{index},{dbuser.DiscordId}");
             }
 

--- a/EGG9000.Bot/EGG9000.Bot.csproj
+++ b/EGG9000.Bot/EGG9000.Bot.csproj
@@ -96,7 +96,6 @@
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.3.2" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="RazorEngine.NetCore" Version="2.2.6" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.3" />


### PR DESCRIPTION
Re the convo here:
https://github.com/kendrome/EGG9000/pull/237#discussion_r3300739870

This `WithContext()` usage was never a Discord API, and was a loose import from Razor, somehow.
Removed it, and the Bot's dependency on Razor.