### PR TITLE
Fix: All currently open audits

### DIFF
--- a/EGG9000.Bot/Automated/_UpdaterBase.cs
+++ b/EGG9000.Bot/Automated/_UpdaterBase.cs
@@ -136,7 +136,8 @@ namespace EGG9000.Bot.Automated {
         private async Task _run(object state) {
             if(await _semaphoreSlim.WaitAsync(TimeSpan.Zero)) {
                 try {
-                    var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    using var scope = _provider.CreateScope();
+                    var _db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                     _logger.LogInformation("Running");
                     LastStarted = DateTime.Now;
                     _lastAlive = DateTimeOffset.UtcNow;
@@ -162,7 +163,8 @@ namespace EGG9000.Bot.Automated {
                     _semaphoreSlim.Release();
                 }
             } else {
-                var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                using var scope = _provider.CreateScope();
+                var _db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                 _db.AutomationLogs.Add(new AutomationLog { Type = GetType().Name, StartTime = DateTimeOffset.UtcNow, Skipped = true });
                 await _db.SaveChangesAsync();
                 _logger.LogWarning("Unable to run, already running for {time}", (DateTime.Now - LastStarted).Humanize());

--- a/EGG9000.Bot/Commands/ConfigureCommands.cs
+++ b/EGG9000.Bot/Commands/ConfigureCommands.cs
@@ -229,7 +229,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgNav(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -237,7 +237,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgPickChannel(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -245,7 +245,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgPickRole(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -253,7 +253,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgPickCoop(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -261,7 +261,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgPickList(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -269,7 +269,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgSetChannel(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -281,7 +281,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgSetRole(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -293,7 +293,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgClear(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -306,7 +306,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgCoopEn(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -318,7 +318,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgCoopLock(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -330,7 +330,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgToggle(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -343,7 +343,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgSetCsvCat(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -356,7 +356,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgSetCsvRole(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -369,7 +369,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgEdit(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             var g = await LoadGuild(db, component.GuildId);
             var f = GuildConfigReflection.Get(data);
@@ -387,7 +387,7 @@ namespace EGG9000.Bot.Commands {
             await component.RespondWithModalAsync(modal);
         }
 
-        [Modal]
+        [Modal(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgEditModal(SocketModal modal, [ComponentData] string data, ApplicationDbContext db) {
             var g = await LoadGuild(db, modal.GuildId);
             var f = GuildConfigReflection.Get(data);
@@ -415,7 +415,7 @@ namespace EGG9000.Bot.Commands {
             await modal.UpdateAsync(x => { x.Content = error is null ? "" : $"⚠️ {error}"; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task CfgBack(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);

--- a/EGG9000.Bot/Commands/EditFaqCommands.cs
+++ b/EGG9000.Bot/Commands/EditFaqCommands.cs
@@ -108,7 +108,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeBack(SocketMessageComponent component, ApplicationDbContext db, DiscordHostedService client) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -116,7 +116,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FePick(SocketMessageComponent component, ApplicationDbContext db, DiscordHostedService client) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -124,19 +124,19 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeAdd(SocketMessageComponent component) {
             await component.RespondWithModalAsync(TopicModal("FeModal:new", null).Build());
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeEditText(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             var t = await db.FAQTopics.FirstOrDefaultAsync(x => x.InternalId == data);
             if(t is null) { await component.DeferAsync(); return; }
             await component.RespondWithModalAsync(TopicModal($"FeModal:edit:{data}", t).Build());
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeStaff(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db, DiscordHostedService client) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -146,7 +146,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FePalace(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db, DiscordHostedService client) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -156,11 +156,11 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeWUp(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db, DiscordHostedService client) =>
             await AdjustWeight(component, data, db, client, +1);
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeWDn(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db, DiscordHostedService client) =>
             await AdjustWeight(component, data, db, client, -1);
 
@@ -173,7 +173,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeDel(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db, DiscordHostedService client) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -183,7 +183,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [Modal]
+        [Modal(AdminOnly = StaffOnlyLevel.Admin)]
         public static async Task FeModal(SocketModal modal, [ComponentData] string data, ApplicationDbContext db, DiscordHostedService client) {
             var g = await LoadGuild(db, modal.GuildId);
             var (op, id) = SplitFirst(data);

--- a/EGG9000.Bot/Commands/RankupCommands.cs
+++ b/EGG9000.Bot/Commands/RankupCommands.cs
@@ -129,7 +129,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuNav(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -137,7 +137,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuBack(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -147,7 +147,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuToggle(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -158,7 +158,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuFilter(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -169,7 +169,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuPickGroup(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -177,7 +177,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuPickMsg(SocketMessageComponent component, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -185,7 +185,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuAdd(SocketMessageComponent component, [ComponentData] string data) {
             var modal = new ModalBuilder().WithTitle("New rank-up message").WithCustomId($"RuMsgModal:new:{data}")
                 .AddTextInput("Message", customId: "text", TextInputStyle.Paragraph, placeholder: "Use {{user}} {{rank}} {{eb}} {{oom}} {{emoji:name}}", required: true, maxLength: 1500)
@@ -193,7 +193,7 @@ namespace EGG9000.Bot.Commands {
             await component.RespondWithModalAsync(modal);
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuEditBtn(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             var msg = await db.RankupMessages.FirstOrDefaultAsync(m => m.InternalId == data);
             if(msg is null) { await component.DeferAsync(); return; }
@@ -203,7 +203,7 @@ namespace EGG9000.Bot.Commands {
             await component.RespondWithModalAsync(modal);
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuDelBtn(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {
             await component.DeferAsync();
             var g = await LoadGuild(db, component.GuildId);
@@ -218,7 +218,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Embed = embed; x.Components = components; });
         }
 
-        [Modal]
+        [Modal(AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
         public static async Task RuMsgModal(SocketModal modal, ApplicationDbContext db) {
             var g = await LoadGuild(db, modal.GuildId);
             var (op, arg) = SplitFirst(Tail(modal.Data.CustomId));

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -746,7 +746,7 @@ namespace EGG9000.Bot.Commands {
             }, cts.Token);
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task SysLoadNav(SocketMessageComponent component, ApplicationDbContext db, DiscordSocketClient client, IServiceProvider serviceProvider) {
             await component.DeferAsync();
             var section = component.Data.Values.FirstOrDefault() ?? "overview";
@@ -758,7 +758,7 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Content = SysLoadContent(snap); x.Embed = SysLoadSection(section, snap); x.Components = SysLoadComponents(section, refreshing, IsEphemeral(component.Message)); });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task SysLoadRefresh(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db, DiscordSocketClient client, IServiceProvider serviceProvider) {
             await component.DeferAsync();
             var section = string.IsNullOrEmpty(data) ? "overview" : data;
@@ -767,14 +767,14 @@ namespace EGG9000.Bot.Commands {
             await component.ModifyOriginalResponseAsync(x => { x.Content = SysLoadContent(snap); x.Embed = SysLoadSection(section, snap); x.Components = SysLoadComponents(section, refreshing, IsEphemeral(component.Message)); });
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task SysLoadStop(SocketMessageComponent component) {
             await component.DeferAsync();
             if(_sysLoad.TryGetValue(component.Message.Id, out var session))
                 session.Cts.Cancel();
         }
 
-        [ComponentCommand]
+        [ComponentCommand(AdminOnly = StaffOnlyLevel.FarmHand)]
         public static async Task SysLoadDismiss(SocketMessageComponent component) {
             if(_sysLoad.TryGetValue(component.Message.Id, out var session))
                 session.Cts.Cancel();

--- a/EGG9000.Bot/Services/CommandService.cs
+++ b/EGG9000.Bot/Services/CommandService.cs
@@ -157,6 +157,15 @@ namespace EGG9000.Bot.Services {
                 }
             }*/
             try {
+                // Discord gates slash/user commands by DefaultMemberPermissions, but applies no
+                // permission gating to component (button/select) or modal callbacks. The dispatcher
+                // must therefore enforce the required staff level itself for those interaction types,
+                // otherwise any member can replay a privileged customId. Slash/user commands keep
+                // relying on Discord's gating so per-guild permission customization still works.
+                if((arg is SocketMessageComponent || arg is SocketModal) && command.AdminOnly != StaffOnlyLevel.None && !HasStaffPermission(command.AdminOnly, arg.User)) {
+                    await arg.RespondAsync(text: "", embed: EmbedError("You do not have permission to use this control."), ephemeral: true);
+                    return;
+                }
                 semaphoreAcquired = await _semaphoreSlim.WaitAsync(TimeSpan.FromSeconds(2.5));
                 if(semaphoreAcquired) {
                     var parameters = new List<object>();
@@ -267,6 +276,21 @@ namespace EGG9000.Bot.Services {
         }
 
 
+
+        private static bool HasStaffPermission(StaffOnlyLevel level, IUser user) {
+            if(level == StaffOnlyLevel.None) return true;
+            if(user is not SocketGuildUser guildUser) return false;
+            var perms = guildUser.GuildPermissions;
+            if(perms.Administrator) return true;
+            var required = level switch {
+                StaffOnlyLevel.Admin => GuildPermission.Administrator,
+                StaffOnlyLevel.CluckingCoordinator => GuildPermission.ManageChannels,
+                StaffOnlyLevel.FarmHand => GuildPermission.CreatePrivateThreads,
+                StaffOnlyLevel.ChickenTender => GuildPermission.ModerateMembers,
+                _ => GuildPermission.UseApplicationCommands
+            };
+            return perms.Has(required);
+        }
 
         private static FauxSocketSlashCommandDataOption FindOption(string name, IList<FauxSocketSlashCommandDataOption> options) {
             var foundOption = options.FirstOrDefault(x => x.Name == name);
@@ -389,6 +413,15 @@ namespace EGG9000.Bot.Services {
 
             if(command.SubFunctions != null) {
                 command = command.SubFunctions.First(x => x.Name == arg.Data.Options.First().Name);
+            }
+
+            // Server-side backstop: Discord already hides staff commands from non-staff, so this only
+            // bites if a command is mis-registered or a guild grants it to a non-staff role. It stops
+            // sensitive handlers (member EID/EB enumeration, internal service names) from running for a
+            // user who lacks the command's required staff level.
+            if(command.AdminOnly != StaffOnlyLevel.None && !HasStaffPermission(command.AdminOnly, arg.User)) {
+                _ = arg.RespondAsync(System.Array.Empty<AutocompleteResult>());
+                return Task.CompletedTask;
             }
 
             var paremeter = command.Parameters.First(x => x.Name.Equals(arg.Data.Current.Name, StringComparison.OrdinalIgnoreCase));

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -176,18 +176,20 @@ namespace EGG9000.Common.Services {
                     }, _logger);
                     return;
                 }
-                dbuser.EggIncAccounts.ForEach(async account => {
+                var eiContracts = await db.CachedEiContractsAsync();
+                foreach(var account in dbuser.EggIncAccounts) {
                     var rawBackup = await EggIncApi.FirstContact(account.Id);
-                    if(rawBackup is null || rawBackup.Backup is null) return;
-                    var customBackup = new CustomBackup(rawBackup.Backup, await db.CachedEiContractsAsync(), account?.Backup ?? null);
+                    if(rawBackup is null || rawBackup.Backup is null) continue;
+                    var customBackup = new CustomBackup(rawBackup.Backup, eiContracts, account?.Backup ?? null);
                     account.Backup = customBackup?.Farms is not null ? customBackup : account.Backup;
-                });
+                }
                 if(dbuser.GuildId == 0 && await db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.GuildId == user.Guild.Id)) {
                     dbuser.GuildId = user.Guild.Id;
                 }
                 dbuser.UpdateAccounts();
                 await db.SaveChangesAsync();
-                var earningsBonus = dbuser.EggIncAccounts.Max(x => x.Backup.EarningsBonus);
+                var accountsWithBackup = dbuser.EggIncAccounts.Where(x => x.Backup is not null).ToList();
+                var earningsBonus = accountsWithBackup.Count > 0 ? accountsWithBackup.Max(x => x.Backup.EarningsBonus) : 0;
                 var role = await DiscordHelpers.CheckRoles(db, user.Guild, user, dbuser, _discord, null, [], _logger);
                 var roleText = role is not null ? $" You have been assigned the rank of {role?.Name} thanks to your EB of {earningsBonus.ToEggString()}" : "";
                 var response = await ChannelHelper.DetermineAndSend(_discord.Gateway, dbguild, GuildChannelType.General, new() { Text = $"Welcome back {user.Mention}!{roleText}" }, _logger);

--- a/EGG9000.Common/Consumers/RestartConsumer.cs
+++ b/EGG9000.Common/Consumers/RestartConsumer.cs
@@ -1,4 +1,6 @@
-﻿using MassTransit;
+﻿using EGG9000.Common.Helpers;
+
+using MassTransit;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
@@ -10,6 +12,10 @@ namespace EGG9000.Common.Consumers {
         private readonly ILogger<RestartConsumer> _logger = logger;
 
         public Task Consume(ConsumeContext<RestartMessage> context) {
+            if(!SecretsHelper.IsValidBusSecret(context.Message.Secret)) {
+                _logger.LogWarning("Rejected RestartMessage with invalid control secret (request ID {id})", context.RequestId);
+                return Task.CompletedTask;
+            }
             _logger.LogInformation("Restart Consumer called with request ID {id}", context.RequestId);
             Environment.ExitCode = 1;
             _applicationLifetime.StopApplication();
@@ -18,5 +24,7 @@ namespace EGG9000.Common.Consumers {
         }
     }
 
-    public class RestartMessage { }
+    public class RestartMessage {
+        public string Secret { get; set; } = SecretsHelper.BusControlSecret;
+    }
 }

--- a/EGG9000.Common/Consumers/ShutdownConsumer.cs
+++ b/EGG9000.Common/Consumers/ShutdownConsumer.cs
@@ -1,4 +1,6 @@
-﻿using MassTransit;
+﻿using EGG9000.Common.Helpers;
+
+using MassTransit;
 
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -13,6 +15,10 @@ namespace EGG9000.Common.Consumers {
         private readonly ILogger<ShutdownConsumer> _logger = logger;
 
         public Task Consume(ConsumeContext<ShutdownMessage> context) {
+            if(!SecretsHelper.IsValidBusSecret(context.Message.Secret)) {
+                _logger.LogWarning("Rejected ShutdownMessage with invalid control secret");
+                return Task.CompletedTask;
+            }
             var assemblyConfigurationAttribute = typeof(ShutdownConsumer).Assembly.GetCustomAttribute<AssemblyConfigurationAttribute>();
             var buildConfigurationName = assemblyConfigurationAttribute?.Configuration;
 
@@ -31,9 +37,11 @@ namespace EGG9000.Common.Consumers {
             var buildConfigurationName = assemblyConfigurationAttribute?.Configuration;
             Configuration = buildConfigurationName;
             ProcessId = Environment.ProcessId;
+            Secret = SecretsHelper.BusControlSecret;
         }
         public int ProcessId { get; set; }
         public string Configuration { get; set; }
+        public string Secret { get; set; }
 
     }
 

--- a/EGG9000.Common/Consumers/UpdateApiVersionsConsumer.cs
+++ b/EGG9000.Common/Consumers/UpdateApiVersionsConsumer.cs
@@ -1,4 +1,5 @@
 using EGG9000.Common.EggIncAPI;
+using EGG9000.Common.Helpers;
 
 using MassTransit;
 
@@ -12,6 +13,10 @@ namespace EGG9000.Common.Consumers {
 
         public Task Consume(ConsumeContext<UpdateApiVersionsMessage> context) {
             var m = context.Message;
+            if(!SecretsHelper.IsValidBusSecret(m.Secret)) {
+                _logger.LogWarning("Rejected UpdateApiVersionsMessage with invalid control secret");
+                return Task.CompletedTask;
+            }
             EggIncApi.SetVersions(m.ClientVersion, m.AppVersion, m.AppBuild);
             _logger.LogInformation("[ApiVersions] Applied client={client} version={version} build={build}", m.ClientVersion, m.AppVersion, m.AppBuild);
             return Task.CompletedTask;
@@ -22,5 +27,6 @@ namespace EGG9000.Common.Consumers {
         public uint ClientVersion { get; set; }
         public string AppVersion { get; set; }
         public string AppBuild { get; set; }
+        public string Secret { get; set; } = SecretsHelper.BusControlSecret;
     }
 }

--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -252,9 +252,11 @@ namespace EGG9000.Common.Database.Entities {
         public bool UpdateDMStatus(DiscordHelpersExt.DMResult dmResult) {
             switch(dmResult) {
                 case DiscordHelpersExt.DMResult.Success:
-                    if(DMSBlocked) DMSBlocked = false; return true;
+                    if(DMSBlocked) { DMSBlocked = false; return true; }
+                    return false;
                 case DiscordHelpersExt.DMResult.CannotSendToUser:
-                    if(!DMSBlocked) DMSBlocked = true; return true;
+                    if(!DMSBlocked) { DMSBlocked = true; return true; }
+                    return false;
                 default:
                     break;
             }

--- a/EGG9000.Common/Helpers/DockerSecretsHelper.cs
+++ b/EGG9000.Common/Helpers/DockerSecretsHelper.cs
@@ -65,10 +65,33 @@ namespace EGG9000.Common.Helpers
         /// </summary>
         public static string ApiSalt { get; private set; }
 
+        /// <summary>
+        /// Shared secret authenticating control messages on the RabbitMQ bus (Restart / Shutdown /
+        /// UpdateApiVersions). Loaded from Docker secret <c>bus_control_secret</c> or
+        /// <c>ConnectionStrings:BusControlSecret</c>. Null/empty disables enforcement (back-compat /
+        /// local dev) - set it on every instance to enforce.
+        /// </summary>
+        public static string BusControlSecret { get; private set; }
+
+        /// <summary>
+        /// Constant-time check of a control-message secret against <see cref="BusControlSecret"/>.
+        /// Returns true (no enforcement) when no secret is configured.
+        /// </summary>
+        public static bool IsValidBusSecret(string provided)
+        {
+            var expected = BusControlSecret;
+            if (string.IsNullOrEmpty(expected)) return true;
+            if (string.IsNullOrEmpty(provided)) return false;
+            return System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(
+                System.Text.Encoding.UTF8.GetBytes(expected),
+                System.Text.Encoding.UTF8.GetBytes(provided));
+        }
+
         public static void Initialize(IConfiguration config)
         {
             BotToken = GetConfigOrSecret(config, "ConnectionStrings:Token", "token");
             ApiSalt = GetConfigOrSecret(config, "ConnectionStrings:ApiSalt", "egg_inc_api_salt");
+            BusControlSecret = GetConfigOrSecret(config, "ConnectionStrings:BusControlSecret", "bus_control_secret");
         }
     }
 }

--- a/EGG9000.Common/Services/CommandAttributes.cs
+++ b/EGG9000.Common/Services/CommandAttributes.cs
@@ -31,9 +31,11 @@ namespace EGG9000.Common.Commands {
     }
     [AttributeUsage(AttributeTargets.Method)]
     public class ComponentCommandAttribute : System.Attribute {
+        public StaffOnlyLevel AdminOnly = StaffOnlyLevel.None;
     }
     [AttributeUsage(AttributeTargets.Method)]
     public class ModalAttribute : System.Attribute {
+        public StaffOnlyLevel AdminOnly = StaffOnlyLevel.None;
     }
 
     [AttributeUsage(AttributeTargets.Parameter)]
@@ -52,15 +54,19 @@ namespace EGG9000.Common.Commands {
     public class SlashCommandFunction : CommandFunctionBase {
         public SlashCommandAttribute Details { get; set; }
         public List<SlashCommandFunction> SubFunctions { get; set; }
+        public override StaffOnlyLevel AdminOnly => Details?.AdminOnly ?? StaffOnlyLevel.None;
     }
     public class UserCommandFunction : CommandFunctionBase {
         public UserCommandAttribute Details { get; set; }
+        public override StaffOnlyLevel AdminOnly => Details?.AdminOnly ?? StaffOnlyLevel.None;
     }
     public class ComponentCommandFunction : CommandFunctionBase {
         public ComponentCommandAttribute Details { get; set; }
+        public override StaffOnlyLevel AdminOnly => Details?.AdminOnly ?? StaffOnlyLevel.None;
     }
     public class ModalCommandFunction : CommandFunctionBase {
         public ModalAttribute Details { get; set; }
+        public override StaffOnlyLevel AdminOnly => Details?.AdminOnly ?? StaffOnlyLevel.None;
     }
 
 
@@ -68,6 +74,7 @@ namespace EGG9000.Common.Commands {
         public MethodInfo MethodInfo { get; set; }
         public ParameterInfo[] Parameters { get; set; }
         public string Name { get; set; }
+        public virtual StaffOnlyLevel AdminOnly => StaffOnlyLevel.None;
     }
 
 

--- a/EGG9000.Site/Controllers/DonationController.cs
+++ b/EGG9000.Site/Controllers/DonationController.cs
@@ -1,20 +1,29 @@
-﻿using Discord.WebSocket;
+using Discord.WebSocket;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Stripe;
 using Stripe.Checkout;
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace EGG9000.Site.Controllers {
     [AllowAnonymous]
-    public class DonationController(ApplicationDbContext db, DiscordSocketClient discord) : Controller {
+    public class DonationController(ApplicationDbContext db, DiscordSocketClient discord, IConfiguration configuration) : Controller {
         private readonly ApplicationDbContext _db = db;
         private readonly DiscordSocketClient _discord = discord;
+        private readonly IConfiguration _configuration = configuration;
+
+        private const ulong PalaceGuildId = 656455567858073601;
+        private const ulong DonorRoleId = 785575541469085746;
+        private const ulong LiveAnnounceChannelId = 656455568353132546;
+        private const ulong TestAnnounceChannelId = 777303939442802710;
 
         public IActionResult Index() {
             return View();
@@ -24,92 +33,66 @@ namespace EGG9000.Site.Controllers {
             return View();
         }
 
-        public async Task<IActionResult> Endpoint([FromBody] EndPointObject body) {
-            SocketGuildUser discordUser = null;
-            var guild = _discord.Guilds.First(x => x.Id == 656455567858073601);
+        [HttpPost]
+        public async Task<IActionResult> Endpoint() {
+            var apiKey = SecretsHelper.GetConfigOrSecret(_configuration, "ConnectionStrings:StripeApiKey", "stripe_api_key");
+            var webhookSecret = SecretsHelper.GetConfigOrSecret(_configuration, "ConnectionStrings:StripeWebhookSecret", "stripe_webhook_secret");
 
+            // No key / signing secret means donations are not configured (e.g. inactive Stripe account).
+            // Reject rather than trusting the request body.
+            if(string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(webhookSecret)) {
+                return NotFound();
+            }
+            StripeConfiguration.ApiKey = apiKey;
 
-            var test = !body.livemode;
-            Stripe.StripeConfiguration.ApiKey = test ? "sk_test_51Huh4PFPOewxUi5tQQHemFZFQ4x5CJ7edl8MmlS4QkIr2hFXcUSlp5DGL406mlg2MiJO6utmgHBDv5vL9Kgyqp5500L5GcePwf" : "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";
-            var lineItems = new SessionLineItemService().List(body.data.@object.id, new SessionLineItemListOptions { Limit = 20 });
+            var json = await new StreamReader(Request.Body).ReadToEndAsync();
+            Stripe.Event stripeEvent;
+            try {
+                // Verifies the Stripe-Signature header against the webhook signing secret. Throws on
+                // a forged/replayed/tampered payload, which is the only authentication this endpoint has.
+                stripeEvent = EventUtility.ConstructEvent(json, Request.Headers["Stripe-Signature"], webhookSecret);
+            } catch(StripeException) {
+                return BadRequest();
+            }
+
+            if(stripeEvent.Type != "checkout.session.completed" || stripeEvent.Data.Object is not Session session) {
+                return Ok();
+            }
+
+            var guild = _discord.Guilds.FirstOrDefault(x => x.Id == PalaceGuildId);
+            if(guild is null) return Ok();
+
+            var lineItems = new SessionLineItemService().List(session.Id, new SessionLineItemListOptions { Limit = 20 });
             var donationType = string.Join("/", lineItems.Select(x => x.Description));
-            if(!string.IsNullOrWhiteSpace(body.data.@object.client_reference_id)) {
-                var donation = new Donation {
-                    UserId = Guid.Parse(body.data.@object.client_reference_id),
-                    Amount = body.data.@object.amount_total / 100,
-                    When = DateTimeOffset.FromUnixTimeSeconds(body.created), Type = donationType
-                };
-                _db.Donations.Add(donation);
+            var amount = (session.AmountTotal ?? 0) / 100;
 
+            SocketGuildUser discordUser = null;
+            if(!string.IsNullOrWhiteSpace(session.ClientReferenceId) && Guid.TryParse(session.ClientReferenceId, out var userId)) {
+                _db.Donations.Add(new Donation {
+                    UserId = userId,
+                    Amount = amount,
+                    When = new DateTimeOffset(DateTime.SpecifyKind(stripeEvent.Created, DateTimeKind.Utc)),
+                    Type = donationType
+                });
                 await _db.SaveChangesAsync();
 
-                var dbuser = await _db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.Id == Guid.Parse(body.data.@object.client_reference_id));
-                discordUser = guild.Users.FirstOrDefault(x => x.Id == dbuser.DiscordId);
-                var role = guild.Roles.FirstOrDefault(x => x.Id == 785575541469085746);
-                if(role != null) {
-                    _ = discordUser.AddRoleAsync(role).ConfigureAwait(false);
+                var dbuser = await _db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.Id == userId);
+                if(dbuser is not null) {
+                    discordUser = guild.Users.FirstOrDefault(x => x.Id == dbuser.DiscordId);
+                    var role = guild.Roles.FirstOrDefault(x => x.Id == DonorRoleId);
+                    if(discordUser is not null && role is not null) {
+                        _ = discordUser.AddRoleAsync(role).ConfigureAwait(false);
+                    }
                 }
             }
-            //656455568353132546 general
 
-            var channelId = test ? 777303939442802710 : (ulong)656455568353132546;
-            var channel = guild.TextChannels.First(x => x.Id == channelId);
-            _ = channel.SendMessageAsync($"{(discordUser == null ? "Anonymous" : discordUser.Mention)} donated {body.data.@object.amount_total / 100:C0} USD to a {donationType}. Thank you for your support! {(body.livemode ? "" : "**TEST MODE** ")}");
+            var channelId = session.Livemode ? LiveAnnounceChannelId : TestAnnounceChannelId;
+            var channel = guild.TextChannels.FirstOrDefault(x => x.Id == channelId);
+            if(channel is not null) {
+                _ = channel.SendMessageAsync($"{(discordUser == null ? "Anonymous" : discordUser.Mention)} donated {amount:C0} USD to a {donationType}. Thank you for your support! {(session.Livemode ? "" : "**TEST MODE** ")}");
+            }
 
-            return Content("");
+            return Ok();
         }
-    }
-
-    public class TotalDetails {
-        public int amount_discount { get; set; }
-        public int amount_tax { get; set; }
-    }
-
-    public class Object {
-        public string id { get; set; }
-        public string @object { get; set; }
-        public object allow_promotion_codes { get; set; }
-        public int amount_subtotal { get; set; }
-        public int amount_total { get; set; }
-        public object billing_address_collection { get; set; }
-        public string cancel_url { get; set; }
-        public string client_reference_id { get; set; }
-        public string currency { get; set; }
-        public string customer { get; set; }
-        public object customer_email { get; set; }
-        public bool livemode { get; set; }
-        public object locale { get; set; }
-        public string mode { get; set; }
-        public string payment_intent { get; set; }
-        public List<string> payment_method_types { get; set; }
-        public string payment_status { get; set; }
-        public object setup_intent { get; set; }
-        public object shipping { get; set; }
-        public object shipping_address_collection { get; set; }
-        public object submit_type { get; set; }
-        public object subscription { get; set; }
-        public string success_url { get; set; }
-        public TotalDetails total_details { get; set; }
-    }
-
-    public class Data {
-        public Object @object { get; set; }
-    }
-
-    public class Request {
-        public object id { get; set; }
-        public object idempotency_key { get; set; }
-    }
-
-    public class EndPointObject {
-        public string id { get; set; }
-        public string @object { get; set; }
-        public string api_version { get; set; }
-        public int created { get; set; }
-        public Data data { get; set; }
-        public bool livemode { get; set; }
-        public int pending_webhooks { get; set; }
-        public Request request { get; set; }
-        public string type { get; set; }
     }
 }

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -36,8 +36,10 @@ using NLog.Web;
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.IO.Compression;
 using System.Net;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 
@@ -61,11 +63,33 @@ var app = builder.Build();
 // the Discord OAuth callback is built as https, not the proxy's internal http hop.
 app.UseForwardedHeaders();
 
+// Security response headers on every response (incl. static files). Set before the rest of the
+// pipeline so they apply regardless of which handler produces the response. CSP is report-only
+// for now so violations are observable (browser console) without breaking Stripe.js / Discord
+// OAuth / existing inline assets - tighten to enforcing once the report is clean.
+app.Use(async (context, next) => {
+    var headers = context.Response.Headers;
+    headers["X-Content-Type-Options"] = "nosniff";
+    headers["X-Frame-Options"] = "DENY";
+    headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+    headers["Content-Security-Policy-Report-Only"] =
+        "default-src 'self'; " +
+        "script-src 'self' 'unsafe-inline' https://js.stripe.com; " +
+        "style-src 'self' 'unsafe-inline'; " +
+        "img-src 'self' data: https:; " +
+        "font-src 'self' data:; " +
+        "frame-src https://js.stripe.com https://hooks.stripe.com; " +
+        "connect-src 'self' https://api.stripe.com; " +
+        "frame-ancestors 'none'";
+    await next();
+});
+
 if(app.Environment.IsDevelopment()) {
     app.UseDeveloperExceptionPage();
     app.UseMigrationsEndPoint();
 } else {
     app.UseExceptionHandler("/Home/Error");
+    app.UseHsts();
 }
 
 app.UseHttpsRedirection();
@@ -74,7 +98,6 @@ app.UseStaticFiles(new StaticFileOptions {
 });
 
 app.UseRouting();
-app.UseCors("SiteCorsPolicy");
 app.UseResponseCaching();
 app.UseAuthentication(); 
 app.UseAuthorization();
@@ -98,7 +121,18 @@ app.Run();
 
 
 void ConfigureServices(IServiceCollection services, IConfiguration Configuration) {
-    services.AddDataProtection().PersistKeysToDbContext<ApplicationDbContext>().SetApplicationName("EGG9000");
+    var dataProtection = services.AddDataProtection().PersistKeysToDbContext<ApplicationDbContext>().SetApplicationName("EGG9000");
+    // Keys are persisted to the DB; encrypt them at rest with a key-encryption certificate so a DB
+    // leak cannot be used to forge auth/OAuth cookies. The PFX lives outside the DB (Docker secret /
+    // mounted file). If not configured the keys stay unencrypted - acceptable for local dev only.
+    var dpCertPath = SecretsHelper.GetConfigOrSecret(Configuration, "DataProtection:CertPath", "dataprotection_cert_path");
+    var dpCertPassword = SecretsHelper.GetConfigOrSecret(Configuration, "DataProtection:CertPassword", "dataprotection_cert_password");
+    if(!string.IsNullOrEmpty(dpCertPath) && File.Exists(dpCertPath)) {
+        var dpCert = X509CertificateLoader.LoadPkcs12FromFile(dpCertPath, dpCertPassword);
+        dataProtection.ProtectKeysWithCertificate(dpCert);
+    } else {
+        logger.Warn("DataProtection key-encryption certificate not configured (DataProtection:CertPath / dataprotection_cert_path). Data-protection keys are persisted UNENCRYPTED in the database.");
+    }
     services.AddDbContext<ApplicationDbContext>(
         options => options.UseNpgsql(Configuration.GetConnectionString("DefaultConnection"), x => x.CommandTimeout(30)),
         contextLifetime: ServiceLifetime.Scoped,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,6 @@ services:
       ASPNETCORE_URLS: http://+:5013
       SITE_ACTIVE: "false"
       SITE_COLOR: blue
-      Docker__Host: unix:///var/run/docker.sock
       # CIDR(s) of the TLS-terminating reverse proxy (proxy-v6 network) so X-Forwarded-Proto is
       # trusted. Comma-separated; IPv4 and IPv6 both supported.
       TRUSTED_PROXY_NETWORKS: ""
@@ -78,14 +77,11 @@ services:
       - egg9000_network
     ports:
       - "5013:5013"
-    volumes:
-      # Correct syntax for Docker Desktop on Windows with Linux containers
-      - /var/run/docker.sock:/var/run/docker.sock
-    # Grant access to Docker socket (choose one):
-    # Option A: Run as root (simpler but less secure)
-    user: root
-    # Option B: Add to docker group (more secure, requires group ID)
-    # user: "1000:999"  # Replace 999 with your docker group ID
+    # The Docker socket is intentionally NOT mounted and the container does NOT run as root.
+    # No code on this branch uses the Docker API. If bot lifecycle management is reintroduced,
+    # do NOT mount /var/run/docker.sock directly into this public container - front it with a
+    # read/verb-limited docker-socket-proxy and point the client at tcp://docker-socket-proxy:2375.
+    # See docs/audit/infra.md (H1).
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -107,9 +103,12 @@ services:
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-guest}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-change_me}
+    # Bot and site reach the broker by service name on egg9000_network, so the broker does not
+    # need a public host port. Bind to loopback only - AMQP and the admin UI must not be exposed
+    # on 0.0.0.0. Use an SSH tunnel to reach the management UI. See docs/audit/infra.md (H2).
     ports:
-      - "5672:5672"
-      - "15672:15672"
+      - "127.0.0.1:5672:5672"
+      - "127.0.0.1:15672:15672"
     networks:
       - egg9000_network
     healthcheck:


### PR DESCRIPTION
Closes #293
Closes #294
Closes #295 

- Stripe webhook hardening
- Stripe keys -> secrets
- Component & Modal authorization through interactions
- `DataProtection` key encryption
- Removed Docker socket from site
- RabbitMQ localhost-only ports
- Bus message authentication
- Security response headers
- Autocomplete permission backstop
- UserJoined race/NPE fix
- `IServiceScope` leak fix
- `UpdateDMStatus` braces fix
- Removed dead CORS