### PR TITLE
Fix: Docker Build (Size, Time, etc.) + Site Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,75 +1,53 @@
-.bash_history
-.cache
-.cargo
-.composer
-.hsperfdata
-.idea
-.npm
-.nuget
-.pytest_cache
-.Rhistory
-.Rproj.user
-.rproj.data
-.sass-cache
-_sass
+# Build output - the main culprit for large contexts
+**/bin/
+**/obj/
 
-# Build output and VCS (huge context bloat if not excluded)
-**/bin
-**/obj
-.git
+# Publish artifacts
+artifacts/
+
+# Git
+.git/
 .gitignore
 
-# Logs
-logs
-*.log
-
-# Docker
+# Docker files (not needed inside image)
 Dockerfile*
 docker-compose*
 .dockerignore
 
-# Node
-node_modules
-npm-debug.log
-
-# Visual Studio
-.vs
-.vscode
-artifacts/
-.gitignore
-**/bin/
-**/obj/
+# Visual Studio / Rider
+.vs/
+.vscode/
+.idea/
 *.suo
 *.user
 *.userprefs
 *.sln.iml
 
-# Rider
-.idea
-*.sln.iml
+# Logs
+logs/
+*.log
 
-# misc
+# Node
+node_modules/
+npm-debug.log
+
+# OS
 .DS_Store
+.bash_history
+
+# Secrets / certs (never send to Docker daemon)
 *.pem
 *.pfx
 *.pub
+secrets.json
+
+# Misc generated
 *.cache
 *.out
-*.dll
-*.exe
-*.so
-*.dylib
-*.a
-*.o
-*.target.xml
-*.svcmap
-*.pdb
-*_i.c
-*_p.c
-*_h.c
-*.ilk
-*.log
 *.lock.json
-*.suo
-*.user
-*.userprefs
+*.pdb
+*.ilk
+_sass/
+.sass-cache/
+.nuget/
+.npm/

--- a/EGG9000.Site/Dockerfile
+++ b/EGG9000.Site/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build for ASP.NET Core 9 web application
+# Multi-stage build for ASP.NET Core 10 web application
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 EXPOSE 8080
@@ -8,9 +8,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user for security
-RUN useradd --create-home appuser && chown -R appuser:appuser /app
-USER appuser
+USER app
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release

--- a/EGG9000.Site/Properties/launchSettings.json
+++ b/EGG9000.Site/Properties/launchSettings.json
@@ -21,6 +21,19 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPNETCORE_HTTP_PORTS": "5013",
+        "Docker__Host": "npipe://./pipe/docker_engine"
+      },
+      "publishAllPorts": true,
+      "useSSL": false
     }
   }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,80 @@
+# docker-compose.dev.yml
+# Explicit dev stack. Single instance of each service, no blue/green.
+# Usage: docker-compose -f docker-compose.dev.yml up
+# Requires: ${APPDATA}/Microsoft/UserSecrets/{id}/secrets.json populated with credentials.
+
+services:
+  bot:
+    image: kendrome/egg9000bot:latest
+    build:
+      context: .
+      dockerfile: EGG9000.Bot/Dockerfile
+      args:
+        BUILD_CONFIGURATION: Debug
+    restart: on-failure
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Development
+      BOT_ACTIVE: "true"
+      BOT_COLOR: blue
+      ConnectionStrings__RabbitMQServer: rabbitmq|e9k|devpassword
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+    networks:
+      - egg9000_dev_network
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+
+  site:
+    image: kendrome/egg9000site:latest
+    build:
+      context: .
+      dockerfile: EGG9000.Site/Dockerfile
+      args:
+        BUILD_CONFIGURATION: Debug
+    restart: on-failure
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_HTTP_PORTS: "5013"
+      ConnectionStrings__RabbitMQServer: rabbitmq|e9k|devpassword
+      Docker__Host: npipe://./pipe/docker_engine
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+      - //./pipe/docker_engine://./pipe/docker_engine
+    ports:
+      - "5013:5013"
+    networks:
+      - egg9000_dev_network
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5013/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
+
+  rabbitmq:
+    image: rabbitmq:3.12-management
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: e9k
+      RABBITMQ_DEFAULT_PASS: devpassword
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - egg9000_dev_network
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+networks:
+  egg9000_dev_network:
+    driver: bridge

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,34 @@
+# docker-compose.override.yml
+# Auto-loaded by docker-compose and Visual Studio Container Orchestration.
+# Sets development environment and mounts user secrets for local development.
+# DO NOT commit secrets or real credentials here.
+
+services:
+  bot_blue:
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Development
+      BOT_ACTIVE: "true"
+      BOT_COLOR: blue
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+
+  bot_green:
+    restart: "no"
+
+  site_blue:
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_HTTP_PORTS: "5013"
+      Docker__Host: npipe://./pipe/docker_engine
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+
+  rabbitmq:
+    environment:
+      RABBITMQ_DEFAULT_USER: e9k
+      RABBITMQ_DEFAULT_PASS: devpassword
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       BOT_COLOR: blue
       # App will read from /run/secrets/ via DockerSecretsHelper
     volumes:
