### PR TITLE
Chore: slightly change wording on Contract page

### DIFF
--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -221,7 +221,7 @@
         <p><a href="#@coopNum">Jump to my co-op @coopNum</a></p>
             }
         } else {
-        <p>You are not currently in a co-op nor prefarming</p>
+        <p>You are not currently in a co-op</p>
         }
 
     </div>


### PR DESCRIPTION
Removed "nor prefarming" from the contract page, this wording has been annoying me for some time now so putting this in now so i dont forget. 