### PR TITLE
Feat: More Granular Admin Roles

### DIFF
--- a/EGG9000.Site/Controllers/ContractController.cs
+++ b/EGG9000.Site/Controllers/ContractController.cs
@@ -232,7 +232,7 @@ namespace EGG9000.Site.Controllers {
         }
 
 
-        [Authorize(Roles = "Admin,GuildAdmin")]
+        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin")]
         public async Task<IActionResult> MoveToCoop([FromQuery] Guid CoopId, [FromQuery] Guid UserId, [FromQuery] string EggIncId) {
             var targetCoop = await _db.Coops.Include(x => x.Contract).AsQueryable().FirstAsync(x => x.Id == CoopId);
             var dbuser = await _db.DBUsers.AsQueryable().FirstAsync(x => x.Id == UserId);
@@ -270,7 +270,7 @@ namespace EGG9000.Site.Controllers {
             });
         }
 
-        [Authorize(Roles = "Admin,GuildAdmin")]
+        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin")]
         public async Task<IActionResult> RemoveXref([FromBody] RemoveXrefModel model) {
             var xref = await _db.UserCoopXrefs.AsQueryable().FirstOrDefaultAsync(x => x.UserId == model.UserId && x.CoopId == model.CoopId && x.EggIncId == model.EggIncId);
             if(xref == null) {

--- a/EGG9000.Site/Controllers/HomeController.cs
+++ b/EGG9000.Site/Controllers/HomeController.cs
@@ -683,7 +683,8 @@ namespace EGG9000.Site.Controllers {
             return View();
         }
 
-        [Authorize(Roles = "Admin,GuildAdmin")]
+        // Read tier: leaderboard name-links land here and redirect to MyFarms.ViewUser (also read tier).
+        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin,GuildReadOnlyAdmin")]
         public async Task<IActionResult> ViewUser(Guid id) {
             var user = await _db.DBUsers.Include(x => x.UserCoopXrefs).ThenInclude(x => x.Coop).FirstOrDefaultAsync(x => x.Id == id);
             return RedirectToAction("ViewUser", "MyFarms", new { discordId = user.DiscordId });

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -67,7 +67,7 @@ namespace EGG9000.Site.Controllers {
             return await ViewUser(ulong.Parse(logins.First().ProviderKey));
         }
 
-        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin")]
+        [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin,GuildReadOnlyAdmin")]
         public async Task<IActionResult> ViewUser(ulong discordId) {
 
 

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -72,6 +72,16 @@ using (var migrateScope = app.Services.CreateScope())
 }
 #endif
 
+// Ensure the read-only staff role exists. Site roles are granted by hand in the admin Permissions UI,
+// so the IdentityRole row must be present before an admin can assign it. Idempotent: creates only when
+// missing, so it is safe to run on every startup (incl. dev against the live DB).
+using (var roleScope = app.Services.CreateScope()) {
+    var roleManager = roleScope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+    if(!await roleManager.RoleExistsAsync("GuildReadOnlyAdmin")) {
+        await roleManager.CreateAsync(new IdentityRole("GuildReadOnlyAdmin"));
+    }
+}
+
 // Must run before any middleware that reads the request scheme/host (HTTPS redirect, auth,
 // OAuth redirect_uri generation). Honors X-Forwarded-Proto from the TLS-terminating proxy so
 // the Discord OAuth callback is built as https, not the proxy's internal http hop.

--- a/EGG9000.Site/Views/Contract/Day1Coops.cshtml
+++ b/EGG9000.Site/Views/Contract/Day1Coops.cshtml
@@ -5,7 +5,8 @@
     Guild dbguild = ViewBag.DBGuild;
     SocketGuild guild = ViewBag.Guild;
     var contract = (ViewBag.Contract as Contract).Details;
-    var isLesserAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin");
+    // isLesserAdmin = read/staff tier (read-only data exposure); isAdmin = write tier (start/reload buttons).
+    var isLesserAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
     var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
     var boardingGroups = Model.coopGroups.GroupBy(x => x.BoardingGroup).Select(x => new
     {

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -18,13 +18,15 @@
 
     var count = currentCoops.Count;
     var ebrgx = new Regex(@"\(.+?\)");
-    // LesserAdmins are intentionally excluded: on this page admin gates coop names, member ids, the
-    // remove (X) button and move controls. The backend move/remove endpoints already reject LesserAdmin,
-    // so showing them the controls only leaks coop names and dangles dead buttons.
-    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
+    // Two staff tiers gate this page. isAdmin = write tier (remove users from coops) - global Admins,
+    // guild admins, and GuildLesserAdmin (FH/CC staff). isStaff = read tier - everyone in isAdmin plus
+    // GuildReadOnlyAdmin, the read-only CT learners who get coop names, thread links and the spots panel
+    // but no write controls. Member discord/egg ids and the X button stay on isAdmin.
+    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin");
+    var isStaff = isAdmin || User.IsInRole("GuildReadOnlyAdmin");
 
     var activeCoops = currentCoops.Select(c => new {
-        Name = (isAdmin || c.CoopParticipants.Any(u => u.DiscordUser?.Id.ToString() == discordId)) ? c.Coop.Name : "",
+        Name = (isStaff || c.CoopParticipants.Any(u => u.DiscordUser?.Id.ToString() == discordId)) ? c.Coop.Name : "",
         c.Coop.ContractID,
         CurrentCoop = c.CoopParticipants.Any(x => x.DiscordUser?.Id.ToString() == discordId),
         Status = c.Coop.Finished ? "Finished" : c.TimeRemaining < TimeSpan.Zero ? "Complete once everyone checks in" : $"Time to complete {c.TimeRemaining.Humanize(precision: 2).ShortenTime()}",
@@ -228,7 +230,7 @@
         }
 
     </div>
-    @if(isAdmin && !isSolo) {
+    @if(isStaff && !isSolo) {
     <div style="float: right;">
         <table>
             <tr>
@@ -245,12 +247,12 @@
     <div style="clear: both;"></div>
     <div class="row scrollable">
         <div class="col-sm" ng-if="ActiveCoops.length > 0">
-            <h2>Active Coops 
-            @if(isAdmin) {
+            <h2>Active Coops
+            @if(isStaff) {
             <span  class="btn btn-sm btn-primary" ng-click="ToggleAll()">Toggle All</span>
             }
             </h2>
-            @if(isAdmin) {
+            @if(isStaff) {
             <p ng-if>
                 Note: The co-ops are sorted such that the top ones listed have spots available with the soonest ending on top.
             </p>
@@ -258,15 +260,15 @@
             <div class="card" ng-repeat="coop in ActiveCoops" ng-class="{ CurrentCoop: coop.CurrentCoop}">
                 <div style="position: relative; top: -20px;" id="{{coop.Name}}" ng-if="coop.CurrentCoop"></div>
                 <h5 class="card-header" ng-click="coop.Hide = !coop.Hide">
-                    <a ng-click="$event.stopPropagation();" ng-if="IsAdmin || coop.CurrentCoop" ng-href="/coop/{{coop.ContractID}}/{{coop.Name}}">{{coop.Name}}</a>
+                    <a ng-click="$event.stopPropagation();" ng-if="IsStaff || coop.CurrentCoop" ng-href="/coop/{{coop.ContractID}}/{{coop.Name}}">{{coop.Name}}</a>
 
-                    <a ng-click="$event.stopPropagation();" ng-if="(IsAdmin || coop.CurrentCoop) && !coop.DeletedChannel" ng-href="discord://discordapp.com/channels/{{coop.OverflowGuildId}}/{{coop.DiscordChannelId}}/"><img src="/images/discordicon.png" style="max-height: 1em;" /></a>
+                    <a ng-click="$event.stopPropagation();" ng-if="(IsStaff || coop.CurrentCoop) && !coop.DeletedChannel" ng-href="discord://discordapp.com/channels/{{coop.OverflowGuildId}}/{{coop.DiscordChannelId}}/"><img src="/images/discordicon.png" style="max-height: 1em;" /></a>
 
                     <span style="font-size: 0;"> - {{coop.MaxSize - coop.Users.length}} spot{{coop.MaxSize - coop.Users.length > 1 ? 's' : ''}}</span>
 
-                    <div ng-if="!IsAdmin">Co-op</div>
+                    <div ng-if="!IsStaff">Co-op</div>
                     <span style="user-select: none;">{{coop.Status}}</span>
-                    <abbr ng-if="IsAdmin" style="user-select: none;">
+                    <abbr ng-if="IsStaff" style="user-select: none;">
                         {{coop.Users.length}}/{{coop.MaxSize}}&nbsp;
                     </abbr>
                 </h5>
@@ -484,7 +486,9 @@
                 }
             ])
             .controller('Page', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
+                // IsAdmin gates write actions; IsStaff gates read-only display (names, links, counts).
                 $scope.IsAdmin = @JsonConvert.SerializeObject(isAdmin);
+                $scope.IsStaff = @JsonConvert.SerializeObject(isStaff);
 
                 $scope.ActiveCoops = @Html.Raw(JsonConvert.SerializeObject(activeCoops));
                 $scope.EmptyCoops = [];

--- a/EGG9000.Site/Views/Contract/Index.cshtml
+++ b/EGG9000.Site/Views/Contract/Index.cshtml
@@ -1,7 +1,8 @@
 ﻿@model (List<EGG9000.Common.Database.Entities.GuildContract> Contracts, Guild DbGuild )
 @{
     ViewData["Title"] = "Contracts";
-    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin");
+    // Read/staff tier - gates only the recent-scores-grid button (a read-only view).
+    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
 }
 
 @if (isAdmin || (Model.DbGuild?.PublicScoreGrid ?? false))

--- a/EGG9000.Site/Views/Home/CSLeaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/CSLeaderboard.cshtml
@@ -8,7 +8,8 @@
 	var discordId = claimsIdentity.Claims.First(x => x.Type == "DiscordId").Value;
 
 	var myAccounts = Model.Where(x => x.DiscordUser.Id.ToString() == discordId);
-	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
+	// Read/staff tier - gates only the clickable player-name link to MyFarms on this read-only page.
+	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
 }
 
 

--- a/EGG9000.Site/Views/Home/Coop.cshtml
+++ b/EGG9000.Site/Views/Home/Coop.cshtml
@@ -33,7 +33,8 @@
 	var projectPercentWidth = Math.Min(projectPercent, 100) - percent;
 	var projectPercentEveryoneWidth = Math.Min(projectPercentEveryone, 100) - projectPercentWidth - percent;
 
-	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
+	// Read/staff tier - gates read-only detail column + MyFarms lookup link on this read-only page.
+	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
 }
 
 

--- a/EGG9000.Site/Views/Home/CraftingLevelLeaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/CraftingLevelLeaderboard.cshtml
@@ -8,7 +8,8 @@
     var discordId = claimsIdentity.Claims.First(x => x.Type == "DiscordId").Value;
 
     var myAccounts = Model.Where(x => x.DiscordUser.Id.ToString() == discordId);
-    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
+    // Read/staff tier - gates only the clickable player-name link to MyFarms on this read-only page.
+    var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
 }
 
 @if (myAccounts.Count() == 1)

--- a/EGG9000.Site/Views/Home/Leaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/Leaderboard.cshtml
@@ -7,7 +7,8 @@
 	var discordId = claimsIdentity.Claims.First(x => x.Type == "DiscordId").Value;
 
 	var myAccounts = Model.Where(x => x.DiscordUser.Id.ToString() == discordId);
-	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
+	// Read/staff tier - gates only the clickable player-name link to MyFarms on this read-only page.
+	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
 }
 
 

--- a/EGG9000.Site/Views/MyFarms/-ContractHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ContractHistory.cshtml
@@ -5,7 +5,9 @@
 @{
 	var backup = Model.backup;
 	var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
-	var isLesserAdmin = isAdmin || User.IsInRole("GuildLesserAdmin");
+	// Read/staff tier - gates display-only extra columns (cheat metrics). Includes the read-only
+	// GuildReadOnlyAdmin (CT) tier; no write controls are gated on this flag.
+	var isLesserAdmin = isAdmin || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
 	var contracts = Model.contracts;
 
 	var farms = backup.Farms;

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -23,7 +23,10 @@
     Guild dbguild = Model.DBGuild;
 
     var isAdmin = User.IsInRole("Admin") || User.IsInRole("GuildAdmin");
-    var isLesserAdmin = isAdmin || User.IsInRole("GuildLesserAdmin");
+    // Read/staff tier - gates display-only context when viewing another user's farms (titles, status
+    // badges, extra columns). All write controls (remove merit/demerit) are gated on isAdmin instead, so
+    // the read-only GuildReadOnlyAdmin (CT) tier is safe to include here.
+    var isLesserAdmin = isAdmin || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
     var isSelf = Model.IsSelf;
 
     var emojiReplace = new Regex(@"<:[^:]+:(\d+)>");


### PR DESCRIPTION
- Adds `GuildReadOnlyAdmin`, which grants users access to view, but not _edit_ other users
- Split `/Contract` perms to reflect this
- Changed clickable user links to be visible for all levels of admin, since all levels can view MyFarms of others