### PR TITLE
fix: dispose IServiceScope in _UpdaterBase._run()

### DIFF
--- a/EGG9000.Bot/Automated/_UpdaterBase.cs
+++ b/EGG9000.Bot/Automated/_UpdaterBase.cs
@@ -135,8 +135,9 @@ namespace EGG9000.Bot.Automated {
 
         private async Task _run(object state) {
             if(await _semaphoreSlim.WaitAsync(TimeSpan.Zero)) {
+                using var scope = _provider.CreateScope();
                 try {
-                    var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    var _db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                     _logger.LogInformation("Running");
                     LastStarted = DateTime.Now;
                     _lastAlive = DateTimeOffset.UtcNow;
@@ -162,7 +163,8 @@ namespace EGG9000.Bot.Automated {
                     _semaphoreSlim.Release();
                 }
             } else {
-                var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                using var skippedScope = _provider.CreateScope();
+                var _db = skippedScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                 _db.AutomationLogs.Add(new AutomationLog { Type = GetType().Name, StartTime = DateTimeOffset.UtcNow, Skipped = true });
                 await _db.SaveChangesAsync();
                 _logger.LogWarning("Unable to run, already running for {time}", (DateTime.Now - LastStarted).Humanize());


### PR DESCRIPTION
## Audit Finding #3 - IServiceScope Leak in _UpdaterBase._run()

### Problem
The IServiceScope created via _provider.CreateScope() was never disposed in either:
- The main execution path (line 139)
- The skipped-run path (line 165)

This leaks the scope and all its tracked services (including ApplicationDbContext and its DB connection) on every invocation. With _run firing every 1-15 minutes for 20+ hosted services, this creates a continuous resource leak.

### Fix
Use using var scope = _provider.CreateScope() to ensure deterministic disposal in both paths.

### Validation
- Build: 0 errors
- Tests: 86/86 passing
