### PR TITLE
Chore: Combine Paths for Loading EI Account "Extra Data"

### DIFF
--- a/EGG9000.Bot/Automated/UserGrades.cs
+++ b/EGG9000.Bot/Automated/UserGrades.cs
@@ -36,48 +36,14 @@ namespace EGG9000.Bot.Automated {
                 tasks.Add(Task.Run(async () => {
                     foreach(var account in user.EggIncAccounts) {
                         try {
-                            var (info, error) = await EggIncApi.GetContractPlayerInfo(account.Id);
-                            if(info == null) {
-                                _logger.LogWarning($"No response getting grade for user {user.DiscordUsername} {account.Name}: {error}");
-                            } else if(info.Status != Ei.ContractPlayerInfo.Types.Status.Complete) {
-                                _logger.LogTrace($"Skipping non-final grade ({info.Status}) for user {user.DiscordUsername} {account.Name}");
-                            } else {
-                                using var scope = _provider.CreateScope();
-                                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                            using var scope = _provider.CreateScope();
+                            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-                                if(GradeSync.ApplyGradeChange(user, account, info.Grade, setPromotionTime: false, guardUnset: true, _logger)) {
-                                    await db.DBUsers.Where(c => c.Id == user.Id).ExecuteUpdateAsync(s => s
-                                        .SetProperty(c => c._contractRegistrationByte, user._contractRegistrationByte));
-                                }
-
-                                // Season progress upsert
-                                if(info.SeasonProgress.Count > 0) {
-                                    var seasonIds = info.SeasonProgress
-                                        .Select(sp => sp.SeasonId)
-                                        .Where(id => !string.IsNullOrEmpty(id))
-                                        .ToList();
-                                    var existingRows = await db.UserSeasonProgresses
-                                        .Where(x => x.EggIncId == account.Id && seasonIds.Contains(x.SeasonId))
-                                        .ToListAsync(CancellationToken.None);
-
-                                    foreach(var sp in info.SeasonProgress) {
-                                        if(string.IsNullOrEmpty(sp.SeasonId)) continue;
-                                        var row = existingRows.FirstOrDefault(x => x.SeasonId == sp.SeasonId);
-                                        if(row == null) {
-                                            db.UserSeasonProgresses.Add(new UserSeasonProgress {
-                                                EggIncId = account.Id,
-                                                SeasonId = sp.SeasonId,
-                                                TotalCxp = sp.TotalCxp,
-                                                StartingGrade = (int)sp.StartingGrade
-                                            });
-                                        } else {
-                                            row.TotalCxp = sp.TotalCxp;
-                                            row.StartingGrade = (int)sp.StartingGrade;
-                                        }
-                                    }
-                                    await db.SaveChangesAsync(CancellationToken.None);
-                                }
+                            if(await AccountRefresh.ApplyExtrasAsync(user, account, db, _logger, CancellationToken.None)) {
+                                await db.DBUsers.Where(c => c.Id == user.Id).ExecuteUpdateAsync(s => s
+                                    .SetProperty(c => c._contractRegistrationByte, user._contractRegistrationByte));
                             }
+                            await db.SaveChangesAsync(CancellationToken.None);
                         } catch(Exception ex) {
                             _logger.LogError(ex, $"Error getting grade for user {user.DiscordUsername} {account.Name}");
                         } finally {

--- a/EGG9000.Bot/Commands/ContextUserCommands.cs
+++ b/EGG9000.Bot/Commands/ContextUserCommands.cs
@@ -4,6 +4,7 @@ using EGG9000.Common.Commands;
 using EGG9000.Common.Database;
 using EGG9000.Common.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,8 +13,8 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 namespace EGG9000.Bot.Commands {
     public static class ContextUserCommands {
         [UserCommand(Name = "Userstatus", AdminOnly = StaffOnlyLevel.FarmHand)]
-        public static async Task Userstatus(SocketUserCommand command, ApplicationDbContext db, DiscordHostedService _client) {
-            await UserStatusCommands._userstatus(command, db, _client, command.Data.Member, true, false);
+        public static async Task Userstatus(SocketUserCommand command, ApplicationDbContext db, DiscordHostedService _client, ILogger logger) {
+            await UserStatusCommands._userstatus(command, db, _client, logger, command.Data.Member, true, false);
         }
 
         [UserCommand(Name = "Contract Settings", AdminOnly = StaffOnlyLevel.FarmHand)]

--- a/EGG9000.Bot/Commands/UserStatusCommands.cs
+++ b/EGG9000.Bot/Commands/UserStatusCommands.cs
@@ -11,6 +11,7 @@ using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using System;
 using System.Collections.Generic;
@@ -23,17 +24,17 @@ namespace EGG9000.Bot.Commands {
     public static class UserStatusCommands {
 
         [SlashCommand(Description = "Get a users status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
-        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, [SlashParam] SocketUser user, [SlashParam(Required = false)] bool showinchannel = false,
+        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, ILogger logger, [SlashParam] SocketUser user, [SlashParam(Required = false)] bool showinchannel = false,
             [SlashParam(Required = false, Description = "Pull a fresh backup for all accounts of this user before reporting their status")] bool pullfreshbackup = false) {
-            return _userstatus(command, db, _client, user, true, showinchannel, pullfreshbackup);
+            return _userstatus(command, db, _client, logger, user, true, showinchannel, pullfreshbackup);
         }
 
         [SlashCommand(Description = "Get your status", AllowInDMs = true)]
-        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client) {
-            return _userstatus(command, db, _client, command.User);
+        public static Task UserStatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, ILogger logger) {
+            return _userstatus(command, db, _client, logger, command.User);
         }
 
-        public static async Task _userstatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, IUser user, bool admin = false, bool showInChannel = false, bool pullFreshBackup = false) {
+        public static async Task _userstatus(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, ILogger logger, IUser user, bool admin = false, bool showInChannel = false, bool pullFreshBackup = false) {
             await command.DeferAsync(ephemeral: !showInChannel);
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {
@@ -46,16 +47,14 @@ namespace EGG9000.Bot.Commands {
             }
 
             if(pullFreshBackup) {
+                var cachedContracts = await db.CachedEiContractsAsync();
                 foreach(var account in dbuser.EggIncAccounts) {
-                    var rawBackup = await EggIncApi.FirstContact(account.Id);
-                    if(rawBackup is null || rawBackup.Backup is null) {
+                    var backup = await AccountRefresh.RefreshBackupAsync(account, cachedContracts);
+                    if(backup is null) {
                         await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Backup for account `{account?.Backup?.UserName ?? account.Id}` returned as null from the API"); });
                         return;
                     }
-                    var customBackup = new CustomBackup(rawBackup.Backup, await db.CachedEiContractsAsync(), account?.Backup ?? null);
-                    if(customBackup?.Farms is not null) {
-                        account.Backup = customBackup;
-                    }
+                    await AccountRefresh.ApplyExtrasAsync(dbuser, account, db, logger);
                 }
                 dbuser.UpdateAccounts();
                 await db.SaveChangesAsync();

--- a/EGG9000.Common/Helpers/AccountRefresh.cs
+++ b/EGG9000.Common/Helpers/AccountRefresh.cs
@@ -1,0 +1,85 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.EggIncAPI;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Common.Helpers {
+    // Shared per-account refresh primitives. RefreshBackupAsync pulls and assigns a fresh backup;
+    // ApplyExtrasAsync pulls the "alt" data (grade + per-season CXP) that is too expensive to run on
+    // every mass backup. Both mutate the account in memory and stage DB changes; the caller persists
+    // (UpdateAccounts + SaveChanges, or a targeted ExecuteUpdate). Compose them as needed.
+    public static class AccountRefresh {
+
+        // Pulls a fresh backup for one account and assigns it (carry-forward via the prior backup so
+        // monotonic data like colleggtible levels is preserved). Returns the new backup, or null if the
+        // API failed or returned no farms. In-memory only - caller persists the account blob.
+        public static async Task<CustomBackup> RefreshBackupAsync(EggIncAccount account, FrozenSet<Ei.Contract> cachedContracts) {
+            var firstContact = await EggIncApi.FirstContact(account.Id);
+            if(firstContact?.Backup is null)
+                return null;
+
+            var backup = new CustomBackup(firstContact.Backup, cachedContracts, account.Backup);
+            if(backup?.Farms is null)
+                return null;
+
+            account.Backup = backup;
+            return backup;
+        }
+
+        // Pulls grade + per-season CXP from get_contract_player_info and applies them: grade via GradeSync
+        // (in memory, repacks the account blob) and UserSeasonProgress upserts staged on `db` (NOT saved).
+        // Caller persists the account blob and calls SaveChanges. Returns whether the grade changed.
+        public static async Task<bool> ApplyExtrasAsync(DBUser user, EggIncAccount account, ApplicationDbContext db, ILogger logger, CancellationToken cancellationToken = default) {
+            var (info, error) = await EggIncApi.GetContractPlayerInfo(account.Id);
+            if(info is null) {
+                logger.LogWarning("No response getting grade for user {User} ({Account}): {Error}", user.DiscordUsername, account.Name, error);
+                return false;
+            }
+            if(info.Status != Ei.ContractPlayerInfo.Types.Status.Complete) {
+                logger.LogTrace("Skipping non-final grade ({Status}) for user {User} ({Account})", info.Status, user.DiscordUsername, account.Name);
+                return false;
+            }
+
+            var gradeChanged = GradeSync.ApplyGradeChange(user, account, info.Grade, setPromotionTime: false, guardUnset: true, logger);
+            if(!gradeChanged)
+                logger.LogInformation("No grade change for user {User} ({Account}) grade: {Grade}", user.DiscordUsername, account.Name, info.Grade);
+
+            await UpsertSeasonProgress(account.Id, info.SeasonProgress, db, cancellationToken);
+            return gradeChanged;
+        }
+
+        private static async Task UpsertSeasonProgress(string eggIncId, IEnumerable<Ei.ContractPlayerInfo.Types.SeasonProgress> seasonProgress, ApplicationDbContext db, CancellationToken cancellationToken) {
+            var rows = seasonProgress.Where(sp => !string.IsNullOrEmpty(sp.SeasonId)).ToList();
+            if(rows.Count == 0)
+                return;
+
+            var seasonIds = rows.Select(sp => sp.SeasonId).ToList();
+            var existing = await db.UserSeasonProgresses
+                .Where(x => x.EggIncId == eggIncId && seasonIds.Contains(x.SeasonId))
+                .ToListAsync(cancellationToken);
+
+            foreach(var sp in rows) {
+                var row = existing.FirstOrDefault(x => x.SeasonId == sp.SeasonId);
+                if(row is null) {
+                    db.UserSeasonProgresses.Add(new UserSeasonProgress {
+                        EggIncId = eggIncId,
+                        SeasonId = sp.SeasonId,
+                        TotalCxp = sp.TotalCxp,
+                        StartingGrade = (int)sp.StartingGrade
+                    });
+                } else {
+                    row.TotalCxp = sp.TotalCxp;
+                    row.StartingGrade = (int)sp.StartingGrade;
+                }
+            }
+        }
+    }
+}

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -136,15 +136,8 @@ namespace EGG9000.Site.Controllers {
             // (the view dereferences account.Backup directly). Fresh backups are refreshed out of band below.
             var accountsNeedingBackup = user.EggIncAccounts.Where(a => a.Backup is null).ToList();
             if(accountsNeedingBackup.Count > 0) {
-                var fetched = await Task.WhenAll(accountsNeedingBackup.Select(async a => {
-                    var raw = await EggIncApi.FirstContact(a.Id);
-                    return (account: a, backup: new CustomBackup(raw.Backup, cachedContracts, null));
-                }));
-                var changed = false;
-                foreach(var (account, backup) in fetched) {
-                    if(backup?.Farms is not null) { account.Backup = backup; changed = true; }
-                }
-                if(changed) {
+                var fetched = await Task.WhenAll(accountsNeedingBackup.Select(a => AccountRefresh.RefreshBackupAsync(a, cachedContracts)));
+                if(fetched.Any(b => b is not null)) {
                     user.UpdateAccounts();
                     await _db.SaveChangesAsync();
                 }
@@ -183,22 +176,13 @@ namespace EGG9000.Site.Controllers {
                     var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == discordId);
                     if(user is null) return;
                     var cachedContracts = await db.CachedEiContractsAsync();
-                    var results = await Task.WhenAll(user.EggIncAccounts.Select(async account => {
-                        var rawBackup = await EggIncApi.FirstContact(account.Id);
-                        var customBackup = new CustomBackup(rawBackup.Backup, cachedContracts, account?.Backup ?? null);
-                        return (account, customBackup);
-                    }));
-                    var update = false;
-                    foreach(var (account, customBackup) in results) {
-                        if(customBackup?.Farms is not null) {
-                            account.Backup = customBackup;
-                            update = true;
-                        }
-                    }
-                    if(update) {
-                        user.UpdateAccounts();
-                        await db.SaveChangesAsync();
-                    }
+                    // Backups are network-only + per-account in memory, so fetch them concurrently.
+                    await Task.WhenAll(user.EggIncAccounts.Select(account => AccountRefresh.RefreshBackupAsync(account, cachedContracts)));
+                    // Extras stage DB writes, so run them sequentially against the single context.
+                    foreach(var account in user.EggIncAccounts)
+                        await AccountRefresh.ApplyExtrasAsync(user, account, db, _logger);
+                    user.UpdateAccounts();
+                    await db.SaveChangesAsync();
                 } catch(Exception e) {
                     _logger.LogError(e, "Background backup refresh failed for {discordId}", discordId);
                 }


### PR DESCRIPTION
With the move away from using just CustomBackup, due to the fields Kev has removed, etc., the process for "refreshing" an account has changed. It used to be that we could accept that pulling a fresh backup meant the account would be refreshed, however just backup is no longer enough.

This PR adds some common logic for "fully refresh [an account]," which should be treated as the operator for pulling new data, should we need to do any more of this in the future.

Practically, this means that a user's grade + season progress will now force-refresh when users visit `MyFarms` (as a background load), and they will also refresh during `/userstatus`, if the "force new backup" param is `true`.