### PR TITLE
Chore: Secrets Scan Action + `PingOnCoopCreatedEvenIfJoined`

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -9,6 +9,10 @@ permissions:
 
 jobs:
   gitleaks:
+    # gitleaks-action needs the org GITLEAKS_LICENSE secret, which is unavailable to PRs from forks.
+    # Skip there (the check simply won't appear) so contributor fork PRs don't show a red X; ci.yml
+    # is the required gate, not this. Still runs on org-repo branches and pushes.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -531,9 +531,14 @@ namespace EGG9000.Bot.Automated.Coops {
                     var user = users.FirstOrDefault(x => x.User.Id == xref.UserId);
                     if(xref.CoopSetting is null && user is not null) {
                         xref.CoopSetting = new CoopSetting(xref, user.User, dbGuild);
-                        if(xref.CoopSetting.PingOnCoopCreated && !xref.JoinedCoop) {
+                        // PingOnCoopCreated: only when not already joined. PingOnCoopCreatedEvenIfJoined:
+                        // regardless of join state (restores the pre-fix behavior for users who opt in).
+                        var pingEvenIfJoined = xref.CoopSetting.PingOnCoopCreatedEvenIfJoined;
+                        var pingIfNotJoined = xref.CoopSetting.PingOnCoopCreated && !xref.JoinedCoop;
+                        if(pingEvenIfJoined || pingIfNotJoined) {
                             await SendDMWarning(_db, parentGuild.GetUser(user.User.DiscordId), coopThread, "Co-op has been created", coop);
                             xref.CoopSetting.PingOnCoopCreated = false;
+                            xref.CoopSetting.PingOnCoopCreatedEvenIfJoined = false;
                         }
                         xref.UpdateCoopSetting();
                     }

--- a/EGG9000.Bot/Commands/CoopSettings.cs
+++ b/EGG9000.Bot/Commands/CoopSettings.cs
@@ -76,7 +76,7 @@ namespace EGG9000.Bot.Commands {
                 var guildOverride = guild.GetCoopSetting(coopSettingEnum);
                 var nextToText = guildOverride.Locked ? (guildOverride.Enabled ? "✅ Yes **(Locked by Server)**" : "❌ No **(Locked by Server)**") : (coopSetting[option.Property] ? "✅ Yes" : "❌ No");
 
-                if(coopOnly && option.Property == "PingOnCoopCreated")
+                if(coopOnly && (option.Property == "PingOnCoopCreated" || option.Property == "PingOnCoopCreatedEvenIfJoined"))
                     continue;
                 eBuilder.AddField($"{option.Property}: {nextToText}", option.Description);
                 if(!guildOverride.Locked) {

--- a/EGG9000.Common.Test/CoopSettingResolutionTests.cs
+++ b/EGG9000.Common.Test/CoopSettingResolutionTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using EGG9000.Common.Database.Entities;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Common.Test {
+    /// <summary>
+    /// Locks the semantics of the enum-driven CoopSetting override resolution: user defaults,
+    /// server force-enable, the precedence of server force-disable over everything, and the legacy
+    /// per-xref opt-ins.
+    /// </summary>
+    [TestClass]
+    public class CoopSettingResolutionTests {
+        private static Guild GuildWith(params ServerCoopSetting[] settings) =>
+            new() { CoopSettings = settings.ToList() };
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void User_default_enables_setting() {
+            var user = new DBUser { CoopSetting = new CoopSetting { PingOnMessage = true } };
+            var resolved = new CoopSetting(new UserCoopXref(), user, new Guild());
+            Assert.IsTrue(resolved.PingOnMessage);
+            Assert.IsFalse(resolved.PingOnFull);
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void Guild_force_enable_beats_user_off() {
+            var user = new DBUser { CoopSetting = new CoopSetting() };
+            var guild = GuildWith(new ServerCoopSetting { CoopSetting = GuildCoopSetting.PingOnFull, Enabled = true, Locked = true });
+            var resolved = new CoopSetting(new UserCoopXref(), user, guild);
+            Assert.IsTrue(resolved.PingOnFull);
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void Guild_force_disable_beats_user_and_xref() {
+            var user = new DBUser { CoopSetting = new CoopSetting { PingOnFull = true } };
+            var xref = new UserCoopXref { PingOnFull = true };
+            var guild = GuildWith(new ServerCoopSetting { CoopSetting = GuildCoopSetting.PingOnFull, Enabled = false, Locked = true });
+            var resolved = new CoopSetting(xref, user, guild);
+            Assert.IsFalse(resolved.PingOnFull);
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void Xref_optins_layer_on_top() {
+            var user = new DBUser { CoopSetting = new CoopSetting() };
+            var xref = new UserCoopXref { PingOnHighestEB = true, PingOnFinished = true };
+            var resolved = new CoopSetting(xref, user, new Guild());
+            Assert.IsTrue(resolved.PingOnHighestEB);
+            // PingOnEveryoneCheckedIn legacy-rides on xref.PingOnFinished.
+            Assert.IsTrue(resolved.PingOnEveryoneCheckedIn);
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void PingOnCoopCreatedEvenIfJoined_is_distinct_from_PingOnCoopCreated() {
+            var user = new DBUser { CoopSetting = new CoopSetting { PingOnCoopCreatedEvenIfJoined = true } };
+            var resolved = new CoopSetting(new UserCoopXref(), user, new Guild());
+            Assert.IsTrue(resolved.PingOnCoopCreatedEvenIfJoined);
+            Assert.IsFalse(resolved.PingOnCoopCreated);
+        }
+    }
+}

--- a/EGG9000.Common/Database/Entities/Guild.cs
+++ b/EGG9000.Common/Database/Entities/Guild.cs
@@ -161,12 +161,14 @@ namespace EGG9000.Common.Database.Entities {
         PingOnEveryoneCheckedIn = 3,
         [Description("Any non-bot message is sent in channel")]
         PingOnMessage = 4,
-        [Description("Additional DM alongside the standard @mention in the co-op channel")]
+        [Description("DM when your co-op is created, only if you have not already joined")]
         PingOnCoopCreated = 5,
         [Description("Get notified when someone adds/removes a Tachyon Deflector")]
         PingOnTachyonChange = 6,
         [Description("Get notified when your co-op will complete as soon as everyone checks in")]
-        PingOnCompleteOnCheckIn = 7
+        PingOnCompleteOnCheckIn = 7,
+        [Description("DM when your co-op is created, even if you have already joined")]
+        PingOnCoopCreatedEvenIfJoined = 8
     }
 
     [NotMapped]

--- a/EGG9000.Common/Database/Entities/UserCoopXref.cs
+++ b/EGG9000.Common/Database/Entities/UserCoopXref.cs
@@ -202,6 +202,8 @@ namespace EGG9000.Common.Database.Entities {
         public bool PingOnTachyonChange { get; set; }
         [Key(7)]
         public bool PingOnCompleteOnCheckIn { get; set; }
+        [Key(8)]
+        public bool PingOnCoopCreatedEvenIfJoined { get; set; }
 
         [IgnoreMember]
         public bool this[string propertyName] {
@@ -222,30 +224,32 @@ namespace EGG9000.Common.Database.Entities {
         }
 
         public CoopSetting(UserCoopXref xref, DBUser user, Guild userGuild) {
-            if(user.CoopSetting is null)
-                user.CoopSetting = new CoopSetting();
+            user.CoopSetting ??= new CoopSetting();
 
-            PingOnFull = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnFull) || user.CoopSetting.PingOnFull || xref.PingOnFull;
-            PingOnHighestEB = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnHighestEB) || user.CoopSetting.PingOnHighestEB || xref.PingOnHighestEB;
-            PingOnFinished = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnFinished) || user.CoopSetting.PingOnFinished;
-            PingOnEveryoneCheckedIn = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnEveryoneCheckedIn) ||  user.CoopSetting.PingOnEveryoneCheckedIn || xref.PingOnFinished;
-            PingOnMessage = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnMessage) ||  user.CoopSetting.PingOnMessage;
-            PingOnCoopCreated = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnCoopCreated) || user.CoopSetting.PingOnCoopCreated;
-            PingOnTachyonChange = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnTachyonChange) || user.CoopSetting.PingOnTachyonChange;
-            PingOnCompleteOnCheckIn = userGuild.IsLockedAndEnabled(GuildCoopSetting.PingOnCompleteOnCheckIn) || user.CoopSetting.PingOnCompleteOnCheckIn;
+            // Resolve every ping setting uniformly off the GuildCoopSetting enum: a server
+            // force-enable or the user's saved default turns it on. New settings need no wiring here -
+            // just a matching CoopSetting property and enum value (settings without a property, if
+            // any, are skipped, mirroring the settings menu).
+            foreach(var setting in Enum.GetValues<GuildCoopSetting>()) {
+                var name = setting.ToString();
+                if(typeof(CoopSetting).GetProperty(name) is null)
+                    continue;
+                this[name] = userGuild.IsLockedAndEnabled(setting) || user.CoopSetting[name];
+            }
 
-            var disableOverrides = Enum.GetValues(typeof(GuildCoopSetting))
-                .Cast<GuildCoopSetting>()
-                .ToDictionary(setting => setting, userGuild.IsLockedAndDisabled);
+            // Legacy per-xref opt-ins layered on top of the user/guild defaults.
+            PingOnFull |= xref.PingOnFull;
+            PingOnHighestEB |= xref.PingOnHighestEB;
+            PingOnEveryoneCheckedIn |= xref.PingOnFinished;
 
-            if(disableOverrides[GuildCoopSetting.PingOnFull]) PingOnFull = false;
-            if(disableOverrides[GuildCoopSetting.PingOnHighestEB]) PingOnHighestEB = false;
-            if(disableOverrides[GuildCoopSetting.PingOnFinished]) PingOnFinished = false;
-            if(disableOverrides[GuildCoopSetting.PingOnEveryoneCheckedIn]) PingOnEveryoneCheckedIn = false;
-            if(disableOverrides[GuildCoopSetting.PingOnMessage]) PingOnMessage = false;
-            if(disableOverrides[GuildCoopSetting.PingOnCoopCreated]) PingOnCoopCreated = false;
-            if(disableOverrides[GuildCoopSetting.PingOnTachyonChange]) PingOnTachyonChange = false;
-            if(disableOverrides[GuildCoopSetting.PingOnCompleteOnCheckIn]) PingOnCompleteOnCheckIn = false;
+            // A server force-disable wins over user defaults and the per-xref opt-ins above.
+            foreach(var setting in Enum.GetValues<GuildCoopSetting>()) {
+                var name = setting.ToString();
+                if(typeof(CoopSetting).GetProperty(name) is null)
+                    continue;
+                if(userGuild.IsLockedAndDisabled(setting))
+                    this[name] = false;
+            }
         }
     }
 }


### PR DESCRIPTION
- Fixed the secrets scan action failing due to cross-repo scopes correctly rejecting secret usage
- When we fixed the timing bug around `PingOnCoopCreated`, there were some people who were used to getting the pings, even if they had already joined. So, added that as a separate option.