### PR TITLE
Feature: Artifact Sets V2

### DIFF
--- a/EGG9000.Bot/Automated/ArtifactCheaters.cs
+++ b/EGG9000.Bot/Automated/ArtifactCheaters.cs
@@ -1,4 +1,5 @@
 ﻿using Discord;
+using EGG9000.Bot.Commands.Informational;
 using EGG9000.Bot.Common.Helpers;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
@@ -166,7 +167,7 @@ namespace EGG9000.Bot.Automated {
                         var image = new FileAttachment(new MemoryStream(Convert.FromBase64String(B64)), "Inventory.jpeg", "Inventory Image");
                         var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
                             Text = message,
-                            Embed = Commands.ArtifactCommands._inventoryEmbed(user, outlier),
+                            Embed = ArtifactCommands._inventoryEmbed(user, outlier),
                             File = image,
                             SendFile = true,
                         });
@@ -176,7 +177,7 @@ namespace EGG9000.Bot.Automated {
 
                         await sendResponse.ModifyAsync(x => {
                             x.Content = message;
-                            x.Embed = Commands.ArtifactCommands._inventoryEmbed(user, outlier, imageUrl);
+                            x.Embed = ArtifactCommands._inventoryEmbed(user, outlier, imageUrl);
                         });
                     }
 

--- a/EGG9000.Bot/Automated/ArtifactCheaters.cs
+++ b/EGG9000.Bot/Automated/ArtifactCheaters.cs
@@ -171,9 +171,7 @@ namespace EGG9000.Bot.Automated {
                             File = image,
                             SendFile = true,
                         });
