### PR TITLE
Chore: Missing Seasonal PEs on MyFarms

### DIFF
--- a/EGG9000.Common/Database/Entities/SeasonInfo.cs
+++ b/EGG9000.Common/Database/Entities/SeasonInfo.cs
@@ -54,6 +54,11 @@ namespace EGG9000.Common.Database.Entities {
                 return 0;
             return gradeGoals.Sum(g => g.PeAmount);
         }
+
+        public IEnumerable<SeasonPeGoal> GetUnearnedGoals(Ei.Contract.Types.PlayerGrade grade, double totalCxp) =>
+            Goals.TryGetValue((int)grade, out var gradeGoals)
+                ? gradeGoals.Where(g => totalCxp < g.Cxp)
+                : [];
     }
 
     public class SeasonPeGoal {

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -110,19 +110,23 @@ namespace EGG9000.Site.Controllers {
                 .Where(x => seasonIds.Contains(x.Id))
                 .ToListAsync();
             var seasonInfoMap = seasonInfos.ToDictionary(si => si.Id);
-            var seasonPEByEggIncId = eggIncIds.ToDictionary(
-                id => id,
-                id => {
-                    var earned = 0;
-                    var max = 0;
-                    foreach(var sp in seasonProgresses.Where(sp => sp.EggIncId == id)) {
-                        if(!seasonInfoMap.TryGetValue(sp.SeasonId, out var info)) continue;
-                        earned += info.GetPeEarned((Ei.Contract.Types.PlayerGrade)sp.StartingGrade, sp.TotalCxp);
-                        max += info.GetMaxPe((Ei.Contract.Types.PlayerGrade)sp.StartingGrade);
-                    }
-                    return (Earned: earned, Max: max);
+            var seasonPEByEggIncId = new Dictionary<string, (int Earned, int Max)>();
+            var missingSeasonalPEByEggIncId = new Dictionary<string, List<MissingSeasonalPe>>();
+            foreach(var id in eggIncIds) {
+                var earned = 0;
+                var max = 0;
+                var missing = new List<MissingSeasonalPe>();
+                foreach(var sp in seasonProgresses.Where(sp => sp.EggIncId == id)) {
+                    if(!seasonInfoMap.TryGetValue(sp.SeasonId, out var info)) continue;
+                    var grade = (Ei.Contract.Types.PlayerGrade)sp.StartingGrade;
+                    earned += info.GetPeEarned(grade, sp.TotalCxp);
+                    max += info.GetMaxPe(grade);
+                    foreach(var goal in info.GetUnearnedGoals(grade, sp.TotalCxp))
+                        missing.Add(new MissingSeasonalPe(info.Name, sp.TotalCxp, goal.Cxp, goal.PeAmount, info.StartTime));
                 }
-            );
+                seasonPEByEggIncId[id] = (Earned: earned, Max: max);
+                missingSeasonalPEByEggIncId[id] = missing.OrderBy(m => m.StartTime).ToList();
+            }
 
             var dbCustomEggs = _cache.GetOrCreate("CustomEggsCache", entry => {
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
@@ -150,7 +154,7 @@ namespace EGG9000.Site.Controllers {
 
 
             Console.WriteLine(string.Join("\n", times.Finished().Select(y => $"{y.name}: {y.time.Humanize().ShortenTime()}")));
-            return View("Index", new MyFarmsModel(user, Contracts, Demerits, Merits, /*RawBackups,*/ Snapshots, xrefs, coops, erItems, scoring, DbGuild, uncompletedPes, dbCustomEggs, isSelf, cachedContracts, seasonPEByEggIncId));
+            return View("Index", new MyFarmsModel(user, Contracts, Demerits, Merits, /*RawBackups,*/ Snapshots, xrefs, coops, erItems, scoring, DbGuild, uncompletedPes, dbCustomEggs, isSelf, cachedContracts, seasonPEByEggIncId, missingSeasonalPEByEggIncId));
         }
 
         private async Task GetScores(DBUser user, List<(string EggIncId, MyContracts MyContracts)> scoring) {
@@ -205,8 +209,11 @@ namespace EGG9000.Site.Controllers {
             List<DBCustomEgg> CustomEggs,
             bool IsSelf,
             FrozenSet<Ei.Contract> CachedContracts,
-            Dictionary<string, (int Earned, int Max)> SeasonPEByEggIncId
+            Dictionary<string, (int Earned, int Max)> SeasonPEByEggIncId,
+            Dictionary<string, List<MissingSeasonalPe>> MissingSeasonalPEByEggIncId
         );
+
+        public record MissingSeasonalPe(string SeasonName, double CurrentCxp, double GoalCxp, int PeAmount, DateTimeOffset StartTime);
 
         public async Task<IActionResult> EarningsBoostCalculator() {
             var loginuser = (await _userManager.GetUserAsync(User));

--- a/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
@@ -1,4 +1,4 @@
-﻿@model (CustomBackup backup, List<UserSnapShot> snapshots, bool isAdmin, Dictionary<string, List<EGG9000.Common.Database.Entities.Contract>> uncompletePEs, List<Contract> contracts, (int Earned, int Max) peFromSeasons)
+﻿@model (CustomBackup backup, List<UserSnapShot> snapshots, bool isAdmin, Dictionary<string, List<EGG9000.Common.Database.Entities.Contract>> uncompletePEs, List<Contract> contracts, (int Earned, int Max) peFromSeasons, List<EGG9000.Site.Controllers.MyFarmsController.MissingSeasonalPe> missingSeasonalPEs)
 @{
     string calculateMER(double se, ulong pe) {
         se = se / 1e18;
@@ -50,6 +50,27 @@
                     </table>
                 </div>
             </div>
+
+            @if (Model.missingSeasonalPEs.Count > 0) {
+                <div class="card" style="margin-top:15px;">
+                    <h4 class="card-header" style="text-align: center">Missing Seasonal Eggs of Prophecy</h4>
+                    <div class="card-body">
+                        @foreach (var season in Model.missingSeasonalPEs) {
+                            var pct = Math.Min(100, season.GoalCxp > 0 ? season.CurrentCxp / season.GoalCxp * 100 : 0);
+                            <div style="margin-bottom:12px;">
+                                <div class="d-flex justify-content-between align-items-center" style="margin-bottom:4px;">
+                                    <span><b>@season.SeasonName</b></span>
+                                    <span><span class="text-info">@season.CurrentCxp.ToString("N0")</span> / @season.GoalCxp.ToString("N0") CS</span>
+                                    <span><img src="/images/Egg_of_Prophecy.png" style="max-height: 1.2em;" alt="Egg of Prophecy" /></span>
+                                </div>
+                                <div class="progress" role="progressbar" aria-valuenow="@((int)pct)" aria-valuemin="0" aria-valuemax="100">
+                                    <div class="progress-bar bg-success" style="width:@pct.ToString(System.Globalization.CultureInfo.InvariantCulture)%"></div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            }
 
             @if (Model.uncompletePEs[Model.backup.EggIncId].Count() > 0 || true) {
                 <div class="card" style="margin-top:15px;">

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -480,7 +480,7 @@
                     @if (snapshots != null) {
                         <div class="tab-pane" id="ebhistory@(index)" role="tabpanel">
                             @{
-                                await Html.RenderPartialAsync("-EBHistory", (backup, snapshots, isAdmin, uncompletePEs, contracts, Model.SeasonPEByEggIncId.GetValueOrDefault(backup.EggIncId, (Earned: 0, Max: 0))));
+                                await Html.RenderPartialAsync("-EBHistory", (backup, snapshots, isAdmin, uncompletePEs, contracts, Model.SeasonPEByEggIncId.GetValueOrDefault(backup.EggIncId, (Earned: 0, Max: 0)), Model.MissingSeasonalPEByEggIncId.GetValueOrDefault(backup.EggIncId, new List<EGG9000.Site.Controllers.MyFarmsController.MissingSeasonalPe>())));
                             }
                         </div>
                     }


### PR DESCRIPTION
Adds a "missing seasonal PEs" section to MyFarms, if the player is missing >0.
<img width="748" height="501" alt="image" src="https://github.com/user-attachments/assets/c9306151-6dac-4781-b110-699993d8a98f" />
