### PR TITLE
Hotfix: Logger Reg

### DIFF
--- a/EGG9000.Bot/Program.cs
+++ b/EGG9000.Bot/Program.cs
@@ -148,6 +148,7 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
         services.AddSingleton<CoopAssignmentLookup>();
         services.AddHostedService<CoopAssignmentLookupRefreshService>();
         services.AddSingleton<Words>();
+        services.AddSingleton<BotLogger>();
 
 #if RELEASE
         var release = true;
@@ -185,9 +186,6 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
                 options.AppVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                 options.ReleaseStage = "production";
             });
-
-            services.AddSingleton<BotLogger>();
-
 
             var rabbitmqConn = SecretsHelper.GetConfigOrSecret(
                 hostContext.Configuration,


### PR DESCRIPTION
I did this in a previous PR, but it got reverted, somehow. The logger needs to be registered for all envs, else this crashes when we run the Dockerfile.