-                        var baseUrl = sendResponse.Embeds.First().Image.ToString();
-                        var formatIndex = baseUrl.IndexOf("&format", StringComparison.OrdinalIgnoreCase);
-                        var imageUrl = formatIndex is int index && index != -1 ? baseUrl[..(index + "&format".Length)] : baseUrl;
+                        var imageUrl = ArtifactCommands.TrimImageUrl(sendResponse.Embeds.First().Image.ToString());
 
                         await sendResponse.ModifyAsync(x => {
                             x.Content = message;

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -18,7 +18,7 @@ using static EGG9000.Bot.Commands.DiscordEnums.AutoCompleteHandlers;
 using static EGG9000.Common.Helpers.ArtifactHelpers;
 using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
-namespace EGG9000.Bot.Commands {
+namespace EGG9000.Bot.Commands.Informational {
     public static class ArtifactCommands {
 
         [SlashCommand(Description = "View a user's inventory", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
@@ -134,7 +134,7 @@ namespace EGG9000.Bot.Commands {
             }
 
             // Fresh pull, update only the sets.
-            var fresh = new CustomBackup((await ContractsAPI.FirstContact(account.Id)).Backup, account.Backup ?? null);
+            var fresh = new CustomBackup((await EggIncApi.FirstContact(account.Id)).Backup, await db.CachedEiContractsAsync(), account.Backup ?? null);
             if(account.Backup is null) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Backup came back empty from the Egg, Inc. API."); }); return; }
             account.Backup.ArtifactSets = fresh.ArtifactSets;
             dbUser.UpdateAccounts();

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -68,7 +68,8 @@ namespace EGG9000.Bot.Commands.Informational {
         public static async Task _viewInventory(FauxCommand command, ApplicationDbContext db, DBUser user, EggIncAccount account, bool showInChannel = true) {
             //Pull and save a fresh backup
             var backup = new CustomBackup((await EggIncApi.FirstContact(account.Id)).Backup, await db.CachedEiContractsAsync(), account.Backup ?? null);
-            account.Backup.ArtifactHall = backup.ArtifactHall;
+            if(account.Backup is null) account.Backup = backup;
+            else account.Backup.ArtifactHall = backup.ArtifactHall;
             user.UpdateAccounts();
             await db.SaveChangesAsync();
 
@@ -89,9 +90,7 @@ namespace EGG9000.Bot.Commands.Informational {
             var image = new FileAttachment(new MemoryStream(Convert.FromBase64String(B64)), "Inventory.jpeg", "Inventory Image");
             await command.RespondWithFileAsync(image, text: " ", embed: _inventoryEmbed(user, account), ephemeral: !showInChannel);
             var response = command.GetOriginalResponseAsync().Result; // Get the response to edit it
-            var baseUrl = response.Embeds.First().Image.ToString();
-            var formatIndex = baseUrl.IndexOf("&format", StringComparison.OrdinalIgnoreCase);
-            var imageUrl = formatIndex is int index && index != -1 ? baseUrl[..(index + "&format".Length)] : baseUrl;
+            var imageUrl = TrimImageUrl(response.Embeds.First().Image.ToString());
             await command.ModifyOriginalResponseAsync(x => {
                 x.Content = "";
                 x.Embed = _inventoryEmbed(user, account, imageUrl);
@@ -133,10 +132,11 @@ namespace EGG9000.Bot.Commands.Informational {
                 return;
             }
 
-            // Fresh pull, update only the sets.
+            // Fresh pull, update only the sets. Use the fresh backup as the initial one if the
+            // account had none yet (new/failed registration) rather than bailing on usable data.
             var fresh = new CustomBackup((await EggIncApi.FirstContact(account.Id)).Backup, await db.CachedEiContractsAsync(), account.Backup ?? null);
-            if(account.Backup is null) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Backup came back empty from the Egg, Inc. API."); }); return; }
-            account.Backup.ArtifactSets = fresh.ArtifactSets;
+            if(account.Backup is null) account.Backup = fresh;
+            else account.Backup.ArtifactSets = fresh.ArtifactSets;
             dbUser.UpdateAccounts();
             await db.SaveChangesAsync();
 
@@ -158,7 +158,7 @@ namespace EGG9000.Bot.Commands.Informational {
                 }
                 var files = pages.Select((b, i) => new FileAttachment(new MemoryStream(Convert.FromBase64String(b)), $"afxset_page_{(i + 1):D2}.jpeg")).ToList();
                 var resp = await command.RespondWithFilesAsyncGettingMessage(files, text: "Uploading artifact sets...");
-                urls = resp.Attachments.OrderBy(a => a.Filename).Select(a => TrimImageUrl(a.Url)).ToList();
+                urls = [.. resp.Attachments.OrderBy(a => a.Filename).Select(a => TrimImageUrl(a.Url))];
                 account.AfxSetsImageHash = hash;
                 account.AfxSetsImageUrls = urls;
                 dbUser.UpdateAccounts();
@@ -175,9 +175,9 @@ namespace EGG9000.Bot.Commands.Informational {
             });
         }
 
-        private static string TrimImageUrl(string baseUrl) {
+        public static string TrimImageUrl(string baseUrl) {
             var i = baseUrl.IndexOf("&format", StringComparison.OrdinalIgnoreCase);
-            return i != -1 ? baseUrl[..(i + "&format".Length)] : baseUrl;
+            return i != -1 ? baseUrl[..i] : baseUrl;
         }
 
         private static Embed AfxSetsImageEmbed(DBUser user, EggIncAccount account, List<string> urls, int page) {
@@ -220,7 +220,7 @@ namespace EGG9000.Bot.Commands.Informational {
 
         private static MessageComponent AfxSetsComponents(DBUser user, int accountIndex, List<List<EggIncArtifactInstance>> sets, int pageCount, int page) {
             var cb = new ComponentBuilder();
-            var perPage = 5;
+            var perPage = AfxSetsCreatorConfig.DefaultSetsPerPage;
             var pageStart = page * perPage;
 
             var menu = new SelectMenuBuilder().WithCustomId($"AfxSetsSelect:{user.DiscordId},{accountIndex},{page}").WithPlaceholder("Select a set to view details");

--- a/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/ArtifactCommands.cs
@@ -5,6 +5,7 @@ using EGG9000.Common.Commands;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
+using EGG9000.Common.Helpers.AfxSets;
 using EGG9000.Common.Services;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -112,37 +113,16 @@ namespace EGG9000.Bot.Commands {
             return builder.Build();
         }
 
-        private class AfxSetBuilder {
-            public ComponentBuilder ComponentBuilder { get; set; }
-            public EmbedBuilder EmbedBuilder { get; set; }
-            public AfxSetBuilder() { }
-        }
-
-        public static Color RandomColor() {
-            var random = new Random();
-
-            // Generate random values for red, green, and blue components.
-            var red = (byte)random.Next(256);
-            var green = (byte)random.Next(256);
-            var blue = (byte)random.Next(256);
-
-            // Create and return the Discord.Color.
-            return new Color(red, green, blue);
-        }
-
         [SlashCommand(Description = "Show off your saved Artifact Sets")]
-        public static async Task SavedAfSets(FauxCommand command, ApplicationDbContext db, [SlashParam(AutocompleteHandler = typeof(PersonalUserAccountAutoComplete))] string useraccount, [SlashParam(Description = "Set # to statically display", Required = false, PositiveOnly = true)] int index = 0) {
+        public static async Task SavedAfSets(FauxCommand command, ApplicationDbContext db, [SlashParam(AutocompleteHandler = typeof(PersonalUserAccountAutoComplete))] string useraccount) {
             await command.DeferAsync();
-            var lockSet = true;
-            if(index == 0) {
-                index = 1;
-                lockSet = false;
-            }
+
             var dbUser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
             if(dbUser == null) {
                 await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{command.User.Id}>.\nAre you registered?"); });
                 return;
             }
+
             EggIncAccount account = null;
             var accountIndex = 0;
             try {
@@ -153,81 +133,153 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var afxSets = account.Backup?.ArtifactSets;
-            if(afxSets is null || afxSets.Count == 0) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Backup is empty, or no Artifact Sets were found for this account"); });
+            // Fresh pull, update only the sets.
+            var fresh = new CustomBackup((await ContractsAPI.FirstContact(account.Id)).Backup, account.Backup ?? null);
+            if(account.Backup is null) { await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Backup came back empty from the Egg, Inc. API."); }); return; }
+            account.Backup.ArtifactSets = fresh.ArtifactSets;
+            dbUser.UpdateAccounts();
+            await db.SaveChangesAsync();
+
+            var sets = account.Backup.ArtifactSets;
+            if(sets is null || sets.Count == 0) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("No Artifact Sets were found for this account."); });
                 return;
             }
 
-            if(index < 1 || (index != 1 && index > afxSets.Count)) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Set number `{index}` larger than maximum set number `{afxSets.Count}`."); });
-                return;
+            var hash = AfxSetsHash.Compute(sets);
+            List<string> urls;
+            if(account.AfxSetsImageHash == hash && account.AfxSetsImageUrls is { Count: > 0 }) {
+                urls = account.AfxSetsImageUrls;
+            } else {
+                var (pages, renderError) = await AfxSetsRender.AfxSetsB64(account);
+                if(pages is null || pages.Count == 0) {
+                    await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Artifact set images could not be generated.\n```{renderError}```"); });
+                    return;
+                }
+                var files = pages.Select((b, i) => new FileAttachment(new MemoryStream(Convert.FromBase64String(b)), $"afxset_page_{(i + 1):D2}.jpeg")).ToList();
+                var resp = await command.RespondWithFilesAsyncGettingMessage(files, text: "Uploading artifact sets...");
+                urls = resp.Attachments.OrderBy(a => a.Filename).Select(a => TrimImageUrl(a.Url)).ToList();
+                account.AfxSetsImageHash = hash;
+                account.AfxSetsImageUrls = urls;
+                dbUser.UpdateAccounts();
+                await db.SaveChangesAsync();
             }
 
-            var builder = AFXSetEmbedBuilder(dbUser, accountIndex, afxSets, afxSets[index - 1]);
             await command.ModifyOriginalResponseAsync(x => {
                 x.Content = "";
-                x.Components = lockSet ? null : builder.ComponentBuilder?.Build();
-                x.Embed = builder.EmbedBuilder.Build();
+                // Drop the uploaded page attachments now that we have their CDN URLs; the embed
+                // references those URLs directly so the loose image files don't clutter the message.
+                x.Attachments = new List<FileAttachment>();
+                x.Embeds = new[] { AfxSetsImageEmbed(dbUser, account, urls, 0), AfxSetsDetailEmbed(null) };
+                x.Components = AfxSetsComponents(dbUser, accountIndex, sets, urls.Count, 0);
+            });
+        }
+
+        private static string TrimImageUrl(string baseUrl) {
+            var i = baseUrl.IndexOf("&format", StringComparison.OrdinalIgnoreCase);
+            return i != -1 ? baseUrl[..(i + "&format".Length)] : baseUrl;
+        }
+
+        private static Embed AfxSetsImageEmbed(DBUser user, EggIncAccount account, List<string> urls, int page) {
+            var name = account.Backup?.UserName ?? "(No Name)";
+            var eb = account.Backup?.EarningsBonus.ToEggString() ?? "No EB";
+            return new EmbedBuilder()
+                .WithColor(Color.Blue)
+                .WithAuthor(new EmbedAuthorBuilder().WithName("EGG9000").WithIconUrl("https://cdn.discordapp.com/avatars/514257192803893272/47be266c55cab32eacfb33c9affc82dd.webp"))
+                .WithDescription($"Artifact Sets of <@{user.DiscordId}> - `{name} ({eb})`")
+                .WithTitle("Link to full resolution image")
+                .WithUrl(urls[page])
+                .WithImageUrl(urls[page])
+                .WithFooter(new EmbedFooterBuilder().WithText($"Page {page + 1}/{urls.Count}"))
+                .Build();
+        }
+
+        private static Embed AfxSetsDetailEmbed(List<EggIncArtifactInstance> set, int globalIndex = -1) {
+            if(set is null) {
+                return new EmbedBuilder().WithColor(Color.DarkGrey).WithDescription("Select a set from the dropdown to view its artifacts and explorer links.").Build();
+            }
+            var emoji = GetAfxSetString(set);
+            var links = set.Select(a => {
+                var artifactLink = $"[{a.Artifact}]({AfxExplorerLink.Url(a, false)})";
+                // Collapse duplicate stones into "Name x N".
+                var stoneLinks = string.Concat((a.Stones ?? new())
+                    .GroupBy(s => (s.Id, s.Tier))
+                    .Select(g => {
+                        var s = g.First();
+                        var label = g.Count() > 1 ? $"{s.Artifact} x {g.Count()}" : s.Artifact;
+                        return $" + [{label}]({AfxExplorerLink.Url(s, true)})";
+                    }));
+                return artifactLink + stoneLinks;
+            });
+            return new EmbedBuilder()
+                .WithColor(Color.Gold)
+                .WithAuthor(new EmbedAuthorBuilder().WithName($"Set {globalIndex + 1}").WithIconUrl("https://cdn.discordapp.com/emojis/877681508607987772.webp"))
+                .WithDescription($"{emoji}\n\n**Explorer Links:**\n{string.Join("\n", links)}")
+                .Build();
+        }
+
+        private static MessageComponent AfxSetsComponents(DBUser user, int accountIndex, List<List<EggIncArtifactInstance>> sets, int pageCount, int page) {
+            var cb = new ComponentBuilder();
+            var perPage = 5;
+            var pageStart = page * perPage;
+
+            var menu = new SelectMenuBuilder().WithCustomId($"AfxSetsSelect:{user.DiscordId},{accountIndex},{page}").WithPlaceholder("Select a set to view details");
+            var added = 0;
+            for(var i = pageStart; i < pageStart + perPage && i < sets.Count; i++) {
+                if(sets[i].Count == 0) continue; // empty sets are not selectable
+                menu.AddOption($"Set {i + 1}", i.ToString());
+                added++;
+            }
+            if(added > 0) cb.WithSelectMenu(menu);
+
+            cb.WithButton("◀", $"AfxSetsPage:{user.DiscordId},{accountIndex},{page - 1}", ButtonStyle.Secondary, disabled: page <= 0);
+            cb.WithButton("▶", $"AfxSetsPage:{user.DiscordId},{accountIndex},{page + 1}", ButtonStyle.Secondary, disabled: page >= pageCount - 1);
+            return cb.Build();
+        }
+
+        [ComponentCommand]
+        public static async Task AfxSetsPage(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
+            var parts = data.Split(",");
+            if(parts.Length < 3) return;
+            var discordId = ulong.Parse(parts[0]);
+            var accountIndex = int.Parse(parts[1]);
+            var page = int.Parse(parts[2]);
+
+            var user = db.DBUsers.FirstOrDefault(x => x.DiscordId == discordId);
+            if(user is null || user.EggIncAccounts.Count - 1 < accountIndex) return;
+            var account = user.EggIncAccounts[accountIndex];
+            var sets = account.Backup?.ArtifactSets;
+            var urls = account.AfxSetsImageUrls;
+            if(sets is null || urls is null || page < 0 || page >= urls.Count) return;
+
+            await component.UpdateAsync(x => {
+                x.Content = "";
+                x.Embeds = new[] { AfxSetsImageEmbed(user, account, urls, page), AfxSetsDetailEmbed(null) };
+                x.Components = AfxSetsComponents(user, accountIndex, sets, urls.Count, page);
             });
         }
 
         [ComponentCommand]
-        public static async Task LoadAFXSet(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
-
-            var dataItems = data.Split(",");
-            var discordId = ulong.Parse(dataItems[0] ?? "-1");
-            var accountIndex = int.Parse(dataItems[1] ?? "-1");
-            var currentSetIndex = int.Parse(dataItems[2] ?? "-1");
-
-            if(discordId < 0 || accountIndex < 0 || currentSetIndex < 0) return;
+        public static async Task AfxSetsSelect(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
+            var parts = data.Split(",");
+            if(parts.Length < 3) return;
+            var discordId = ulong.Parse(parts[0]);
+            var accountIndex = int.Parse(parts[1]);
+            var page = int.Parse(parts[2]);
+            var selected = int.Parse(component.Data.Values.First());
 
             var user = db.DBUsers.FirstOrDefault(x => x.DiscordId == discordId);
             if(user is null || user.EggIncAccounts.Count - 1 < accountIndex) return;
-
             var account = user.EggIncAccounts[accountIndex];
-            var afxSets = account.Backup?.ArtifactSets;
-            if(afxSets is null) return;
+            var sets = account.Backup?.ArtifactSets;
+            var urls = account.AfxSetsImageUrls;
+            if(sets is null || urls is null || selected < 0 || selected >= sets.Count || page < 0 || page >= urls.Count) return;
 
-            var builder = AFXSetEmbedBuilder(user, accountIndex, afxSets, afxSets[currentSetIndex]);
             await component.UpdateAsync(x => {
                 x.Content = "";
-                x.Components = builder.ComponentBuilder?.Build();
-                x.Embed = builder.EmbedBuilder.Build();
+                x.Embeds = new[] { AfxSetsImageEmbed(user, account, urls, page), AfxSetsDetailEmbed(sets[selected], selected) };
+                x.Components = AfxSetsComponents(user, accountIndex, sets, urls.Count, page);
             });
-        }
-
-        private static AfxSetBuilder AFXSetEmbedBuilder(DBUser user, int accountIndex, List<List<EggIncArtifactInstance>> afxSets, List<EggIncArtifactInstance> currentSet) {
-            var builder = new AfxSetBuilder() {
-                ComponentBuilder = null
-            };
-
-            var componentBuilder = new ComponentBuilder();
-            var buttonCount = 0;
-
-            var currentSetIndex = afxSets.IndexOf(currentSet);
-
-            var account = user.EggIncAccounts[accountIndex];
-            var accText = user.EggIncAccounts.Count > 1 ? $"For account: {account.Backup?.UserName ?? "[No Name]"} ({account.Backup?.EarningsBonus.ToEggString() ?? "No EB"})" : "";
-
-            var embedBuilder = new EmbedBuilder().WithAuthor(
-                new EmbedAuthorBuilder()
-                    .WithName($"Set {currentSetIndex + 1}")
-                    .WithIconUrl("https://cdn.discordapp.com/emojis/877681508607987772.webp")
-                ).WithColor(RandomColor())
-                .WithDescription(GetAfxSetString(currentSet));
-            if(accText != "") embedBuilder.WithFooter(new EmbedFooterBuilder().WithText(accText));
-
-            if(currentSetIndex > 0 && afxSets.Count > 1 && afxSets[currentSetIndex - 1] is not null) {
-                componentBuilder.WithButton($"← Set {currentSetIndex}", $"LoadAFXSet:{user.DiscordId},{accountIndex},{currentSetIndex - 1}"); buttonCount++;
-            }
-            if(currentSetIndex < afxSets.Count - 1 && afxSets[currentSetIndex + 1] is not null) {
-                componentBuilder.WithButton($"Set {currentSetIndex + 2} →", $"LoadAFXSet:{user.DiscordId},{accountIndex},{currentSetIndex + 1}"); buttonCount++;
-            }
-            if(buttonCount > 0) builder.ComponentBuilder = componentBuilder;
-
-            builder.EmbedBuilder = embedBuilder;
-            return builder;
         }
 
     }

--- a/EGG9000.Common.Test/ArtifactSetsTests.cs
+++ b/EGG9000.Common.Test/ArtifactSetsTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+using EGG9000.Common.Helpers.AfxSets;
+using EGG9000.Common.Helpers;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Common.Test {
+    [TestClass]
+    public class ArtifactSetsTests {
+        [TestMethod]
+        public void BuildSetsPreservingEmpty_dropsNullsKeepsEmptyAndOrder() {
+            var input = new List<List<string>> {
+                new() { "a", null, "b" }, // partial -> [a, b]
+                new() { },                 // empty saved set -> []
+                new() { null },            // all unresolved -> []
+                new() { "c", "d", "e", "f" }
+            };
+            var result = AfxSetsBuilder.BuildSetsPreservingEmpty(input);
+            Assert.AreEqual(4, result.Count, "one output set per saved set");
+            CollectionAssert.AreEqual(new[] { "a", "b" }, result[0]);
+            Assert.AreEqual(0, result[1].Count);
+            Assert.AreEqual(0, result[2].Count);
+            CollectionAssert.AreEqual(new[] { "c", "d", "e", "f" }, result[3]);
+        }
+
+        [TestMethod]
+        public void AfxSetsHash_isStableAndOrderSensitive() {
+            var a = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = new() { new EggIncArtifactInstance { Id = 1, Tier = 2, Rarity = 0, Stones = new() } } };
+            var b = new EggIncArtifactInstance { Id = 8, Tier = 3, Rarity = 2, Stones = new() };
+            var set1 = new List<List<EggIncArtifactInstance>> { new() { a, b } };
+            var set1Copy = new List<List<EggIncArtifactInstance>> { new() { a, b } };
+            var set2 = new List<List<EggIncArtifactInstance>> { new() { b, a } };
+
+            Assert.AreEqual(AfxSetsHash.Compute(set1), AfxSetsHash.Compute(set1Copy), "same data -> same hash");
+            Assert.AreNotEqual(AfxSetsHash.Compute(set1), AfxSetsHash.Compute(set2), "reordering -> different hash");
+        }
+
+        [TestMethod]
+        public void AfxExplorerLink_buildsArtifactAndStoneUrls() {
+            // Id 26 = TachyonDeflector, tier 4 -> tachyon-deflector-4
+            var deflector = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = new() };
+            Assert.AreEqual(
+                "https://wasmegg-carpet.netlify.app/artifact-explorer/#/artifact/tachyon-deflector-4/",
+                AfxExplorerLink.Url(deflector, isStone: false));
+
+            // Id 1 = TachyonStone, Tier is 0-based; T4 stone has Tier 3 -> +1 -> tachyon-stone-4
+            var stone = new EggIncArtifactInstance { Id = 1, Tier = 3, Rarity = 0, Stones = new() };
+            Assert.AreEqual(
+                "https://wasmegg-carpet.netlify.app/artifact-explorer/#/artifact/tachyon-stone-4/",
+                AfxExplorerLink.Url(stone, isStone: true));
+        }
+    }
+}

--- a/EGG9000.Common.Test/ArtifactSetsTests.cs
+++ b/EGG9000.Common.Test/ArtifactSetsTests.cs
@@ -8,26 +8,29 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace EGG9000.Common.Test {
     [TestClass]
     public class ArtifactSetsTests {
+        private static readonly string[] expectedFirst = ["a", "b"];
+        private static readonly string[] expectedSecond = ["c", "d", "e", "f"];
+
         [TestMethod]
         public void BuildSetsPreservingEmpty_dropsNullsKeepsEmptyAndOrder() {
             var input = new List<List<string>> {
-                new() { "a", null, "b" }, // partial -> [a, b]
-                new() { },                 // empty saved set -> []
-                new() { null },            // all unresolved -> []
+                new() { "a", null!, "b" }, // partial -> [a, b]
+                new() { }, // empty saved set -> []
+                new() { null! }, // all unresolved -> []
                 new() { "c", "d", "e", "f" }
             };
             var result = AfxSetsBuilder.BuildSetsPreservingEmpty(input);
-            Assert.AreEqual(4, result.Count, "one output set per saved set");
-            CollectionAssert.AreEqual(new[] { "a", "b" }, result[0]);
-            Assert.AreEqual(0, result[1].Count);
-            Assert.AreEqual(0, result[2].Count);
-            CollectionAssert.AreEqual(new[] { "c", "d", "e", "f" }, result[3]);
+            Assert.HasCount(4, result, "one output set per saved set");
+            CollectionAssert.AreEqual(expectedFirst, result[0]);
+            Assert.IsEmpty(result[1]);
+            Assert.IsEmpty(result[2]);
+            CollectionAssert.AreEqual(expectedSecond, result[3]);
         }
 
         [TestMethod]
         public void AfxSetsHash_isStableAndOrderSensitive() {
-            var a = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = new() { new EggIncArtifactInstance { Id = 1, Tier = 2, Rarity = 0, Stones = new() } } };
-            var b = new EggIncArtifactInstance { Id = 8, Tier = 3, Rarity = 2, Stones = new() };
+            var a = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = [new EggIncArtifactInstance { Id = 1, Tier = 2, Rarity = 0, Stones = [] }] };
+            var b = new EggIncArtifactInstance { Id = 8, Tier = 3, Rarity = 2, Stones = [] };
             var set1 = new List<List<EggIncArtifactInstance>> { new() { a, b } };
             var set1Copy = new List<List<EggIncArtifactInstance>> { new() { a, b } };
             var set2 = new List<List<EggIncArtifactInstance>> { new() { b, a } };
@@ -39,13 +42,13 @@ namespace EGG9000.Common.Test {
         [TestMethod]
         public void AfxExplorerLink_buildsArtifactAndStoneUrls() {
             // Id 26 = TachyonDeflector, tier 4 -> tachyon-deflector-4
-            var deflector = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = new() };
+            var deflector = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = [] };
             Assert.AreEqual(
                 "https://wasmegg-carpet.netlify.app/artifact-explorer/#/artifact/tachyon-deflector-4/",
                 AfxExplorerLink.Url(deflector, isStone: false));
 
             // Id 1 = TachyonStone, Tier is 0-based; T4 stone has Tier 3 -> +1 -> tachyon-stone-4
-            var stone = new EggIncArtifactInstance { Id = 1, Tier = 3, Rarity = 0, Stones = new() };
+            var stone = new EggIncArtifactInstance { Id = 1, Tier = 3, Rarity = 0, Stones = [] };
             Assert.AreEqual(
                 "https://wasmegg-carpet.netlify.app/artifact-explorer/#/artifact/tachyon-stone-4/",
                 AfxExplorerLink.Url(stone, isStone: true));

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -378,27 +378,17 @@ namespace EGG9000.Common.Database {
             }).ToList();
 
             /* Setup for artifact sets */
-            var afxSetsItemIds = backup.ArtifactsDb.SavedArtifactSets.Select(s => {
-                return s.Slots.Select(sl => sl.ItemId).ToList();
-            }).ToList();
-
-            List<List<EggIncArtifactInstance>> afxSetsList = new();
-            foreach(var afxSetItems in afxSetsItemIds) {
-                var afxInstances = new List<EggIncArtifactInstance>();
-                foreach(var id in afxSetItems) {
-                    var x = backup.ArtifactsDb.InventoryItems.FirstOrDefault(item => item.ItemId == id);
-                    if(x is null) continue;
-
+            var afxSetsProjected = backup.ArtifactsDb.SavedArtifactSets.Select(s =>
+                s.Slots.Select(sl => {
+                    var x = backup.ArtifactsDb.InventoryItems.FirstOrDefault(item => item.ItemId == sl.ItemId);
+                    if(x is null) return null;
                     var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
-                    if(artifact is null) continue;
-
+                    if(artifact is null) return null;
                     artifact.Stones = x.Artifact.Stones.Select(EggIncArtifacts.GetArtifact).Where(y => y != null).ToList();
-
-                    afxInstances.Add(artifact);
-                }
-                if(afxInstances.Count == afxSetItems.Count) afxSetsList.Add(afxInstances);
-            }
-            ArtifactSets = afxSetsList;
+                    return artifact;
+                })
+            );
+            ArtifactSets = EGG9000.Common.Helpers.AfxSets.AfxSetsBuilder.BuildSetsPreservingEmpty(afxSetsProjected);
 
             ArtifactHall.AddRange(backup.ArtifactsDb.ArtifactStatus.Where(a =>
                 !backup.ArtifactsDb.InventoryItems.Any(x => a.Spec.Name == x.Artifact.Spec.Name &&

--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -394,6 +394,10 @@ namespace EGG9000.Common.Database.Entities {
         public bool DoTwoToThreeContracts { get; set; } = false;
         [Key(39)]
         public bool DoUnfinishedCollegtibles { get; set; } = false;
+        [Key(40)]
+        public string AfxSetsImageHash { get; set; } = "";
+        [Key(41)]
+        public List<string> AfxSetsImageUrls { get; set; } = new();
 
         public byte GetGroup(bool Ultra) {
             if(Ultra && UltraGroup > 0)

--- a/EGG9000.Common/Helpers/AfxSets/AfxExplorerLink.cs
+++ b/EGG9000.Common/Helpers/AfxSets/AfxExplorerLink.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+using EGG9000.Common.Helpers;
+
+namespace EGG9000.Common.Helpers.AfxSets {
+    public static class AfxExplorerLink {
+        private const string Base = "https://wasmegg-carpet.netlify.app/artifact-explorer/#/artifact/";
+
+        public static string Url(EggIncArtifactInstance instance, bool isStone) {
+            var enumName = ((ArtifactNames)instance.Id).ToString();
+            var slug = Regex.Replace(enumName, "(?<=.)([A-Z])", "-$1").ToLowerInvariant();
+            // Stone Tier is 0-based (0..3); the explorer uses 1..4. Artifact Tier is already 1-based.
+            var tier = isStone ? instance.Tier + 1 : instance.Tier;
+            return $"{Base}{slug}-{tier}/";
+        }
+    }
+}

--- a/EGG9000.Common/Helpers/AfxSets/AfxSetsBuilder.cs
+++ b/EGG9000.Common/Helpers/AfxSets/AfxSetsBuilder.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EGG9000.Common.Helpers.AfxSets {
+    public static class AfxSetsBuilder {
+        // One output set per input saved set, in order. Drops unresolved (null) slots
+        // within a set, but keeps empty sets so set indexes line up with in-game slots.
+        public static List<List<T>> BuildSetsPreservingEmpty<T>(IEnumerable<IEnumerable<T>> resolvedSlotsPerSet) where T : class {
+            return resolvedSlotsPerSet
+                .Select(set => set.Where(x => x is not null).ToList())
+                .ToList();
+        }
+    }
+}

--- a/EGG9000.Common/Helpers/AfxSets/AfxSetsHash.cs
+++ b/EGG9000.Common/Helpers/AfxSets/AfxSetsHash.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using EGG9000.Common.Helpers;
+
+namespace EGG9000.Common.Helpers.AfxSets {
+    public static class AfxSetsHash {
+        // Order-sensitive, stable hash over set contents (id/tier/rarity + stones).
+        public static string Compute(List<List<EggIncArtifactInstance>> sets) {
+            var sb = new StringBuilder();
+            foreach(var set in sets ?? new()) {
+                sb.Append('|');
+                foreach(var a in set) {
+                    sb.Append(a.Id).Append(':').Append(a.Tier).Append(':').Append(a.Rarity).Append('(');
+                    foreach(var s in a.Stones ?? new()) sb.Append(s.Id).Append(':').Append(s.Tier).Append(',');
+                    sb.Append(')');
+                }
+            }
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(sb.ToString())));
+        }
+    }
+}

--- a/EGG9000.Common/Helpers/AfxSets/AfxSetsRender.cs
+++ b/EGG9000.Common/Helpers/AfxSets/AfxSetsRender.cs
@@ -9,7 +9,10 @@ using EGG9000.Common.Helpers;
 
 namespace EGG9000.Common.Helpers.AfxSets {
     // Sizing + layout config shared between the bot (sender) and site (renderer).
-    public class AfxSetsCreatorConfig {
+    public class AfxSetsCreatorConfig : IRenderConfig {
+        // Shared default so the bot's set-selection dropdown pages the same way the renderer does.
+        public const int DefaultSetsPerPage = 5;
+
         public int AFSize { get; set; }
         public int Padding { get; set; }
         public int StoneSize { get; set; }
@@ -28,8 +31,21 @@ namespace EGG9000.Common.Helpers.AfxSets {
             AFCornerRadius = afSize / 4;
             LabelWidth = (int)(afSize * 1.1);
             TextFontSize = afSize / 4;
-            SetsPerPage = 5;
+            SetsPerPage = DefaultSetsPerPage;
             SlotsPerRow = 4;
+        }
+
+        public bool IsValid(out string error) {
+            if(AFSize <= 0) { error = "AFSize must be > 0."; return false; }
+            if(Padding < 0) { error = "Padding must be >= 0."; return false; }
+            if(StoneSize <= 0) { error = "StoneSize must be > 0."; return false; }
+            if(AFCornerRadius < 0) { error = "AFCornerRadius must be >= 0."; return false; }
+            if(LabelWidth < 0) { error = "LabelWidth must be >= 0."; return false; }
+            if(TextFontSize <= 0) { error = "TextFontSize must be > 0."; return false; }
+            if(SetsPerPage <= 0) { error = "SetsPerPage must be > 0."; return false; }
+            if(SlotsPerRow <= 0) { error = "SlotsPerRow must be > 0."; return false; }
+            error = null;
+            return true;
         }
     }
 
@@ -63,8 +79,11 @@ namespace EGG9000.Common.Helpers.AfxSets {
             baseUrl = baseUrl.TrimEnd('/');
 
             // A locally-run Site uses a self-signed dev cert; accept it only when targeting localhost.
+            // Match on the parsed host (not a substring) so e.g. https://localhost.evil.com can't disable TLS.
             HttpClientHandler handler = null;
-            if(baseUrl.Contains("localhost", StringComparison.OrdinalIgnoreCase) || baseUrl.Contains("127.0.0.1")) {
+            var isLocalHost = Uri.TryCreate(baseUrl, UriKind.Absolute, out var parsedBase)
+                && (parsedBase.Host.Equals("localhost", StringComparison.OrdinalIgnoreCase) || parsedBase.Host == "127.0.0.1");
+            if(isLocalHost) {
                 handler = new HttpClientHandler {
                     ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
                 };

--- a/EGG9000.Common/Helpers/AfxSets/AfxSetsRender.cs
+++ b/EGG9000.Common/Helpers/AfxSets/AfxSetsRender.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
+
+namespace EGG9000.Common.Helpers.AfxSets {
+    // Sizing + layout config shared between the bot (sender) and site (renderer).
+    public class AfxSetsCreatorConfig {
+        public int AFSize { get; set; }
+        public int Padding { get; set; }
+        public int StoneSize { get; set; }
+        public int AFCornerRadius { get; set; }
+        public int LabelWidth { get; set; }
+        public int TextFontSize { get; set; }
+        public int SetsPerPage { get; set; }
+        public int SlotsPerRow { get; set; }
+
+        public AfxSetsCreatorConfig() { } // for JSON deserialization
+
+        public AfxSetsCreatorConfig(int afSize) {
+            AFSize = afSize;
+            Padding = afSize / 5;
+            StoneSize = (int)(afSize / 4.5);
+            AFCornerRadius = afSize / 4;
+            LabelWidth = (int)(afSize * 1.1);
+            TextFontSize = afSize / 4;
+            SetsPerPage = 5;
+            SlotsPerRow = 4;
+        }
+    }
+
+    public class AfxSetsAPIObject {
+        public string EID { get; set; }
+        public AfxSetsCreatorConfig Config { get; set; }
+    }
+
+    public class AfxSetsB64Response {
+        public List<string> Pages { get; set; } = new();
+    }
+
+    public static class AfxSetsRender {
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+        // Returns one base64 JPEG (no data: header) per page. On failure pages is null and error
+        // holds a short human-readable reason (also logged).
+        public static async Task<(List<string> pages, string error)> AfxSetsB64(EggIncAccount account) {
+            var posted = new AfxSetsAPIObject { EID = account.Id, Config = new AfxSetsCreatorConfig(100) };
+
+            // E9K_SITE_BASEURL overrides the target site (e.g. https://localhost:44314 when testing
+            // against a locally-run Site through Visual Studio).
+            var baseUrl = Environment.GetEnvironmentVariable("E9K_SITE_BASEURL");
+            if(string.IsNullOrWhiteSpace(baseUrl)) {
+#if RELEASE
+                baseUrl = "https://egg9000.com";
+#else
+                baseUrl = "https://egg9000.dev.sglade.com";
+#endif
+            }
+            baseUrl = baseUrl.TrimEnd('/');
+
+            // A locally-run Site uses a self-signed dev cert; accept it only when targeting localhost.
+            HttpClientHandler handler = null;
+            if(baseUrl.Contains("localhost", StringComparison.OrdinalIgnoreCase) || baseUrl.Contains("127.0.0.1")) {
+                handler = new HttpClientHandler {
+                    ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                };
+            }
+            using var client = handler is null ? new HttpClient() : new HttpClient(handler);
+            client.DefaultRequestHeaders.Add("authenticationKey", SecretsHelper.BotToken);
+
+            var apiUrl = $"{baseUrl}/api/generateafxsetsb64";
+            var content = new StringContent(JsonSerializer.Serialize(posted), Encoding.UTF8, "application/json");
+
+            _logger.Info($"AfxSetsB64: POST {apiUrl} for EID {account.Id}");
+
+            try {
+                var response = await client.PostAsync(apiUrl, content);
+                var json = await response.Content.ReadAsStringAsync();
+                if(!response.IsSuccessStatusCode) {
+                    var body = json.Length > 500 ? json[..500] : json;
+                    var err = $"HTTP {(int)response.StatusCode} {response.StatusCode} from {apiUrl}\n{body}";
+                    _logger.Warn($"AfxSetsB64: {err}");
+                    return (null, err);
+                }
+                var parsed = JsonSerializer.Deserialize<AfxSetsB64Response>(json, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                if(parsed?.Pages is null || parsed.Pages.Count == 0) {
+                    _logger.Warn("AfxSetsB64: response parsed but contained no pages.");
+                    return (null, $"Site returned no pages from {apiUrl}");
+                }
+                _logger.Info($"AfxSetsB64: got {parsed.Pages.Count} page(s) from {apiUrl}");
+                return (parsed.Pages, null);
+            } catch(Exception e) {
+                _logger.Error(e, $"AfxSetsB64: request to {apiUrl} threw");
+                return (null, $"{e.GetType().Name}: {e.Message} (target {apiUrl})");
+            }
+        }
+    }
+}

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -372,7 +372,7 @@ namespace EGG9000.Common.Helpers {
             return orderedList.Where(a => !a.Skip).Select(a => a.AF).ToList();
         }
 
-        public class InventoryCreatorConfig {
+        public class InventoryCreatorConfig : IRenderConfig {
             public int AFSize { get; set; } = 0;
             public int Padding { get; set; } = 0;
             public int StoneSize { get; set; } = 0;
@@ -404,6 +404,19 @@ namespace EGG9000.Common.Helpers {
 
                 TotalWidth = (Columns * AFSize) + (Padding * (Columns + 1));
                 TotalHeight = (Rows * AFSize) + (Padding * (Rows + 1));
+            }
+
+            public bool IsValid(out string error) {
+                if(AFSize <= 0) { error = "AFSize must be > 0."; return false; }
+                if(Padding < 0) { error = "Padding must be >= 0."; return false; }
+                if(StoneSize <= 0) { error = "StoneSize must be > 0."; return false; }
+                if(AFCornerRadius < 0) { error = "AFCornerRadius must be >= 0."; return false; }
+                if(TextHeight <= 0) { error = "TextHeight must be > 0."; return false; }
+                if(TextFontSize <= 0) { error = "TextFontSize must be > 0."; return false; }
+                if(Rows <= 0 || Columns <= 0) { error = "Rows and Columns must be > 0."; return false; }
+                if(TotalWidth <= 0 || TotalHeight <= 0) { error = "TotalWidth and TotalHeight must be > 0."; return false; }
+                error = null;
+                return true;
             }
         }
 

--- a/EGG9000.Common/Helpers/IRenderConfig.cs
+++ b/EGG9000.Common/Helpers/IRenderConfig.cs
@@ -1,0 +1,8 @@
+namespace EGG9000.Common.Helpers {
+    // Implemented by the image-render config objects posted to the Site's generate endpoints.
+    // Centralizes the "is this config safe to render with" check so controllers can validate
+    // uniformly instead of repeating ad-hoc field checks (and missing some, causing 500s).
+    public interface IRenderConfig {
+        bool IsValid(out string error);
+    }
+}

--- a/EGG9000.Site/Controllers/APIController.cs
+++ b/EGG9000.Site/Controllers/APIController.cs
@@ -124,7 +124,7 @@ namespace EGG9000.Site.Controllers {
         [Route("api/generateinventoryb64")]
         public async Task<IActionResult> GenerateInventoryB64([FromHeader] string authenticationKey, [FromBody] InventoryAPIObject userObject) {
 #if RELEASE
-             if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != DockerSecretsHelper.BotToken) return NotFound();
+             if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != SecretsHelper.BotToken) return NotFound();
 #endif
             var user = await _db.DBUsers.FirstOrDefaultAsync(u => u.EIDs.Contains(userObject.EID));
             if(user == null) {
@@ -136,6 +136,8 @@ namespace EGG9000.Site.Controllers {
             }
 
             var config = userObject.Config;
+            if(config is null) return BadRequest(new { message = "Config was null." });
+            if(!config.IsValid(out var configError)) return BadRequest(new { message = configError });
             var rows = config.Rows;
             var columns = config.Columns;
 
@@ -235,7 +237,7 @@ namespace EGG9000.Site.Controllers {
         [Route("api/generateafxsetsb64")]
         public async Task<IActionResult> GenerateAfxSetsB64([FromHeader] string authenticationKey, [FromBody] AfxSetsAPIObject userObject) {
 #if RELEASE
-             if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != DockerSecretsHelper.BotToken) return NotFound();
+             if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != SecretsHelper.BotToken) return NotFound();
 #endif
             if(userObject is null || string.IsNullOrWhiteSpace(userObject.EID) || userObject.Config is null) return BadRequest(new { message = "Invalid request body." });
 
@@ -248,9 +250,7 @@ namespace EGG9000.Site.Controllers {
             if(sets is null || sets.Count == 0) return BadRequest(new { message = "No artifact sets." });
 
             var config = userObject.Config;
-            if(config.SetsPerPage <= 0 || config.SlotsPerRow <= 0 || config.AFSize <= 0 || config.Padding < 0 || config.LabelWidth < 0 || config.TextFontSize <= 0) {
-                return BadRequest(new { message = "Invalid render config." });
-            }
+            if(!config.IsValid(out var configError)) return BadRequest(new { message = configError });
 
             var fontFilePath = GetWWWRelativePath(["Always Together.otf"]);
             if(fontFilePath == null) return BadRequest(new { message = "`Always Together.otf` could not be found." });

--- a/EGG9000.Site/Controllers/APIController.cs
+++ b/EGG9000.Site/Controllers/APIController.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using EGG9000.Common.Helpers;
+using EGG9000.Common.Helpers.AfxSets;
 using static EGG9000.Common.Helpers.ArtifactHelpers;
 
 namespace EGG9000.Site.Controllers {
@@ -230,6 +231,91 @@ namespace EGG9000.Site.Controllers {
             using var ms = new MemoryStream();
             baseImage.Save(ms, new JpegEncoder());
             return File(ms.ToArray(), "image/jpeg");
+        }
+
+        [HttpPost]
+        [Route("api/generateafxsetsb64")]
+        public async Task<IActionResult> GenerateAfxSetsB64([FromHeader] string authenticationKey, [FromBody] AfxSetsAPIObject userObject) {
+            var user = await _db.DBUsers.FirstOrDefaultAsync(u => u.EIDs.Contains(userObject.EID));
+            if(user == null) return BadRequest(new { message = $"User with EID {userObject.EID} was not found." });
+            var account = user.EggIncAccounts.FirstOrDefault(a => a.Id == userObject.EID);
+            if(account == null) return BadRequest(new { message = $"Account with EID {userObject.EID} was not found." });
+
+            var sets = account.Backup?.ArtifactSets;
+            if(sets is null || sets.Count == 0) return BadRequest(new { message = "No artifact sets." });
+
+            var config = userObject.Config;
+            var fontFilePath = GetWWWRelativePath(["Always Together.otf"]);
+            if(fontFilePath == null) return BadRequest(new { message = "`Always Together.otf` could not be found." });
+            var font = new FontCollection().Add(fontFilePath).CreateFont(config.TextFontSize, FontStyle.Bold);
+
+            var pages = new List<string>();
+            for(var pageStart = 0; pageStart < sets.Count; pageStart += config.SetsPerPage) {
+                var pageSets = sets.Skip(pageStart).Take(config.SetsPerPage).ToList();
+                var rowCount = pageSets.Count;
+
+                var width = config.LabelWidth + (config.SlotsPerRow * config.AFSize) + (config.Padding * (config.SlotsPerRow + 1));
+                var height = (rowCount * config.AFSize) + (config.Padding * (rowCount + 1));
+                var pageImage = new Image<Rgba32>(width, height);
+                pageImage.Mutate(x => x.Fill(Color.ParseHex("#242422")));
+
+                for(var r = 0; r < rowCount; r++) {
+                    var set = pageSets[r];
+                    var rowY = config.Padding + r * (config.AFSize + config.Padding);
+
+                    // "Set N" label (global index, 1-based)
+                    var label = $"Set {pageStart + r + 1}";
+                    pageImage.Mutate(x => x.DrawText(label, font, Color.White, new PointF(config.Padding, rowY + config.AFSize / 2f - config.TextFontSize / 2f)));
+
+                    if(set.Count == 0) {
+                        pageImage.Mutate(x => x.DrawText("(empty)", font, Color.ParseHex("#8a8a86"), new PointF(config.LabelWidth + config.Padding, rowY + config.AFSize / 2f - config.TextFontSize / 2f)));
+                        continue;
+                    }
+
+                    for(var c = 0; c < set.Count && c < config.SlotsPerRow; c++) {
+                        var inst = set[c];
+                        var cellX = config.LabelWidth + config.Padding * (c + 1) + c * config.AFSize;
+
+                        var isFrag = inst.Artifact.ToString().ToUpper().Contains("FRAGMENT");
+                        var afName = inst.Artifact.ToString().ToUpper().Replace(" ", "_").Replace("'", "").Replace("_FRAGMENT", "");
+                        var afTier = isFrag ? 1 : (afName.Contains("_STONE") ? inst.Tier + 1 : inst.Tier);
+
+                        var bg = inst.Rarity switch {
+                            1 => Color.ParseHex("#383834"),
+                            2 => Color.ParseHex("#6cb6d9"),
+                            3 => Color.ParseHex("#b72de0"),
+                            4 => Color.ParseHex("#f2d61b"),
+                            _ => Color.ParseHex("#383834")
+                        };
+
+                        var afImagePath = GetWWWRelativePath(["images/artifacts", afName, $"{afName}_{afTier}.png"]);
+                        if(afImagePath == null) continue;
+                        var afImage = Image.Load(afImagePath);
+                        afImage.Mutate(i => i.Resize(new Size(config.AFSize, config.AFSize)));
+
+                        var background = BackgroundImage(bg, config.AFSize, config.AFCornerRadius);
+                        background.Mutate(i => i.DrawImage(afImage, new Point(0, 0), 1f));
+                        pageImage.Mutate(b => b.DrawImage(background, new Point(cellX, rowY), 1f));
+
+                        var stoneIndex = 1;
+                        foreach(var stone in inst.Stones ?? new()) {
+                            var stoneName = stone.Artifact.ToString().ToUpper().Replace(" ", "_");
+                            var stonePath = GetWWWRelativePath(["images/artifacts", stoneName, $"{stoneName}_{stone.Tier + 1}.png"]);
+                            if(stonePath == null) continue;
+                            var stoneImage = Image.Load(stonePath);
+                            stoneImage.Mutate(i => i.Resize(new Size(config.StoneSize, config.StoneSize), true));
+                            pageImage.Mutate(b => b.DrawImage(stoneImage, new Point(cellX + config.AFSize - (int)(config.Padding * 0.5) - (config.StoneSize * stoneIndex), rowY + config.AFSize - (int)(config.Padding * 1.5)), 1f));
+                            stoneIndex++;
+                        }
+                    }
+                }
+
+                using var ms = new MemoryStream();
+                pageImage.Save(ms, new JpegEncoder());
+                pages.Add(Convert.ToBase64String(ms.ToArray()));
+            }
+
+            return Ok(new AfxSetsB64Response { Pages = pages });
         }
     }
 }

--- a/EGG9000.Site/Controllers/APIController.cs
+++ b/EGG9000.Site/Controllers/APIController.cs
@@ -124,9 +124,7 @@ namespace EGG9000.Site.Controllers {
         [Route("api/generateinventoryb64")]
         public async Task<IActionResult> GenerateInventoryB64([FromHeader] string authenticationKey, [FromBody] InventoryAPIObject userObject) {
 #if RELEASE
-            //if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != DockerSecretsHelper.BotToken) {
-            //    return NotFound();
-            //}
+             if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != DockerSecretsHelper.BotToken) return NotFound();
 #endif
             var user = await _db.DBUsers.FirstOrDefaultAsync(u => u.EIDs.Contains(userObject.EID));
             if(user == null) {
@@ -175,7 +173,7 @@ namespace EGG9000.Site.Controllers {
                     $"{afName}_{afTier}.png"
                 ]);
                 if(afImagePath == null) continue;
-                var afImage = Image.Load(afImagePath);
+                using var afImage = Image.Load(afImagePath);
 
                 afImage.Mutate(i => { i.Resize(new Size(config.AFSize, config.AFSize)); });
 
@@ -210,7 +208,7 @@ namespace EGG9000.Site.Controllers {
                     textImage.Mutate(x => x.DrawText(text, font, Color.White, textPosition));
                 }
 
-                var backgroundImage = BackgroundImage(backgroundColor, config.AFSize, config.AFCornerRadius);
+                using var backgroundImage = BackgroundImage(backgroundColor, config.AFSize, config.AFCornerRadius);
                 backgroundImage.Mutate(i => { i.DrawImage(afImage, new Point(0, 0), 1f); });
 
                 baseImage.Mutate(b => { b.DrawImage(backgroundImage, new Point(x, y), 1f); });
@@ -236,6 +234,11 @@ namespace EGG9000.Site.Controllers {
         [HttpPost]
         [Route("api/generateafxsetsb64")]
         public async Task<IActionResult> GenerateAfxSetsB64([FromHeader] string authenticationKey, [FromBody] AfxSetsAPIObject userObject) {
+#if RELEASE
+             if(string.IsNullOrEmpty(authenticationKey) || authenticationKey != DockerSecretsHelper.BotToken) return NotFound();
+#endif
+            if(userObject is null || string.IsNullOrWhiteSpace(userObject.EID) || userObject.Config is null) return BadRequest(new { message = "Invalid request body." });
+
             var user = await _db.DBUsers.FirstOrDefaultAsync(u => u.EIDs.Contains(userObject.EID));
             if(user == null) return BadRequest(new { message = $"User with EID {userObject.EID} was not found." });
             var account = user.EggIncAccounts.FirstOrDefault(a => a.Id == userObject.EID);
@@ -245,6 +248,10 @@ namespace EGG9000.Site.Controllers {
             if(sets is null || sets.Count == 0) return BadRequest(new { message = "No artifact sets." });
 
             var config = userObject.Config;
+            if(config.SetsPerPage <= 0 || config.SlotsPerRow <= 0 || config.AFSize <= 0 || config.Padding < 0 || config.LabelWidth < 0 || config.TextFontSize <= 0) {
+                return BadRequest(new { message = "Invalid render config." });
+            }
+
             var fontFilePath = GetWWWRelativePath(["Always Together.otf"]);
             if(fontFilePath == null) return BadRequest(new { message = "`Always Together.otf` could not be found." });
             var font = new FontCollection().Add(fontFilePath).CreateFont(config.TextFontSize, FontStyle.Bold);
@@ -256,7 +263,7 @@ namespace EGG9000.Site.Controllers {
 
                 var width = config.LabelWidth + (config.SlotsPerRow * config.AFSize) + (config.Padding * (config.SlotsPerRow + 1));
                 var height = (rowCount * config.AFSize) + (config.Padding * (rowCount + 1));
-                var pageImage = new Image<Rgba32>(width, height);
+                using var pageImage = new Image<Rgba32>(width, height);
                 pageImage.Mutate(x => x.Fill(Color.ParseHex("#242422")));
 
                 for(var r = 0; r < rowCount; r++) {
@@ -276,7 +283,7 @@ namespace EGG9000.Site.Controllers {
                         var inst = set[c];
                         var cellX = config.LabelWidth + config.Padding * (c + 1) + c * config.AFSize;
 
-                        var isFrag = inst.Artifact.ToString().ToUpper().Contains("FRAGMENT");
+                        var isFrag = inst.Artifact.ToString().Contains("FRAGMENT", StringComparison.CurrentCultureIgnoreCase);
                         var afName = inst.Artifact.ToString().ToUpper().Replace(" ", "_").Replace("'", "").Replace("_FRAGMENT", "");
                         var afTier = isFrag ? 1 : (afName.Contains("_STONE") ? inst.Tier + 1 : inst.Tier);
 
@@ -290,10 +297,10 @@ namespace EGG9000.Site.Controllers {
 
                         var afImagePath = GetWWWRelativePath(["images/artifacts", afName, $"{afName}_{afTier}.png"]);
                         if(afImagePath == null) continue;
-                        var afImage = Image.Load(afImagePath);
+                        using var afImage = Image.Load(afImagePath);
                         afImage.Mutate(i => i.Resize(new Size(config.AFSize, config.AFSize)));
 
-                        var background = BackgroundImage(bg, config.AFSize, config.AFCornerRadius);
+                        using var background = BackgroundImage(bg, config.AFSize, config.AFCornerRadius);
                         background.Mutate(i => i.DrawImage(afImage, new Point(0, 0), 1f));
                         pageImage.Mutate(b => b.DrawImage(background, new Point(cellX, rowY), 1f));
 
@@ -302,7 +309,7 @@ namespace EGG9000.Site.Controllers {
                             var stoneName = stone.Artifact.ToString().ToUpper().Replace(" ", "_");
                             var stonePath = GetWWWRelativePath(["images/artifacts", stoneName, $"{stoneName}_{stone.Tier + 1}.png"]);
                             if(stonePath == null) continue;
-                            var stoneImage = Image.Load(stonePath);
+                            using var stoneImage = Image.Load(stonePath);
                             stoneImage.Mutate(i => i.Resize(new Size(config.StoneSize, config.StoneSize), true));
                             pageImage.Mutate(b => b.DrawImage(stoneImage, new Point(cellX + config.AFSize - (int)(config.Padding * 0.5) - (config.StoneSize * stoneIndex), rowY + config.AFSize - (int)(config.Padding * 1.5)), 1f));
                             stoneIndex++;


### PR DESCRIPTION
Dependent on #252
Similar to our `/ViewInventory` implementation, this overhauls the `/SavedAfSets` command to dynamically generate images on command run, and uses pagination and dropdowns to navigate.

<img width="625" height="859" alt="image" src="https://github.com/user-attachments/assets/d1c87e95-2ada-4f95-9d78-82f12e67b25e" />
<img width="530" height="667" alt="image" src="https://github.com/user-attachments/assets/4d0c63ad-e229-43d9-a311-ae8f430962ea" />

Bot keeps a cache of these images locally after upload to avoid bleed.