### PR TITLE
fix: gate EnableSensitiveDataLogging behind #if DEBUG

### DIFF
--- a/EGG9000.Bot/BotHostFactory.cs
+++ b/EGG9000.Bot/BotHostFactory.cs
@@ -63,7 +63,9 @@ public static class BotHostFactory {
                     x.MigrationsAssembly("EGG9000.Common");
                     x.CommandTimeout(30);
                 });
+#if DEBUG
                 options.EnableSensitiveDataLogging(true);
+#endif
                 options.AddInterceptors(new QueryCountingInterceptor());
             });
 

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -104,7 +104,9 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
             x.MigrationsAssembly("EGG9000.Common");
             x.CommandTimeout(30);
         });
+#if DEBUG
         options.EnableSensitiveDataLogging(true);
+#endif
     });
 
     services.AddIdentity<IdentityUser, IdentityRole>(options => {


### PR DESCRIPTION
## Audit Finding #1 — Privacy / Security

EnableSensitiveDataLogging(true) was enabled unconditionally in both:
- EGG9000.Bot/BotHostFactory.cs:66
- EGG9000.Site/Program.cs:107

This causes EF Core to include parameter values (potentially user data, Discord IDs, etc.) in log output in **all builds including production**.

### Fix
Wrap both calls in #if DEBUG so sensitive data is only logged during local development.

### Validation
- Build: 0 errors (same 4 pre-existing warnings)
- Tests: 86/86 passing
