### PR TITLE
Chore: Mark EF Migration as Generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-File: .gitattributes
-````````
 ###############################################################################
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
@@ -70,3 +68,11 @@ File: .gitattributes
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# EF Core migration scaffolding is machine-generated. Mark it generated so it
+# is collapsed in diffs/PR reviews and excluded from language stats. The
+# hand-written migration bodies (Up/Down) are NOT marked and review normally.
+###############################################################################
+**/Migrations/*.Designer.cs linguist-generated=true
+**/Migrations/*ModelSnapshot.cs linguist-generated=true


### PR DESCRIPTION
Adds linguist-generated for migration *.Designer.cs and ModelSnapshot so GitHub collapses them in diffs/PR review
Also strips two stray junk lines from .gitattributes.