-      # Mount host user-secrets store (DEV9002 config maps UserSecretsId to "DEV9001") read-only
-      # so AddUserSecrets<Program> resolves it inside the container (runs as built-in 'app' user)
+      # If you are not on Windows, adjust the path to your user secrets store accordingly
+      # (If you get "no default credentials found" errors, check this)
       - ${APPDATA}/Microsoft/UserSecrets/DEV9001:/home/app/.microsoft/usersecrets/DEV9001:ro
     networks:
       - egg9000_network
@@ -43,6 +43,8 @@ services:
       BOT_ACTIVE: "false"
       BOT_COLOR: green
     volumes:
+      # If you are not on Windows, adjust the path to your user secrets store accordingly
+      # (If you get "no default credentials found" errors, check this)
       - ${APPDATA}/Microsoft/UserSecrets/DEV9001:/home/app/.microsoft/usersecrets/DEV9001:ro
     networks:
       - egg9000_network

--- a/publish-docker.ps1
+++ b/publish-docker.ps1
@@ -1,20 +1,70 @@
-# Build and push EGG9000.Site to Docker Hub
+# Build EGG9000.Bot and EGG9000.Site Docker images.
+#
+# Default - build both images locally:
+#   .\publish-docker.ps1
+#
+# Build only one image:
+#   .\publish-docker.ps1 -Bot
+#   .\publish-docker.ps1 -Site
+#
+# Push to Docker Hub (requires Docker Hub login):
+#   .\publish-docker.ps1 -Push
+#   .\publish-docker.ps1 -Bot -Push
+#
+# Stream to a remote host without a registry:
+#   .\publish-docker.ps1 -RemoteHost 192.168.1.66 -RemoteUser david
+
+param(
+    [switch]$Bot,
+    [switch]$Site,
+    [switch]$Push,
+    [string]$RemoteHost = "",
+    [string]$RemoteUser = "root"
+)
+
+# If neither -Bot nor -Site is specified, build both.
+if (-not $Bot -and -not $Site) {
+    $Bot = $true
+    $Site = $true
+}
+
 $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
-$imageName = "kendrome/egg9000site"
-$imageTag = "${imageName}:${timestamp}"
-$imageLatest = "${imageName}:latest"
 
-Write-Host "Building image: $imageTag" -ForegroundColor Green
+function Publish-Image([string]$name) {
+    $tag = "${name}:${timestamp}"
+    $latest = "${name}:latest"
+    if ($RemoteHost -ne "") {
+        Write-Host "Streaming $latest to $RemoteUser@$RemoteHost ..." -ForegroundColor Cyan
+        docker save $latest | ssh "${RemoteUser}@${RemoteHost}" "docker load"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Transfer failed: $latest" -ForegroundColor Red
+            exit 1
+        }
+        Write-Host "Deployed: $latest -> $RemoteUser@$RemoteHost" -ForegroundColor Green
+    } elseif ($Push) {
+        Write-Host "Pushing $latest to Docker Hub ..." -ForegroundColor Cyan
+        docker push $tag
+        docker push $latest
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "Push failed: $latest" -ForegroundColor Red
+            exit 1
+        }
+        Write-Host "Pushed: $tag" -ForegroundColor Green
+    }
+}
 
-# Build from solution root
-docker build -f EGG9000.Site/Dockerfile -t $imageTag -t $imageLatest .
+if ($Bot) {
+    Write-Host "Building kendrome/egg9000bot:latest ..." -ForegroundColor Cyan
+    docker build -f EGG9000.Bot/Dockerfile -t "kendrome/egg9000bot:$timestamp" -t "kendrome/egg9000bot:latest" .
+    if ($LASTEXITCODE -ne 0) { Write-Host "Build failed: egg9000bot" -ForegroundColor Red; exit 1 }
+    Write-Host "Built: kendrome/egg9000bot:latest" -ForegroundColor Green
+    Publish-Image "kendrome/egg9000bot"
+}
 
-if ($LASTEXITCODE -eq 0) {
-    Write-Host "Pushing to Docker Hub..." -ForegroundColor Green
-    docker push $imageTag
-    docker push $imageLatest
-    Write-Host "Published: $imageTag" -ForegroundColor Green
-} else {
-    Write-Host "Build failed!" -ForegroundColor Red
-    exit 1
+if ($Site) {
+    Write-Host "Building kendrome/egg9000site:latest ..." -ForegroundColor Cyan
+    docker build -f EGG9000.Site/Dockerfile -t "kendrome/egg9000site:$timestamp" -t "kendrome/egg9000site:latest" .
+    if ($LASTEXITCODE -ne 0) { Write-Host "Build failed: egg9000site" -ForegroundColor Red; exit 1 }
+    Write-Host "Built: kendrome/egg9000site:latest" -ForegroundColor Green
+    Publish-Image "kendrome/egg9000site"
 }


### PR DESCRIPTION
Fixes the dockerignore so we're not packaging more than we need to in the deployed package, and adds a Dockerfile for the Site target to run.