### PR TITLE
Fix: Status Compression and Over-Saving

### DIFF
--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -246,7 +246,6 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 if(!coop.SuccessfullyStarted && statusReponse.Status.Success) {
                     coop.SuccessfullyStarted = true;
-                    await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                 }
 
                 await CheckForCoopCreatorStillIn(coop, status);
@@ -310,9 +309,7 @@ namespace EGG9000.Bot.Automated.Coops {
                 var coopDetails = new CoopDetails(coop, coop.Contract, coop.League, users, customEggs, _client.Gateway, statusReponse.Status);
 
 
-                if(CheckForCreator(coop, coopDetails)) {
-                    await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
-                }
+                _ = CheckForCreator(coop, coopDetails);
 
 
                 //** Verify if people have access to the parent channel
@@ -372,8 +369,6 @@ namespace EGG9000.Bot.Automated.Coops {
                     _db.Add(xref);
                     participant.AddXref(xref);
                 }
-                if(participantsInCoopButWithoutXref.Count > 0)
-                    await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                 foreach(var participant in participantsInCoopButWithoutXref) {
                     if(coop.UserCoopsXrefs.Any(x => x.UserId == participant.DBUser.Id && x.WasAssigned && !x.JoinedCoop)) {
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"<@{participant.DBUser.DiscordId}>, it looks like you might have joined the coop with the wrong account."));
@@ -482,13 +477,11 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(!coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = true;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!"));
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.Now) {
                         coop.ProjectedToFinish = false;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish."));
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
 
                     if(!coop.Finished && status.Finished()) {
@@ -550,7 +543,6 @@ namespace EGG9000.Bot.Automated.Coops {
                         if(unjoinedRole != null) {
                             await userStatus.DiscordUser.RemoveRoleAsync(unjoinedRole);
                         }
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     }
                 }
 
@@ -566,8 +558,6 @@ namespace EGG9000.Bot.Automated.Coops {
                         xref.UpdateCoopSetting();
                     }
                 }
-                await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
-
                 timings.Set(5.1);
                 var pingsLeft = usersNeedingChannelPermissions.Distinct().Select(id => $"<@{id}>").ToList() ?? [];
 
@@ -591,7 +581,6 @@ namespace EGG9000.Bot.Automated.Coops {
                                 }
                             });
                         coop.RolesAddedToThread = true;
-                        await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                     } catch(Exception) {
                         _logger.LogInformation("Failed to compile role pings for {coop}", coopName);
                     }
@@ -637,9 +626,6 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(xref?.Xref != null) {
                         xref.Xref.AddedToChannel = true;
                     }
-                }
-                if(usersAdded.Count > 0) {
-                    await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None);
                 }
 
                 //Handle waiting on assigned

--- a/EGG9000.Bot/Program.cs
+++ b/EGG9000.Bot/Program.cs
@@ -118,7 +118,7 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
         services.AddDbContextFactory<ApplicationDbContext>(options => {
             options.UseSqlServer(connectionString, x => {
                 x.MigrationsAssembly("EGG9000.Common");
-                x.CommandTimeout(15);
+                x.CommandTimeout(30);
             });
             options.EnableSensitiveDataLogging(true);
         });

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -91,6 +91,7 @@ namespace EGG9000.Common.Database.Entities {
                 _status = value;
                 var bytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(value, new JsonSerializerSettings { ContractResolver = new CustomContractResolver() }));
 
+                byte[] compressed;
                 using(var msi = new MemoryStream(bytes))
                 using(var mso = new MemoryStream()) {
                     using(var gs = new GZipStream(mso, CompressionMode.Compress)) {
@@ -98,8 +99,14 @@ namespace EGG9000.Common.Database.Entities {
                         CopyTo(msi, gs);
                     }
 
-                    _StatusCompressed = mso.ToArray();
+                    compressed = mso.ToArray();
                 }
+
+                // Only reassign the mapped LOB column when the payload actually changed, so EF Core
+                // does not rewrite _StatusCompressed every status cycle. That blob write is the
+                // heaviest and most lock-contended write on Coops during contract launches.
+                if(_StatusCompressed is null || !_StatusCompressed.AsSpan().SequenceEqual(compressed))
+                    _StatusCompressed = compressed;
             }
         }
 

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -122,7 +122,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
     //_logger.LogInformation(Configuration.GetConnectionString("DefaultConnection"));
     //_logger.LogInformation(Configuration.GetChildren().Count().ToString());
     services.AddDbContext<ApplicationDbContext>(
-        options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"), x => x.CommandTimeout(15)),
+        options => options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"), x => x.CommandTimeout(30)),
         contextLifetime: ServiceLifetime.Scoped,
         optionsLifetime: ServiceLifetime.Singleton);
 
@@ -130,7 +130,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
     services.AddDbContextFactory<ApplicationDbContext>(options => {
         options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"), x => {
             x.MigrationsAssembly("EGG9000.Common");
-            x.CommandTimeout(15);
+            x.CommandTimeout(30);
         });
         options.EnableSensitiveDataLogging(true);
     });


### PR DESCRIPTION
Main offender was `ThreadsCoopStatusUpdater` doing ~18 separate SaveChanges per coop per cycle. At BG launch, that was thousands of tiny writes on the same sequential-GUID Coops pages.

- ProcessCoop now saves once at the end of the cycle instead of after every flag flip.
  - Dropped 9 mid-cycle saves (started, projected-to-finish, joined, roles/channel perms, xref adds, etc).
  - Kept the ones that have to persist before a DM goes out (join warnings, outside-coop) and the finish/fail saves.
  - Normal coop goes from ~9 writes a cycle to 1.

- LastStatusUpdate only rewrites _StatusCompressed when the bytes actually changed.
  - The blob was getting rewritten every cycle for every coop even when nothing moved, and is the heaviest write on the table.