### PR TITLE
fix: replace ForEach(async) with proper await in UserJoined

### DIFF
--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -176,18 +176,19 @@ namespace EGG9000.Common.Services {
                     }, _logger);
                     return;
                 }
-                dbuser.EggIncAccounts.ForEach(async account => {
+                var cachedContracts = await db.CachedEiContractsAsync();
+                foreach(var account in dbuser.EggIncAccounts) {
                     var rawBackup = await EggIncApi.FirstContact(account.Id);
-                    if(rawBackup is null || rawBackup.Backup is null) return;
-                    var customBackup = new CustomBackup(rawBackup.Backup, await db.CachedEiContractsAsync(), account?.Backup ?? null);
+                    if(rawBackup is null || rawBackup.Backup is null) continue;
+                    var customBackup = new CustomBackup(rawBackup.Backup, cachedContracts, account?.Backup ?? null);
                     account.Backup = customBackup?.Farms is not null ? customBackup : account.Backup;
-                });
+                }
                 if(dbuser.GuildId == 0 && await db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.GuildId == user.Guild.Id)) {
                     dbuser.GuildId = user.Guild.Id;
                 }
                 dbuser.UpdateAccounts();
                 await db.SaveChangesAsync();
-                var earningsBonus = dbuser.EggIncAccounts.Max(x => x.Backup.EarningsBonus);
+                var earningsBonus = dbuser.EggIncAccounts.Where(x => x.Backup is not null).Max(x => x.Backup.EarningsBonus);
                 var role = await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, [], _logger);
                 var roleText = role is not null ? $" You have been assigned the rank of {role?.Name} thanks to your EB of {earningsBonus.ToEggString()}" : "";
                 var response = await ChannelHelper.DetermineAndSend(_discord.Gateway, dbguild, GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!{roleText}" }, _logger);


### PR DESCRIPTION
## Audit Finding #2 - ForEach(async) Race Condition + NPE in UserJoined

### Problem
DiscordUserService.cs:179-184 uses .ForEach(async ...) which creates fire-and-forget tasks.

This causes three issues:
1. **Race condition**: UpdateAccounts() and SaveChangesAsync() run before backup fetches complete
2. **NullReferenceException**: .Max(x => x.Backup.EarningsBonus) on line 190 crashes when Backup is null
3. **Swallowed exceptions**: errors inside the lambda are silently lost

### Fix
- Replace ForEach(async) with a proper foreach + await loop
- Cache CachedEiContractsAsync() outside the loop (was called N times inside)
- Add null guard on Backup before accessing EarningsBonus

### Validation
- Build: 0 errors
- Tests: 86/86 passing
