### PR TITLE
Fix: API Version Bumps + Future Guarding

### DIFF
--- a/EGG9000.Bot/Automated/UpdateBackups.cs
+++ b/EGG9000.Bot/Automated/UpdateBackups.cs
@@ -46,13 +46,14 @@ namespace EGG9000.Bot.Automated {
             var throttler = new SemaphoreSlim(8);
 
             var tasks = new List<Task>();
+            var discoveredContractDefs = new System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract>();
 
             foreach(var user in usersToCheck) {
                 await throttler.WaitAsync(cancellationToken);
                 tasks.Add(Task.Run(async () => {
                     _logger.LogTrace($"Updating {user.DiscordUsername}");
                     try {
-                        await UpdateUser(user, guilds, cachedContracts);
+                        await UpdateUser(user, guilds, cachedContracts, discoveredContractDefs);
                     } catch(Exception ex) {
                         _logger.LogError(ex, $"Error updating user {user.DiscordUsername} {user.Id}");
                     } finally {
@@ -65,12 +66,16 @@ namespace EGG9000.Bot.Automated {
             times.Set("Updated Backups");
             await _db.SaveChangesAsync(cancellationToken);
 
+            var registered = await _db.RegisterMissingContractsAsync(discoveredContractDefs.Values, cancellationToken);
+            if(registered > 0)
+                _logger.LogInformation("Self-healed {count} contract(s) missing from the DB from player backups", registered);
+
             await ShipReturnDM.UpdateNextShipDM(usersToCheck, _db);
             var finished = times.Finished();
             _logger.LogInformation($"Updated {usersToCheck.Count} user backups. in {finished.Last().time.Humanize(precision: 2)}");
         }
 
-        public async Task UpdateUser(DBUser user, List<Guild> guilds, FrozenSet<Ei.Contract> cachedContracts) {
+        public async Task UpdateUser(DBUser user, List<Guild> guilds, FrozenSet<Ei.Contract> cachedContracts, System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract> discoveredContractDefs) {
             var update = false;
             foreach(var account in user.EggIncAccounts) {
                 var firstContact = await EggIncApi.FirstContact(account.Id);
@@ -78,6 +83,14 @@ namespace EGG9000.Bot.Automated {
 
                 if(dbGuild is null)
                     continue;
+
+                if(firstContact?.Backup?.Contracts is not null) {
+                    foreach(var lc in firstContact.Backup.Contracts.Contracts.Concat(firstContact.Backup.Contracts.Archive)) {
+                        if(lc.Contract is not null && !string.IsNullOrEmpty(lc.Contract.Identifier))
+                            discoveredContractDefs.TryAdd(lc.Contract.Identifier, lc.Contract);
+                    }
+                }
+
                 var oldLevel = account.SubscriptionLevel;
                 var backup = new CustomBackup(firstContact.Backup, cachedContracts);
 

--- a/EGG9000.Bot/Automated/UpdateBackups.cs
+++ b/EGG9000.Bot/Automated/UpdateBackups.cs
@@ -47,13 +47,14 @@ namespace EGG9000.Bot.Automated {
 
             var tasks = new List<Task>();
             var discoveredContractDefs = new System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract>();
+            var knownContractIds = cachedContracts.Select(c => c.Identifier).ToHashSet();
 
             foreach(var user in usersToCheck) {
                 await throttler.WaitAsync(cancellationToken);
                 tasks.Add(Task.Run(async () => {
                     _logger.LogTrace($"Updating {user.DiscordUsername}");
                     try {
-                        await UpdateUser(user, guilds, cachedContracts, discoveredContractDefs);
+                        await UpdateUser(user, guilds, cachedContracts, knownContractIds, discoveredContractDefs);
                     } catch(Exception ex) {
                         _logger.LogError(ex, $"Error updating user {user.DiscordUsername} {user.Id}");
                     } finally {
@@ -75,7 +76,46 @@ namespace EGG9000.Bot.Automated {
             _logger.LogInformation($"Updated {usersToCheck.Count} user backups. in {finished.Last().time.Humanize(precision: 2)}");
         }
 
-        public async Task UpdateUser(DBUser user, List<Guild> guilds, FrozenSet<Ei.Contract> cachedContracts, System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract> discoveredContractDefs) {
+        // Contract identifiers the server has explicitly reported as not-found, so we stop re-fetching
+        // them every cycle. Lives for the process lifetime; only populated from authoritative not_found
+        // responses (never from transient network failures).
+        private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> _notFoundContractIds = new();
+
+        // Some contracts (e.g. single-player ones) are never delivered to our reference account through
+        // get_periodicals, so NewContracts never absorbs them. For every contract a player references
+        // (active or archived) that we have no definition for, fetch it by identifier and stage it for
+        // registration. This is the same id set CustomBackup.AddContracts would otherwise skip.
+        private static async Task DiscoverUnknownContracts(string eggIncId, Ei.Backup backup, HashSet<string> knownContractIds, System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract> discoveredContractDefs) {
+            if(backup?.Contracts is null)
+                return;
+
+            var missing = backup.Contracts.Contracts.Concat(backup.Contracts.Archive)
+                .Where(x => x is not null)
+                .Select(x => x.ContractIdentifier)
+                .Where(id => !string.IsNullOrEmpty(id)
+                    && !knownContractIds.Contains(id)
+                    && !discoveredContractDefs.ContainsKey(id)
+                    && !_notFoundContractIds.ContainsKey(id))
+                .Distinct()
+                .ToArray();
+
+            if(missing.Length == 0)
+                return;
+
+            foreach(var chunk in missing.Chunk(50)) {
+                var info = await EggIncApi.GetContractsInfoAsync(eggIncId, chunk);
+                if(info is null)
+                    continue;
+                foreach(var def in info.Contracts) {
+                    if(!string.IsNullOrEmpty(def.Identifier))
+                        discoveredContractDefs.TryAdd(def.Identifier, def);
+                }
+                foreach(var notFound in info.NotFound)
+                    _notFoundContractIds.TryAdd(notFound, 0);
+            }
+        }
+
+        public async Task UpdateUser(DBUser user, List<Guild> guilds, FrozenSet<Ei.Contract> cachedContracts, HashSet<string> knownContractIds, System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract> discoveredContractDefs) {
             var update = false;
             foreach(var account in user.EggIncAccounts) {
                 var firstContact = await EggIncApi.FirstContact(account.Id);
@@ -84,12 +124,7 @@ namespace EGG9000.Bot.Automated {
                 if(dbGuild is null)
                     continue;
 
-                if(firstContact?.Backup?.Contracts is not null) {
-                    foreach(var lc in firstContact.Backup.Contracts.Contracts.Concat(firstContact.Backup.Contracts.Archive)) {
-                        if(lc.Contract is not null && !string.IsNullOrEmpty(lc.Contract.Identifier))
-                            discoveredContractDefs.TryAdd(lc.Contract.Identifier, lc.Contract);
-                    }
-                }
+                await DiscoverUnknownContracts(account.Id, firstContact?.Backup, knownContractIds, discoveredContractDefs);
 
                 var oldLevel = account.SubscriptionLevel;
                 var backup = new CustomBackup(firstContact.Backup, cachedContracts);

--- a/EGG9000.Bot/Commands/ApiVersionCommands.cs
+++ b/EGG9000.Bot/Commands/ApiVersionCommands.cs
@@ -1,0 +1,55 @@
+using EGG9000.Common.Commands;
+using EGG9000.Common.Consumers;
+using EGG9000.Common.EggIncAPI;
+using EGG9000.Common.Services;
+
+using MassTransit;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using System;
+using System.Threading.Tasks;
+
+using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
+
+namespace EGG9000.Bot.Commands {
+    public static class ApiVersionCommands {
+
+        [SlashCommand(Description = "Update the Egg Inc API version triple at runtime (validated against the live API first).", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "a")]
+        public static async Task SetVersions(
+            FauxCommand command,
+            IServiceProvider provider,
+            [SlashParam(Description = "Numeric client version (e.g. 72)")] int clientVersion,
+            [SlashParam(Description = "App version string (e.g. 1.35.6)")] string appVersion,
+            [SlashParam(Description = "App build string (e.g. 1.35.6.3)")] string appBuild) {
+
+            await command.DeferAsync(ephemeral: true);
+
+            if(clientVersion <= 0 || string.IsNullOrWhiteSpace(appVersion) || string.IsNullOrWhiteSpace(appBuild)) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("clientVersion must be positive and appVersion/appBuild must be non-empty."); });
+                return;
+            }
+
+            var valid = await EggIncApi.ValidateVersionsAsync((uint)clientVersion, appVersion, appBuild);
+            if(!valid) {
+                await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Rejected `{clientVersion} / {appVersion} / {appBuild}`: the API returned no contracts (bad/stale/typo'd version, or a transient failure). Nothing changed."); });
+                return;
+            }
+
+            var oldTriple = $"{EggIncApi.ClientVersion} / {EggIncApi.AppVersion} / {EggIncApi.AppBuild}";
+            EggIncApi.SetVersions((uint)clientVersion, appVersion, appBuild);
+
+            var publisher = provider.GetService<IPublishEndpoint>();
+            var scope = "this instance only (broadcast unavailable)";
+            if(publisher is not null) {
+                await publisher.Publish(new UpdateApiVersionsMessage { ClientVersion = (uint)clientVersion, AppVersion = appVersion, AppBuild = appBuild });
+                scope = "all running instances";
+            }
+
+            await command.ModifyOriginalResponseAsync(x => {
+                x.Content = "";
+                x.Embed = EmbedSuccess($"API versions updated and applied to {scope}.\n**Old:** `{oldTriple}`\n**New:** `{clientVersion} / {appVersion} / {appBuild}`");
+            });
+        }
+    }
+}

--- a/EGG9000.Bot/Program.cs
+++ b/EGG9000.Bot/Program.cs
@@ -204,6 +204,9 @@ void ConfigureServices(HostBuilderContext hostContext, IServiceCollection servic
                 x.AddConsumer<ShutdownConsumer>();
                 x.AddConsumer<ExpireCacheConsumer>();
                 x.AddConsumer<RestartConsumer>();
+                // Per-instance temporary queue so a version update fans out to every running process
+                // instead of being load-balanced across a shared queue.
+                x.AddConsumer<UpdateApiVersionsConsumer>().Endpoint(e => { e.InstanceId = Guid.NewGuid().ToString("N"); e.Temporary = true; });
                 if(string.IsNullOrEmpty(rabbitmqConn)) {
                     logger.Log(NLog.LogLevel.Info, "Using RabbitMQ In Memory");
                     x.UsingInMemory((context, cfg) => {

--- a/EGG9000.Common.Test/ApiVersionTests.cs
+++ b/EGG9000.Common.Test/ApiVersionTests.cs
@@ -1,0 +1,41 @@
+using EGG9000.Common.EggIncAPI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Common.Test {
+    [TestClass]
+    public class ApiVersionTests {
+
+        [TestMethod]
+        public void IsValidPeriodicalsResponse_NullResponse_False() {
+            Assert.IsFalse(EggIncApi.IsValidPeriodicalsResponse(null));
+        }
+
+        [TestMethod]
+        public void IsValidPeriodicalsResponse_NoContracts_False() {
+            var resp = new Ei.PeriodicalsResponse { Contracts = new Ei.ContractsResponse() };
+            Assert.IsFalse(EggIncApi.IsValidPeriodicalsResponse(resp));
+        }
+
+        [TestMethod]
+        public void IsValidPeriodicalsResponse_HasContract_True() {
+            var resp = new Ei.PeriodicalsResponse { Contracts = new Ei.ContractsResponse() };
+            resp.Contracts.Contracts.Add(new Ei.Contract { Identifier = "space-stock-2026" });
+            Assert.IsTrue(EggIncApi.IsValidPeriodicalsResponse(resp));
+        }
+
+        [TestMethod]
+        public void SetVersions_UpdatesAllThree() {
+            var oldClient = EggIncApi.ClientVersion;
+            var oldVersion = EggIncApi.AppVersion;
+            var oldBuild = EggIncApi.AppBuild;
+            try {
+                EggIncApi.SetVersions(999, "9.9.9", "9.9.9.9");
+                Assert.AreEqual(999u, EggIncApi.ClientVersion);
+                Assert.AreEqual("9.9.9", EggIncApi.AppVersion);
+                Assert.AreEqual("9.9.9.9", EggIncApi.AppBuild);
+            } finally {
+                EggIncApi.SetVersions(oldClient, oldVersion, oldBuild);
+            }
+        }
+    }
+}

--- a/EGG9000.Common/Consumers/UpdateApiVersionsConsumer.cs
+++ b/EGG9000.Common/Consumers/UpdateApiVersionsConsumer.cs
@@ -1,0 +1,26 @@
+using EGG9000.Common.EggIncAPI;
+
+using MassTransit;
+
+using Microsoft.Extensions.Logging;
+
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Consumers {
+    public class UpdateApiVersionsConsumer(ILogger<UpdateApiVersionsConsumer> logger) : IConsumer<UpdateApiVersionsMessage> {
+        private readonly ILogger<UpdateApiVersionsConsumer> _logger = logger;
+
+        public Task Consume(ConsumeContext<UpdateApiVersionsMessage> context) {
+            var m = context.Message;
+            EggIncApi.SetVersions(m.ClientVersion, m.AppVersion, m.AppBuild);
+            _logger.LogInformation("[ApiVersions] Applied client={client} version={version} build={build}", m.ClientVersion, m.AppVersion, m.AppBuild);
+            return Task.CompletedTask;
+        }
+    }
+
+    public class UpdateApiVersionsMessage {
+        public uint ClientVersion { get; set; }
+        public string AppVersion { get; set; }
+        public string AppBuild { get; set; }
+    }
+}

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -155,9 +155,9 @@ namespace EGG9000.Common.Database {
             _cache.Remove("DbContext-EiContracts");
         }
 
-        // Registers contract definitions discovered in player backups that the periodicals feed never
-        // delivered to us (e.g. solo/single-player contracts), so they exist in the DB and resolve in
-        // CachedEiContractsAsync for everyone instead of crashing CustomBackup construction.
+        // Registers contract definitions fetched by identifier (get_contracts_info) that the periodicals
+        // feed never delivered to us (e.g. single-player contracts), so they exist in the DB and resolve
+        // in CachedEiContractsAsync for everyone. Inserts the row only; fires no channel/coop automation.
         public async Task<int> RegisterMissingContractsAsync(System.Collections.Generic.IEnumerable<Ei.Contract> contractDefs, System.Threading.CancellationToken ct = default) {
             var defs = contractDefs
                 .Where(c => c is not null && !string.IsNullOrEmpty(c.Identifier))

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -155,6 +155,47 @@ namespace EGG9000.Common.Database {
             _cache.Remove("DbContext-EiContracts");
         }
 
+        // Registers contract definitions discovered in player backups that the periodicals feed never
+        // delivered to us (e.g. solo/single-player contracts), so they exist in the DB and resolve in
+        // CachedEiContractsAsync for everyone instead of crashing CustomBackup construction.
+        public async Task<int> RegisterMissingContractsAsync(System.Collections.Generic.IEnumerable<Ei.Contract> contractDefs, System.Threading.CancellationToken ct = default) {
+            var defs = contractDefs
+                .Where(c => c is not null && !string.IsNullOrEmpty(c.Identifier))
+                .GroupBy(c => c.Identifier)
+                .Select(g => g.First())
+                .ToList();
+            if(defs.Count == 0) return 0;
+
+            var existingIds = (await Contracts.Select(c => c.ID).ToListAsync(ct)).ToHashSet();
+            var missing = defs.Where(d => !existingIds.Contains(d.Identifier)).ToList();
+            if(missing.Count == 0) return 0;
+
+            foreach(var def in missing) {
+                Contracts.Add(new Contract {
+                    ID = def.Identifier,
+                    Created = DateTime.Now,
+                    Description = def.Description,
+                    Name = def.Name,
+                    goals = Newtonsoft.Json.JsonConvert.SerializeObject(def.Goals),
+                    GoodUntil = DateTimeOffset.FromUnixTimeSeconds((long)def.ExpirationTime),
+                    MaxUsers = (int)def.MaxCoopSize,
+                    coop_allowed = def.CoopAllowed,
+                    max_boosts = (int)def.MaxBoosts,
+                    max_soul_eggs = def.MaxSoulEggs,
+                    min_client_version = (int)def.MinClientVersion,
+                    debug = def.Debug,
+                    length_seconds = def.LengthSeconds,
+                    egg = def.Egg.ToString(),
+                    cc_only = def.CcOnly,
+                    _response = Newtonsoft.Json.JsonConvert.SerializeObject(def)
+                });
+            }
+
+            await SaveChangesAsync(ct);
+            ExpireCachedEiContracts();
+            return missing.Count;
+        }
+
         public readonly IMemoryCache _cache;
 #nullable enable
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options, IMemoryCache? cache = null) : base(options) {

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -265,12 +265,8 @@ namespace EGG9000.Common.Database {
             CraftingXP = backup.Artifacts.CraftingXp;
 
             ArchivedFarms = new List<CustomArchivedFarms>();
-            var embeddedContractDefs = backup.Contracts.Contracts.Concat(backup.Contracts.Archive)
-                .Where(x => x.Contract is not null)
-                .GroupBy(x => x.Contract.Identifier)
-                .ToDictionary(g => g.Key, g => g.First().Contract);
-            AddContracts(backup.Contracts.Contracts, contracts, embeddedContractDefs);
-            AddContracts(backup.Contracts.Archive, contracts, embeddedContractDefs);
+            AddContracts(backup.Contracts.Contracts, contracts);
+            AddContracts(backup.Contracts.Archive, contracts);
 
             Farms = new List<CustomFarm>();
             foreach(var farm in backup.Farms.Where(x => x.FarmType != Ei.FarmType.Empty)) {
@@ -325,12 +321,11 @@ namespace EGG9000.Common.Database {
             }
 
             CustomEggMaxFarmSizeReached = [];
+            var allContractList = backup.Contracts.Archive.Concat(backup.Contracts.Contracts).ToList();
             foreach(var customEgg in backup.Contracts.CustomEggInfo.ToList()) {
-                var allContractList = backup.Contracts.Archive;
-                allContractList.AddRange(backup.Contracts.Contracts);
                 var matchingContracts = allContractList.Where(f =>
                     f?.MaxFarmSizeReached > 0
-                    && f.Contract.Egg == Ei.Egg.CustomEgg
+                    && f.Contract?.Egg == Ei.Egg.CustomEgg
                     && f.Contract.CustomEggId.ToLower() == customEgg.Identifier.ToLower()
                 ).ToList();
 
@@ -414,8 +409,8 @@ namespace EGG9000.Common.Database {
         }
 
         private void AddFarm(Ei.Backup.Types.Simulation farm, Ei.Backup backup) {
-            var contract = backup.Contracts.Contracts.FirstOrDefault(x => x.Contract.Identifier == farm.ContractId)
-                ?? backup.Contracts.Archive.Where(x => x != null).FirstOrDefault(x => x.Contract.Identifier == farm.ContractId);
+            var contract = backup.Contracts.Contracts.FirstOrDefault(x => x.ContractIdentifier == farm.ContractId)
+                ?? backup.Contracts.Archive.Where(x => x != null).FirstOrDefault(x => x.ContractIdentifier == farm.ContractId);
 
             var customFarm = new CustomFarm {
                 FarmType = farm.FarmType,
@@ -424,7 +419,7 @@ namespace EGG9000.Common.Database {
                 League = contract?.League,
                 CoopId = contract?.CoopIdentifier,
                 Cancelled = contract?.Cancelled ?? false,
-                Completed = contract != null ? contract.NumGoalsAchieved == contract.Contract.GetGoals(contract).Count : false,
+                Completed = contract?.Contract != null && contract.NumGoalsAchieved == contract.Contract.GetGoals(contract).Count,
                 NumChickens = farm.NumChickens,
                 CommonResearch = farm.CommonResearch.Select(x => new CustomResearch(x)).ToList(),
                 EggType = farm.EggType,
@@ -432,7 +427,7 @@ namespace EGG9000.Common.Database {
                 TrainLength = farm.TrainLength.ToList(),
                 SilosOwned = farm.SilosOwned,
                 TimeAccepted = (long)(contract?.TimeAccepted ?? 0),
-                CoopAllowed = contract?.Contract.CoopAllowed ?? false,
+                CoopAllowed = contract?.Contract?.CoopAllowed ?? false,
                 CoopSharedEndTime = (long)(contract?.CoopSharedEndTime ?? 0),
                 BoostTokensReceived = (ushort)farm.BoostTokensReceived,
                 BoostTokensGiven = (ushort)farm.BoostTokensGiven,
@@ -519,17 +514,14 @@ namespace EGG9000.Common.Database {
             } else return 0;
         }
 
-        private void AddContracts(RepeatedField<Ei.LocalContract> contracts, FrozenSet<Ei.Contract> allContracts, Dictionary<string, Ei.Contract> embeddedContractDefs) {
+        private void AddContracts(RepeatedField<Ei.LocalContract> contracts, FrozenSet<Ei.Contract> allContracts) {
             foreach(var localContract in contracts) {
                 if(localContract.Contract is null) {
-                    var contract = allContracts.FirstOrDefault(x => x.Identifier == localContract.ContractIdentifier)
-                        ?? (embeddedContractDefs.TryGetValue(localContract.ContractIdentifier, out var harvested) ? harvested : null);
-
+                    var contract = allContracts.FirstOrDefault(x => x.Identifier == localContract.ContractIdentifier);
                     if(contract is null) {
-                        // Definition is not in our cache/DB and the backup itself does not carry it
-                        // (e.g. a freshly released contract the reference account has not joined).
-                        // Skip this entry instead of crashing the whole backup or attaching an
-                        // unrelated contract's data via allContracts.First().
+                        // Definition is not in our cache/DB (e.g. a contract never offered to the
+                        // reference account, absorbed lazily via get_contracts_info). Skip this entry
+                        // instead of crashing the whole backup or attaching an unrelated contract.
                         Console.WriteLine($"Missing contract definition, skipping: {localContract.ContractIdentifier}");
                         continue;
                     }

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -1,4 +1,4 @@
-﻿using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.JsonData.EiStatics;
 using Google.Protobuf.Collections;
@@ -265,8 +265,12 @@ namespace EGG9000.Common.Database {
             CraftingXP = backup.Artifacts.CraftingXp;
 
             ArchivedFarms = new List<CustomArchivedFarms>();
-            AddContracts(backup.Contracts.Contracts, contracts);
-            AddContracts(backup.Contracts.Archive, contracts);
+            var embeddedContractDefs = backup.Contracts.Contracts.Concat(backup.Contracts.Archive)
+                .Where(x => x.Contract is not null)
+                .GroupBy(x => x.Contract.Identifier)
+                .ToDictionary(g => g.Key, g => g.First().Contract);
+            AddContracts(backup.Contracts.Contracts, contracts, embeddedContractDefs);
+            AddContracts(backup.Contracts.Archive, contracts, embeddedContractDefs);
 
             Farms = new List<CustomFarm>();
             foreach(var farm in backup.Farms.Where(x => x.FarmType != Ei.FarmType.Empty)) {
@@ -515,18 +519,19 @@ namespace EGG9000.Common.Database {
             } else return 0;
         }
 
-        private void AddContracts(RepeatedField<Ei.LocalContract> contracts, FrozenSet<Ei.Contract> allContracts) {
+        private void AddContracts(RepeatedField<Ei.LocalContract> contracts, FrozenSet<Ei.Contract> allContracts, Dictionary<string, Ei.Contract> embeddedContractDefs) {
             foreach(var localContract in contracts) {
                 if(localContract.Contract is null) {
-                    var contract = allContracts.FirstOrDefault(x => x.Identifier == localContract.ContractIdentifier);
-                    
-                    if(contract == null) {
-                        if(!localContract.HasCoopIdentifier || localContract.ContractIdentifier.Contains("\u0005")) {
-                            contract = allContracts.First();
-                        } else {
-                            Console.WriteLine($"Missing contract: {localContract.ContractIdentifier}");
-                            throw new Exception($"Missing contract: {localContract.ContractIdentifier}");
-                        }
+                    var contract = allContracts.FirstOrDefault(x => x.Identifier == localContract.ContractIdentifier)
+                        ?? (embeddedContractDefs.TryGetValue(localContract.ContractIdentifier, out var harvested) ? harvested : null);
+
+                    if(contract is null) {
+                        // Definition is not in our cache/DB and the backup itself does not carry it
+                        // (e.g. a freshly released contract the reference account has not joined).
+                        // Skip this entry instead of crashing the whole backup or attaching an
+                        // unrelated contract's data via allContracts.First().
+                        Console.WriteLine($"Missing contract definition, skipping: {localContract.ContractIdentifier}");
+                        continue;
                     }
                     localContract.Contract = contract;
                 }

--- a/EGG9000.Common/EggIncAPI/EggIncApi.Ei.cs
+++ b/EGG9000.Common/EggIncAPI/EggIncApi.Ei.cs
@@ -19,17 +19,53 @@ namespace EGG9000.Common.EggIncAPI {
 
     public partial class EggIncApi {
 
-        public static async Task<PeriodicalsResponse> GetPeriodicalsAsync() {
-            return await Post<PeriodicalsResponse, GetPeriodicalsRequest>(new GetPeriodicalsRequest {
-                UserId = "EI5482515761594368",
+        private const string PeriodicalsReferenceUserId = "EI5482515761594368";
+        private const string PeriodicalsPostUserId = "EI4765194876354560";
+
+        private static GetPeriodicalsRequest BuildPeriodicalsRequest(string userId, uint clientVersion) {
+            return new GetPeriodicalsRequest {
+                UserId = userId,
                 PiggyFull = false,
                 PiggyFoundFull = false,
                 SecondsFullRealtime = 2339576.17448521,
                 SecondsFullGametime = 391564.659540082,
                 SoulEggs = 570149167.28294,
-                CurrentClientVersion = ClientVersion,
+                CurrentClientVersion = clientVersion,
                 Debug = false,
-            }, "EI4765194876354560", true);
+            };
+        }
+
+        public static async Task<PeriodicalsResponse> GetPeriodicalsAsync(string userId = PeriodicalsReferenceUserId) {
+            return await Post<PeriodicalsResponse, GetPeriodicalsRequest>(BuildPeriodicalsRequest(userId, ClientVersion), PeriodicalsPostUserId, true);
+        }
+
+        public static bool IsValidPeriodicalsResponse(PeriodicalsResponse resp) {
+            return (resp?.Contracts?.Contracts?.Count ?? 0) > 0;
+        }
+
+        // Validates a candidate version triple by issuing a periodicals call built entirely from the
+        // candidate values, without mutating the live globals. Returns true only on a decodable
+        // response carrying at least one contract. Any failure (rejection, empty, network) returns false.
+        public static async Task<bool> ValidateVersionsAsync(uint clientVersion, string appVersion, string appBuild, string userId = PeriodicalsReferenceUserId) {
+            try {
+                var request = BuildPeriodicalsRequest(userId, clientVersion);
+                request.Rinfo = new BasicRequestInfo {
+                    ClientVersion = clientVersion,
+                    Version = appVersion,
+                    Build = appBuild,
+                    Platform = "IOS",
+                    Country = "US",
+                    Language = "en",
+                    Debug = false
+                };
+                var body = await GetBAC(Convert.ToBase64String(request.ToByteArray()));
+                var responseBytes = await PostRaw("ei/get_periodicals", body, HeaderProfile.Ios);
+                if(responseBytes is null)
+                    return false;
+                return IsValidPeriodicalsResponse(GetFromAuthenticatedMessage<PeriodicalsResponse>(responseBytes));
+            } catch {
+                return false;
+            }
         }
 
         public static async Task<ContractCoopStatusResponse> GetCoopStatus(string ContractName, string CoopName, string EIID = null, List<UserCoopXref> xrefs = null, ILogger _logger = null, CancellationToken cancellationToken = default) {
@@ -176,6 +212,12 @@ namespace EGG9000.Common.EggIncAPI {
             } catch(Exception e) {
                 return new EggIncFirstContactResponse { Success = false, Error = "Bot Exception: " + e.Message };
             }
+        }
+
+        public static async Task<ContractsInfoResponse> GetContractsInfoAsync(string userId, params string[] contractIdentifiers) {
+            var request = new ContractsInfoRequest { ClientVersion = ClientVersion };
+            request.ContractIdentifiers.AddRange(contractIdentifiers);
+            return await Post<ContractsInfoResponse, ContractsInfoRequest>(request, userId);
         }
 
         public static async Task<ContractsArchive> GetContractsArchive(string UserId) {

--- a/EGG9000.Common/EggIncAPI/EggIncApi.cs
+++ b/EGG9000.Common/EggIncAPI/EggIncApi.cs
@@ -22,9 +22,17 @@ namespace EGG9000.Common.EggIncAPI {
 
         public static readonly List<(string EggIncId, Contract.Types.PlayerGrade Grade, string Name)> CoopCreatorIds = [];
 
-        public static uint ClientVersion { get; set; } = 71;
-        public const string AppVersion = "1.35.5";
-        public const string AppBuild = "1.35.5.1";
+        public static uint ClientVersion { get; set; } = 72;
+        public static string AppVersion { get; set; } = "1.35.6";
+        public static string AppBuild { get; set; } = "1.35.6.3";
+
+        // Single mutation point for the Egg Inc API version triple. Updated at runtime by the
+        // /a setversions staff command and the UpdateApiVersions broadcast; not persisted across restarts.
+        public static void SetVersions(uint clientVersion, string appVersion, string appBuild) {
+            ClientVersion = clientVersion;
+            AppVersion = appVersion;
+            AppBuild = appBuild;
+        }
 
         private const string AndroidUserAgent = "Dalvik/2.1.0 (Linux; U; Android 9; SM-G960U1 Build/PPR1.180610.011)";
         private const string IosUserAgent = "egginc/1.26.1.3 CFNetwork/1335.0.3 Darwin/21.6.0";
@@ -76,6 +84,7 @@ namespace EGG9000.Common.EggIncAPI {
             // Post endpoints (iOS headers, Rinfo carried in the payload)
             [typeof(JoinCoopRequest)] = new("ei/join_coop", HeaderProfile.Ios, RinfoMode.WithUser, false, false),
             [typeof(GetPeriodicalsRequest)] = new("ei/get_periodicals", HeaderProfile.Ios, RinfoMode.WithoutUser, false, true),
+            [typeof(ContractsInfoRequest)] = new("ei_ctx/get_contracts_info", HeaderProfile.Ios, RinfoMode.WithUser, true, true),
             [typeof(CreateCoopRequest)] = new("ei/create_coop", HeaderProfile.Ios, RinfoMode.WithUser, false, false),
             [typeof(UpdateCoopPermissionsRequest)] = new("ei/update_coop_permissions", HeaderProfile.Ios, RinfoMode.WithUser, false, false),
             [typeof(ContractCoopStatusUpdateRequest)] = new("ei/update_coop_status", HeaderProfile.Ios, RinfoMode.WithUser, false, false),

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -214,6 +214,9 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
 
     services.AddMassTransit(x => {
         x.AddConsumer<ExpireCacheConsumer>();
+        // Per-instance temporary queue so a version update fans out to every running process
+        // instead of being load-balanced across a shared queue.
+        x.AddConsumer<UpdateApiVersionsConsumer>().Endpoint(e => { e.InstanceId = Guid.NewGuid().ToString("N"); e.Temporary = true; });
         var host = Configuration.GetConnectionString("RabbitMQServer");
         if(string.IsNullOrEmpty(host)) {
             x.UsingInMemory((context, cfg) => {


### PR DESCRIPTION
- Bumped client version to >72 (reason today's solo contract was missed)
- `/a setversions` command to allow for changing API spec without code change
- "Self-healing"; if E9K detects a contract in a player's backup that "it doesn't have," it will hit the API to populate the DB