### PR TITLE
fix: add missing braces in UpdateDMStatus switch cases

### DIFF
--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -252,9 +252,11 @@ namespace EGG9000.Common.Database.Entities {
         public bool UpdateDMStatus(DiscordHelpersExt.DMResult dmResult) {
             switch(dmResult) {
                 case DiscordHelpersExt.DMResult.Success:
-                    if(DMSBlocked) DMSBlocked = false; return true;
+                    if(DMSBlocked) { DMSBlocked = false; return true; }
+                    return false;
                 case DiscordHelpersExt.DMResult.CannotSendToUser:
-                    if(!DMSBlocked) DMSBlocked = true; return true;
+                    if(!DMSBlocked) { DMSBlocked = true; return true; }
+                    return false;
                 default:
                     break;
             }


### PR DESCRIPTION
## Audit Finding #4 - UpdateDMStatus Missing Braces

### Problem
Due to missing braces in the switch cases, return true executed unconditionally on both Success and CannotSendToUser, regardless of whether DMSBlocked actually changed.

Both callers (DiscordHelpers.BoolSendDm and BoolSendDmEmbed) gate SaveChangesAsync on the return value:
if(dbUser.UpdateDMStatus(result)) await db.SaveChangesAsync();

So this caused a redundant database write on every DM send. The DMSBlocked property itself was still set correctly - only the return value was wrong.

### Fix
Add braces around the if body so return true only executes when DMSBlocked actually changed. Add explicit return false for the no-change case.

### Validation
- Build: 0 errors
- Tests: 86/86 passing
