### PR TITLE
Feat: Dynamically Generate AFX Imgs + Inventory Tab

### DIFF
--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
@@ -17,6 +17,18 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
     public static class ArtifactDisplay {
         private static readonly TextInfo _titleCase = new CultureInfo("en-US", false).TextInfo;
 
+        // Sentinel the game uses for a "Guaranteed" effect; treat it as no multiplier so we show the
+        // data-backed "Guaranteed" label instead of "9999x".
+        private const double GuaranteedSentinel = 9999;
+
+        // "{Value}x" for a multiplier artifact/stone (e.g. a 5x boost), or null when the instance isn't a
+        // plain multiplier (additive, sub-2x percent, or the Guaranteed sentinel) and the caller should use
+        // its data-backed Size string instead.
+        private static string MultiplierLabel(EggIncArtifactInstance artifact) =>
+            !artifact.Additive && artifact.Value >= 2 && artifact.Value < GuaranteedSentinel
+                ? $"{artifact.Value}x"
+                : null;
+
         public static string RarityName(int rarity) => rarity switch {
             1 => "Common",
             2 => "Rare",
@@ -32,8 +44,7 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
             if(artifact is null || IsFragment(artifact)) return "";
             var effect = SafeEffect(artifact);
             if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Size)) {
-                if(!artifact.Additive && artifact.Value >= 2 && artifact.Value < 9999) return $"{artifact.Value}x";
-                return effect.Value.Size;
+                return MultiplierLabel(artifact) ?? effect.Value.Size;
             }
             return DerivedValue(artifact);
         }
@@ -74,9 +85,7 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
             if(IsFragment(artifact)) return null;
             var effect = SafeEffect(artifact);
             if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
-                var size = (!artifact.Additive && artifact.Value >= 2 && artifact.Value < 9999)
-                    ? $"{artifact.Value}x"
-                    : (effect.Value.Size ?? "");
+                var size = MultiplierLabel(artifact) ?? effect.Value.Size ?? "";
                 if(string.IsNullOrWhiteSpace(size)) return Encode(effect.Value.Target);
                 return $"<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";
             }
@@ -102,9 +111,7 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
                 var prefix = groupCount > 1 ? $"<span class=\"afx-tip-count\">(x{groupCount})</span> " : "";
                 var effect = SafeEffect(stone);
                 if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
-                    var size = (!stone.Additive && stone.Value >= 2 && stone.Value < 9999)
-                        ? $"{stone.Value}x"
-                        : (effect.Value.Size ?? "");
+                    var size = MultiplierLabel(stone) ?? effect.Value.Size ?? "";
                     if(string.IsNullOrWhiteSpace(size))
                         yield return $"{prefix}{Encode(effect.Value.Target)}";
                     else

--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
@@ -86,6 +86,7 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
             if(artifact is null || artifact.Additive ||
                artifact.Boost == JsonData.EiStatics.EggIncBoostTypeEnum.HostArtifactsOnElightenment)
                 return jsonSize ?? "";
+            if(artifact.Value == 9999) return "Guaranteed";
             if(artifact.Value >= 2) return $"{artifact.Value}x";
             return jsonSize ?? "";
         }

--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
@@ -31,7 +31,7 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
         public static string Effect(EggIncArtifactInstance artifact) {
             if(artifact is null || IsFragment(artifact)) return "";
             var effect = SafeEffect(artifact);
-            if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Size)) return effect.Value.Size;
+            if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Size)) return FormatEffectSize(effect.Value.Size, artifact);
             return DerivedValue(artifact);
         }
 
@@ -71,11 +71,29 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
             if(IsFragment(artifact)) return null;
             var effect = SafeEffect(artifact);
             if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
-                return $"<span class=\"afx-tip-value\">{Encode(effect.Value.Size)}</span> {Encode(effect.Value.Target)}";
+                var size = FormatEffectSize(effect.Value.Size, artifact);
+                if(string.IsNullOrWhiteSpace(size) || IsZeroEffect(size)) return Encode(effect.Value.Target);
+                return $"<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";
             }
             // No data-backed sentence (e.g. a synthetic combos instance): show just the derived value.
             var derived = DerivedValue(artifact);
             return string.IsNullOrEmpty(derived) ? null : $"<span class=\"afx-tip-value\">{Encode(derived)}</span>";
+        }
+
+        // Converts large percentage strings from JSON (e.g. "+1100%") to multiplier format ("12x"),
+        // matching the same threshold DerivedValue uses.
+        private static string FormatEffectSize(string jsonSize, EggIncArtifactInstance artifact) {
+            if(artifact is null || artifact.Additive ||
+               artifact.Boost == JsonData.EiStatics.EggIncBoostTypeEnum.HostArtifactsOnElightenment)
+                return jsonSize ?? "";
+            if(artifact.Value >= 2) return $"{artifact.Value}x";
+            return jsonSize ?? "";
+        }
+
+        private static bool IsZeroEffect(string size) {
+            if(string.IsNullOrWhiteSpace(size)) return false;
+            var trimmed = size.Trim().TrimStart('+', '-').TrimEnd('%', 'x');
+            return double.TryParse(trimmed, out var val) && val == 0;
         }
 
         // One line per distinct stone slotted into the artifact. Identical stones collapse into a single
@@ -95,7 +113,11 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
                 var prefix = groupCount > 1 ? $"<span class=\"afx-tip-count\">(x{groupCount})</span> " : "";
                 var effect = SafeEffect(stone);
                 if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
-                    yield return $"{prefix}<span class=\"afx-tip-value\">{Encode(effect.Value.Size)}</span> {Encode(effect.Value.Target)}";
+                    var size = FormatEffectSize(effect.Value.Size, stone);
+                    if(string.IsNullOrWhiteSpace(size) || IsZeroEffect(size))
+                        yield return $"{prefix}{Encode(effect.Value.Target)}";
+                    else
+                        yield return $"{prefix}<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";
                 } else {
                     yield return $"{prefix}{Encode(_titleCase.ToTitleCase(SafeName(stone)))}";
                 }
@@ -113,10 +135,14 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
         private static string DerivedValue(EggIncArtifactInstance artifact) {
             if(artifact is null) return "";
             if(artifact.Boost == JsonData.EiStatics.EggIncBoostTypeEnum.HostArtifactsOnElightenment) {
-                return $"{Math.Round(artifact.Value * 100)}%";
+                var pct = Math.Round(artifact.Value * 100);
+                return pct == 0 ? "" : $"{pct}%";
             }
-            if(artifact.Additive) return $"+{artifact.Value}";
-            if(artifact.Value < 2) return $"+{Math.Round((artifact.Value - 1) * 100)}%";
+            if(artifact.Additive) return artifact.Value == 0 ? "" : $"+{artifact.Value}";
+            if(artifact.Value < 2) {
+                var pct = Math.Round((artifact.Value - 1) * 100);
+                return pct == 0 ? "" : $"+{pct}%";
+            }
             return $"{artifact.Value}x";
         }
 

--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
@@ -109,16 +109,32 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
 
             foreach(var (stone, groupCount) in groups) {
                 var prefix = groupCount > 1 ? $"<span class=\"afx-tip-count\">(x{groupCount})</span> " : "";
+                var icon = IconUrl(stone, true);
+                var iconHtml = icon is null ? "" : $"<img class=\"afx-tip-icon\" src=\"{Encode(icon)}\" /> ";
                 var effect = SafeEffect(stone);
                 if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
                     var size = MultiplierLabel(stone) ?? effect.Value.Size ?? "";
                     if(string.IsNullOrWhiteSpace(size))
-                        yield return $"{prefix}{Encode(effect.Value.Target)}";
+                        yield return $"{prefix}{iconHtml}{Encode(effect.Value.Target)}";
                     else
-                        yield return $"{prefix}<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";
+                        yield return $"{prefix}{iconHtml}<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";
                 } else {
-                    yield return $"{prefix}{Encode(_titleCase.ToTitleCase(SafeName(stone)))}";
+                    yield return $"{prefix}{iconHtml}{Encode(_titleCase.ToTitleCase(SafeName(stone)))}";
                 }
+            }
+        }
+
+        // Site-relative sprite path, matching the image folders (e.g. /images/artifacts/CLARITY_STONE/
+        // CLARITY_STONE_2.png). Stones use a +1 tier offset, the same convention the renderer uses.
+        // Returns null when the family can't be resolved so the caller just omits the icon.
+        public static string IconUrl(EggIncArtifactInstance artifact, bool stone) {
+            if(artifact is null) return null;
+            try {
+                var name = EggIncArtifacts.GetNameFromJson(artifact).Replace("-", "_").ToUpper();
+                var tier = artifact.Tier + (stone ? 1 : 0);
+                return $"/images/artifacts/{name}/{name}_{tier}.png";
+            } catch {
+                return null;
             }
         }
 

--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
@@ -31,7 +31,10 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
         public static string Effect(EggIncArtifactInstance artifact) {
             if(artifact is null || IsFragment(artifact)) return "";
             var effect = SafeEffect(artifact);
-            if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Size)) return FormatEffectSize(effect.Value.Size, artifact);
+            if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Size)) {
+                if(!artifact.Additive && artifact.Value >= 2 && artifact.Value < 9999) return $"{artifact.Value}x";
+                return effect.Value.Size;
+            }
             return DerivedValue(artifact);
         }
 
@@ -71,30 +74,15 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
             if(IsFragment(artifact)) return null;
             var effect = SafeEffect(artifact);
             if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
-                var size = FormatEffectSize(effect.Value.Size, artifact);
-                if(string.IsNullOrWhiteSpace(size) || IsZeroEffect(size)) return Encode(effect.Value.Target);
+                var size = (!artifact.Additive && artifact.Value >= 2 && artifact.Value < 9999)
+                    ? $"{artifact.Value}x"
+                    : (effect.Value.Size ?? "");
+                if(string.IsNullOrWhiteSpace(size)) return Encode(effect.Value.Target);
                 return $"<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";
             }
             // No data-backed sentence (e.g. a synthetic combos instance): show just the derived value.
             var derived = DerivedValue(artifact);
             return string.IsNullOrEmpty(derived) ? null : $"<span class=\"afx-tip-value\">{Encode(derived)}</span>";
-        }
-
-        // Converts large percentage strings from JSON (e.g. "+1100%") to multiplier format ("12x"),
-        // matching the same threshold DerivedValue uses.
-        private static string FormatEffectSize(string jsonSize, EggIncArtifactInstance artifact) {
-            if(artifact is null || artifact.Additive ||
-               artifact.Boost == JsonData.EiStatics.EggIncBoostTypeEnum.HostArtifactsOnElightenment)
-                return jsonSize ?? "";
-            if(artifact.Value == 9999) return "Guaranteed";
-            if(artifact.Value >= 2) return $"{artifact.Value}x";
-            return jsonSize ?? "";
-        }
-
-        private static bool IsZeroEffect(string size) {
-            if(string.IsNullOrWhiteSpace(size)) return false;
-            var trimmed = size.Trim().TrimStart('+', '-').TrimEnd('%', 'x');
-            return double.TryParse(trimmed, out var val) && val == 0;
         }
 
         // One line per distinct stone slotted into the artifact. Identical stones collapse into a single
@@ -114,8 +102,10 @@ namespace EGG9000.Common.Helpers.ArtifactImaging {
                 var prefix = groupCount > 1 ? $"<span class=\"afx-tip-count\">(x{groupCount})</span> " : "";
                 var effect = SafeEffect(stone);
                 if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
-                    var size = FormatEffectSize(effect.Value.Size, stone);
-                    if(string.IsNullOrWhiteSpace(size) || IsZeroEffect(size))
+                    var size = (!stone.Additive && stone.Value >= 2 && stone.Value < 9999)
+                        ? $"{stone.Value}x"
+                        : (effect.Value.Size ?? "");
+                    if(string.IsNullOrWhiteSpace(size))
                         yield return $"{prefix}{Encode(effect.Value.Target)}";
                     else
                         yield return $"{prefix}<span class=\"afx-tip-value\">{Encode(size)}</span> {Encode(effect.Value.Target)}";

--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactDisplay.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace EGG9000.Common.Helpers.ArtifactImaging {
+    // Turns an artifact (or stone) instance into the bits we show on hover: its tier name, rarity, and the
+    // in-game effect line, in the same shape the game's artifact card uses. The combos table and the
+    // inventory overlay both read from here so labels stay consistent across the site.
+    //
+    // Two flavours of output:
+    //   Title()       - plain text, e.g. "Glistening Beak Of Midas +500%". Kept for any non-HTML caller.
+    //   TooltipHtml() - rich multi-line HTML for the JS tooltip: bold name, colour-coded rarity, a green
+    //                   value, and one line per slotted stone (same-type stones grouped as "(x3)").
+    public static class ArtifactDisplay {
+        private static readonly TextInfo _titleCase = new CultureInfo("en-US", false).TextInfo;
+
+        public static string RarityName(int rarity) => rarity switch {
+            1 => "Common",
+            2 => "Rare",
+            3 => "Epic",
+            4 => "Legendary",
+            _ => "Common"
+        };
+
+        // The short value string the game shows, e.g. "+20%", "Guaranteed". Comes from the artifact data
+        // when available; otherwise we fall back to deriving it from the instance's boost value so combos
+        // suggestions (which can carry synthetic instances) still read sensibly.
+        public static string Effect(EggIncArtifactInstance artifact) {
+            if(artifact is null || IsFragment(artifact)) return "";
+            var effect = SafeEffect(artifact);
+            if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Size)) return effect.Value.Size;
+            return DerivedValue(artifact);
+        }
+
+        // Plain-text label: tier name plus value. Title-cased so it reads cleanly.
+        public static string Title(EggIncArtifactInstance artifact) {
+            if(artifact is null) return "";
+            var name = _titleCase.ToTitleCase(SafeName(artifact));
+            var value = Effect(artifact);
+            return string.IsNullOrEmpty(value) ? name : $"{name} {value}";
+        }
+
+        // Rich tooltip HTML for one artifact and (optionally) its stones. count is how many copies this
+        // tile represents - shown as "x N" when greater than one.
+        public static string TooltipHtml(EggIncArtifactInstance artifact, int count = 1) {
+            if(artifact is null) return "";
+            var sb = new StringBuilder();
+
+            sb.Append("<div class=\"afx-tip-title\">");
+            sb.Append("<span class=\"afx-tip-name\">").Append(Encode(_titleCase.ToTitleCase(SafeName(artifact)))).Append("</span>");
+            sb.Append(" <span class=\"afx-tip-tier\">(T").Append(SafeTier(artifact)).Append(")</span>");
+            sb.Append(' ').Append(RarityHtml(artifact.Rarity));
+            if(count > 1) sb.Append(" <span class=\"afx-tip-count\">x ").Append(count).Append("</span>");
+            sb.Append("</div>");
+
+            var effectLine = EffectLineHtml(artifact);
+            if(effectLine is not null) sb.Append("<div class=\"afx-tip-effect\">").Append(effectLine).Append("</div>");
+
+            foreach(var stoneLine in StoneLinesHtml(artifact)) {
+                sb.Append("<div class=\"afx-tip-stone\">").Append(stoneLine).Append("</div>");
+            }
+
+            return sb.ToString();
+        }
+
+        // The effect sentence with the value coloured: "<green>+20%</green> chance of gold in gifts...".
+        private static string EffectLineHtml(EggIncArtifactInstance artifact) {
+            if(IsFragment(artifact)) return null;
+            var effect = SafeEffect(artifact);
+            if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
+                return $"<span class=\"afx-tip-value\">{Encode(effect.Value.Size)}</span> {Encode(effect.Value.Target)}";
+            }
+            // No data-backed sentence (e.g. a synthetic combos instance): show just the derived value.
+            var derived = DerivedValue(artifact);
+            return string.IsNullOrEmpty(derived) ? null : $"<span class=\"afx-tip-value\">{Encode(derived)}</span>";
+        }
+
+        // One line per distinct stone slotted into the artifact. Identical stones collapse into a single
+        // line tagged with their count, e.g. "(x3) +5% egg laying rate".
+        private static IEnumerable<string> StoneLinesHtml(EggIncArtifactInstance artifact) {
+            if(artifact.Stones is null || artifact.Stones.Count == 0) yield break;
+
+            // Group by identity (id + tier + rarity) while keeping the order stones were slotted in.
+            var groups = new List<(EggIncArtifactInstance Stone, int Count)>();
+            foreach(var stone in artifact.Stones) {
+                var existing = groups.FindIndex(g => g.Stone.Id == stone.Id && g.Stone.Tier == stone.Tier && g.Stone.Rarity == stone.Rarity);
+                if(existing >= 0) groups[existing] = (groups[existing].Stone, groups[existing].Count + 1);
+                else groups.Add((stone, 1));
+            }
+
+            foreach(var (stone, groupCount) in groups) {
+                var prefix = groupCount > 1 ? $"<span class=\"afx-tip-count\">(x{groupCount})</span> " : "";
+                var effect = SafeEffect(stone);
+                if(effect.HasValue && !string.IsNullOrWhiteSpace(effect.Value.Target)) {
+                    yield return $"{prefix}<span class=\"afx-tip-value\">{Encode(effect.Value.Size)}</span> {Encode(effect.Value.Target)}";
+                } else {
+                    yield return $"{prefix}{Encode(_titleCase.ToTitleCase(SafeName(stone)))}";
+                }
+            }
+        }
+
+        private static string RarityHtml(int rarity) =>
+            $"<span class=\"afx-tip-rarity afx-rarity-{rarity}\">{Encode(RarityName(rarity))}</span>";
+
+        private static bool IsFragment(EggIncArtifactInstance artifact) =>
+            artifact?.Artifact?.Contains("Fragment", StringComparison.OrdinalIgnoreCase) == true;
+
+        // Derived value string for instances the data file can't resolve. Mirrors the old combos
+        // artifactTemplate() so those suggestions keep their familiar "+50%" / "2x" / "+3" look.
+        private static string DerivedValue(EggIncArtifactInstance artifact) {
+            if(artifact is null) return "";
+            if(artifact.Boost == JsonData.EiStatics.EggIncBoostTypeEnum.HostArtifactsOnElightenment) {
+                return $"{Math.Round(artifact.Value * 100)}%";
+            }
+            if(artifact.Additive) return $"+{artifact.Value}";
+            if(artifact.Value < 2) return $"+{Math.Round((artifact.Value - 1) * 100)}%";
+            return $"{artifact.Value}x";
+        }
+
+        private static (string Size, string Target)? SafeEffect(EggIncArtifactInstance artifact) {
+            try { return EggIncArtifacts.GetEffectDisplay(artifact); }
+            catch { return null; }
+        }
+
+        private static int SafeTier(EggIncArtifactInstance artifact) {
+            try { return EggIncArtifacts.GetDisplayTier(artifact); }
+            catch { return Math.Max(1, (int)artifact.Tier); }
+        }
+
+        private static string SafeName(EggIncArtifactInstance artifact) {
+            // GetProperNameFromJson is what the combos table has always used, so try it first to keep
+            // those labels unchanged. It throws on fragments, and GetTierName knows how to strip the
+            // "Fragment" suffix, so that's the fallback.
+            try {
+                return EggIncArtifacts.GetProperNameFromJson(artifact);
+            } catch {
+                try {
+                    return EggIncArtifacts.GetTierName(artifact);
+                } catch {
+                    return artifact.Artifact ?? "Unknown";
+                }
+            }
+        }
+
+        private static string Encode(string s) => WebUtility.HtmlEncode(s ?? "");
+    }
+}

--- a/EGG9000.Common/Helpers/ArtifactImaging/ArtifactOverlayManifest.cs
+++ b/EGG9000.Common/Helpers/ArtifactImaging/ArtifactOverlayManifest.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace EGG9000.Common.Helpers.ArtifactImaging {
+    // Describes where each artifact and stone sits inside a generated image so the site can lay a grid
+    // of invisible hover targets on top of it. Rects are stored as percentages of the image size (0-100)
+    // rather than pixels: the image scales responsively in the browser, and percentage hotspots scale
+    // right along with it without any extra math on the client.
+    public sealed class ArtifactOverlayManifest {
+        // Native pixel size of the image the hotspots were measured against. Handy for aspect-ratio
+        // boxes on the client; the hotspots themselves are already normalised.
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public List<ArtifactHotspot> Hotspots { get; set; } = new();
+    }
+
+    // One hover target: the full cell of an artifact. Its tooltip lists the artifact plus any slotted
+    // stones, so stones don't need their own hotspots.
+    public sealed class ArtifactHotspot {
+        public double X { get; set; }
+        public double Y { get; set; }
+        public double W { get; set; }
+        public double H { get; set; }
+        // Rich tooltip markup (already HTML-encoded where needed): name, rarity, effect, stone lines.
+        public string Tip { get; set; }
+    }
+}

--- a/EGG9000.Common/Helpers/EggIncArtifacts.cs
+++ b/EGG9000.Common/Helpers/EggIncArtifacts.cs
@@ -177,6 +177,49 @@ namespace EGG9000.Common.Helpers {
             return artifact is null ? throw new Exception("Unable to locate artifact family: " + instance.Artifact) : artifact.id;
         }
 
+        // The tier number we show to players: 1-4 for artifacts, 2-4 for stones (a stone's stored Tier is
+        // zero-based and one behind its displayed tier), and 1 for fragments. Mirrors the tier offset
+        // logic in GetTierName so the "(T#)" label matches the resolved tier name.
+        public static int GetDisplayTier(EggIncArtifactInstance instance) {
+            var isFragment = instance.Artifact.Contains("Fragment", StringComparison.OrdinalIgnoreCase);
+            var family = ResolveFamily(instance, isFragment);
+            var isStone = family is not null && family.type.Equals("Stone", StringComparison.OrdinalIgnoreCase);
+            return instance.Tier + (isStone && !isFragment ? 1 : 0);
+        }
+
+        // The artifact's in-game effect for its exact tier and rarity, as the game presents it: a value
+        // string ("+20%", "+1000%", "Guaranteed") and the thing it affects ("internal hatchery rate").
+        // Both come straight from eiafx-data.json, so they read exactly like the in-game artifact card.
+        // Returns null for fragments and anything without a matching effect row.
+        public static (string Size, string Target)? GetEffectDisplay(EggIncArtifactInstance instance) {
+            var isFragment = instance.Artifact.Contains("Fragment", StringComparison.OrdinalIgnoreCase);
+            if(isFragment) return null;
+
+            var family = ResolveFamily(instance, isFragment);
+            if(family is null) return null;
+
+            var tierNumber = GetDisplayTier(instance);
+            var tier = family.tiers.FirstOrDefault(x => x.tier_number == tierNumber);
+            if(tier?.effects is null || tier.effects.Count == 0) return null;
+
+            // Stored rarity is 1-based (1 = Common); the data file is 0-based. Fall back to the base
+            // (afx_rarity 0) row, then to whatever the tier offers, so we never throw mid-tooltip.
+            var effect = tier.effects.FirstOrDefault(e => e.afx_rarity == instance.Rarity - 1)
+                ?? tier.effects.FirstOrDefault(e => e.afx_rarity == 0)
+                ?? tier.effects[0];
+
+            if(string.IsNullOrWhiteSpace(effect.effect_target)) return null;
+            return (effect.effect_size, effect.effect_target);
+        }
+
+        private static ArtifactFamily ResolveFamily(EggIncArtifactInstance instance, bool isFragment) {
+            var data = GetEiAfxData();
+            var lookupName = isFragment
+                ? instance.Artifact.Replace("Fragment", string.Empty, StringComparison.OrdinalIgnoreCase).TrimEnd()
+                : instance.Artifact;
+            return data.artifact_families.FirstOrDefault(x => x.name.Equals(lookupName, StringComparison.OrdinalIgnoreCase));
+        }
+
 
         public static double GetMaxRunningBonusAdditive(CustomFarm farm) {
             double val = 0;

--- a/EGG9000.Site/Controllers/APIController.cs
+++ b/EGG9000.Site/Controllers/APIController.cs
@@ -25,12 +25,13 @@ using static EGG9000.Common.Helpers.ArtifactHelpers;
 namespace EGG9000.Site.Controllers {
 
     [AllowAnonymous]
-    public class APIController(ApplicationDbContext db, Bugsnag.IClient bugsnag, IServiceProvider provider, ILogger<APIController> logger, IWebHostEnvironment env) : Controller {
+    public class APIController(ApplicationDbContext db, Bugsnag.IClient bugsnag, IServiceProvider provider, ILogger<APIController> logger, IWebHostEnvironment env, EGG9000.Site.Services.ArtifactImageRenderer renderer) : Controller {
         private readonly ApplicationDbContext _db = db;
         private readonly Bugsnag.IClient _bugsnag = bugsnag;
         private readonly IServiceProvider _provider = provider;
         private readonly ILogger<APIController> _logger = logger;
         private readonly IWebHostEnvironment _env = env;
+        private readonly EGG9000.Site.Services.ArtifactImageRenderer _renderer = renderer;
 
         private string GetWWWRelativePath(List<string> relativePathJoins) {
             var imageDur = _env.WebRootPath;
@@ -137,102 +138,12 @@ namespace EGG9000.Site.Controllers {
                 return BadRequest(new { message = $"Account with EID {userObject.EID} was not found for the user {user.DiscordUsername}" });
             }
 
-            var config = userObject.Config;
-            if(config is null) return BadRequest(new { message = "Config was null." });
-            if(!config.IsValid(out var configError)) return BadRequest(new { message = configError });
-            var rows = config.Rows;
-            var columns = config.Columns;
-
-            var orderedList = GetOrderedInventory(account);
-            if(orderedList is null) return BadRequest(new { message = $"`orderedList` was null." });
-
-            var baseImage = new Image<Rgba32>(config.TotalWidth, config.TotalHeight);
-            baseImage.Mutate(x => x.Fill(Color.ParseHex("#242422")));
-
-            var fontFilePath = GetWWWRelativePath(["Always Together.otf"]);
-            if(fontFilePath == null) return BadRequest(new { message = $"`Always Together.otf` could not be found." });
-            var font = new FontCollection().Add(fontFilePath).CreateFont(config.TextFontSize, FontStyle.Bold);
-
-            var index = 0;
-            foreach(var groupedAf in orderedList) {
-                var isFrag = groupedAf.Artifact.Artifact.ToString().Contains("FRAGMENT", StringComparison.CurrentCultureIgnoreCase);
-                var afName = groupedAf.Artifact.Artifact.ToString().ToUpper().Replace(" ", "_").Replace("'", "").Replace("_FRAGMENT", "");
-                var afTier = isFrag ? 1 : (afName.Contains("_STONE") ? groupedAf.Artifact.Tier + 1 : groupedAf.Artifact.Tier);
-                var afCount = groupedAf.Count;
-                var afStones = groupedAf.Artifact.Stones;
-
-                var (x, y) = GetPositionInGrid(index, rows, columns, config.AFSize, config.Padding);
-
-                var backgroundColor = groupedAf.Artifact.Rarity switch {
-                    1 => Color.ParseHex("#383834"),
-                    2 => Color.ParseHex("#6cb6d9"),
-                    3 => Color.ParseHex("#b72de0"),
-                    4 => Color.ParseHex("#f2d61b"),
-                    _ => Color.ParseHex("#383834")
-                };
-
-                var afImagePath = GetWWWRelativePath([
-                    "images/artifacts",
-                    afName,
-                    $"{afName}_{afTier}.png"
-                ]);
-                if(afImagePath == null) continue;
-                using var afImage = Image.Load(afImagePath);
-
-                afImage.Mutate(i => { i.Resize(new Size(config.AFSize, config.AFSize)); });
-
-                var stoneImages = new List<Image>();
-                foreach(var stone in afStones) {
-                    var stoneName = stone.Artifact.ToString().ToUpper().Replace(" ", "_");
-                    var stoneTier = stone.Tier + 1;
-                    var stonePath = GetWWWRelativePath([
-                        "images/artifacts",
-                        stoneName,
-                        $"{stoneName}_{stoneTier}.png"
-                    ]);
-                    if(stonePath == null) continue;
-                    var stoneImage = Image.Load(stonePath);
-                    stoneImage.Mutate(i => { i.Resize(new Size(config.StoneSize, config.StoneSize), true); });
-                    stoneImages.Add(stoneImage);
-                }
-
-                Image textImage = null;
-                if(afCount != 1) {
-                    var textWidth = Math.Max(config.TextHeight, (afCount.ToString().Length * config.TextBaseWidth) + config.TextBaseWidth);
-                    textImage = new Image<Rgba32>(textWidth, config.TextHeight);
-                    textImage.Mutate(x => x
-                        .Fill(Color.ParseHex("#4f4f4f")) // Fill the image with a background color
-                        .Fill(Color.Transparent, new RectangularPolygon(config.TextCornerRadius, config.TextCornerRadius, textWidth - config.TextCornerRadius, config.TextCornerRadius))); // Create a transparent rectangle with rounded corners
-                    textImage.Mutate(x => x.ApplyRoundedCorners(config.TextCornerRadius));
-                    var text = afCount.ToString();
-                    var center = new PointF(textImage.Width / 2, textImage.Height / 2);
-                    var measured = TextMeasurer.MeasureSize(text, new TextOptions(font));
-                    var textPosition = new PointF(center.X - measured.Width / 2, center.Y - measured.Height / 2);
-
-                    textImage.Mutate(x => x.DrawText(text, font, Color.White, textPosition));
-                }
-
-                using var backgroundImage = BackgroundImage(backgroundColor, config.AFSize, config.AFCornerRadius);
-                backgroundImage.Mutate(i => { i.DrawImage(afImage, new Point(0, 0), 1f); });
-
-                baseImage.Mutate(b => { b.DrawImage(backgroundImage, new Point(x, y), 1f); });
-                if(textImage != null) {
-                    var baseCenter = new Point(x + backgroundImage.Width, y + backgroundImage.Height);
-                    var textPosition = new Point(baseCenter.X - (int)(textImage.Width / 1.5), baseCenter.Y - (int)(textImage.Height / 1.5));
-                    baseImage.Mutate(b => { b.DrawImage(textImage, textPosition, 1f); });
-                } else if(stoneImages.Count > 0) {
-                    var stoneIndex = 1;
-                    foreach(var stoneImage in stoneImages) {
-                        baseImage.Mutate(b => { b.DrawImage(stoneImage, new Point(x + config.AFSize - (int)(config.Padding * 0.5) - (config.StoneSize * stoneIndex), (int)(y + config.AFSize - (config.Padding * 1.5))), 1f); });
-                        stoneIndex++;
-                    }
-                }
-                index++;
-            }
-
-            using var ms = new MemoryStream();
-            baseImage.Save(ms, new JpegEncoder());
-            return File(ms.ToArray(), "image/jpeg");
+            // The drawing (and the matching hover-target manifest) lives in ArtifactImageRenderer so the
+            // bot endpoint and the MyFarms inventory tab paint from the exact same code. The bot only
+            // wants the image bytes here; the manifest is ignored.
+            var render = _renderer.RenderInventory(account, userObject.Config);
+            if(!render.Ok) return BadRequest(new { message = render.Error });
+            return File(render.Jpeg, "image/jpeg");
         }
 
         [HttpPost]

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -35,7 +35,7 @@ namespace EGG9000.Site.Controllers {
     [Authorize]
     public class MyFarmsController(ILogger<MyFarmsController> logger, UserManager<ApplicationUser> userManager, DiscordSocketClient discord,
         RoleManager<IdentityRole> roleManager, ApplicationDbContext db, Bugsnag.IClient bugsnag, IMemoryCache cache, DatabaseCache databaseCache,
-        IServiceScopeFactory scopeFactory) : Controller {
+        IServiceScopeFactory scopeFactory, EGG9000.Site.Services.ArtifactImageRenderer artifactRenderer) : Controller {
 
         private readonly ILogger<MyFarmsController> _logger = logger;
         private readonly ApplicationDbContext _db = db;
@@ -46,6 +46,7 @@ namespace EGG9000.Site.Controllers {
         private readonly IMemoryCache _cache = cache;
         private readonly DatabaseCache _databaseCache = databaseCache;
         private readonly IServiceScopeFactory _scopeFactory = scopeFactory;
+        private readonly EGG9000.Site.Services.ArtifactImageRenderer _artifactRenderer = artifactRenderer;
 
         public async Task<IActionResult> Index() {
             var sw = new Stopwatch();
@@ -155,6 +156,33 @@ namespace EGG9000.Site.Controllers {
 
             Console.WriteLine(string.Join("\n", times.Finished().Select(y => $"{y.name}: {y.time.Humanize().ShortenTime()}")));
             return View("Index", new MyFarmsModel(user, Contracts, Demerits, Merits, /*RawBackups,*/ Snapshots, xrefs, coops, erItems, scoring, DbGuild, uncompletedPes, dbCustomEggs, isSelf, cachedContracts, seasonPEByEggIncId, missingSeasonalPEByEggIncId));
+        }
+
+        // Lazily renders the artifact-inventory image plus its hover-target manifest for one account. The
+        // MyFarms inventory tab fetches this the first time it's opened, so the main page load never pays
+        // for the image generation. Access is restricted to the account's owner or a staff member, matching
+        // who is allowed to view the farms in the first place.
+        [HttpGet]
+        public async Task<IActionResult> InventoryOverlay(string eid) {
+            if(string.IsNullOrWhiteSpace(eid)) return BadRequest(new { error = "Missing account id." });
+
+            var loginuser = await _userManager.GetUserAsync(User);
+            var logins = await _userManager.GetLoginsAsync(loginuser);
+            var loginUserId = ulong.Parse(logins.First().ProviderKey);
+
+            var owner = await _db.DBUsers.FirstOrDefaultAsync(x => x.EIDs.Contains(eid));
+            if(owner is null) return NotFound(new { error = "Account not found." });
+
+            var isStaff = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
+            if(owner.DiscordId != loginUserId && !isStaff) return Forbid();
+
+            var account = owner.EggIncAccounts.FirstOrDefault(a => a.Id == eid);
+            if(account is null) return NotFound(new { error = "Account not found." });
+
+            var render = _artifactRenderer.RenderInventory(account);
+            if(!render.Ok) return Json(new { error = render.Error });
+
+            return Json(new { imageB64 = Convert.ToBase64String(render.Jpeg), manifest = render.Manifest });
         }
 
         private async Task GetScores(DBUser user, List<(string EggIncId, MyContracts MyContracts)> scoring) {

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -235,6 +235,7 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
     services.AddControllersWithViews().AddXmlSerializerFormatters().AddXmlDataContractSerializerFormatters();
     services.AddRazorPages();
     services.AddTransient<IEmailSender, EmailSenderBlank>();
+    services.AddSingleton<EGG9000.Site.Services.ArtifactImageRenderer>();
     services.AddHostedService<NewCoopChecker>();
     services.AddSingleton<DatabaseCache>();
     services.AddHostedService<UserCacheRefreshService>();

--- a/EGG9000.Site/Services/ArtifactImageRenderer.cs
+++ b/EGG9000.Site/Services/ArtifactImageRenderer.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.AspNetCore.Hosting;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
+using EGG9000.Common.Helpers.ArtifactImaging;
+using SixLabors.Fonts;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using static EGG9000.Common.Helpers.ArtifactHelpers;
+
+namespace EGG9000.Site.Services {
+    // Draws artifact images and, in the same pass, records where every artifact landed so the site can
+    // overlay hover targets on top of them. Two shapes are produced from one shared cell painter:
+    //   - the full inventory grid (MyFarms Inventory tab + the bot's image endpoint)
+    //   - a single 4-slot active-artifact set (the Ships & Farms cards)
+    // Building the image and the hotspot manifest in the same loop guarantees the hover targets line up
+    // with what was actually painted.
+    public sealed class ArtifactImageRenderer(IWebHostEnvironment env) {
+        private readonly IWebHostEnvironment _env = env;
+
+        private const string BackgroundHex = "#242422";
+
+        public sealed class RenderResult {
+            public byte[] Jpeg { get; init; }
+            public ArtifactOverlayManifest Manifest { get; init; }
+            public string Error { get; init; }
+            public bool Ok => Error is null;
+        }
+
+        // Convenience overload for the site: picks a near-square grid the same way the bot's InventoryB64
+        // helper does, so the on-site image matches the Discord one.
+        public RenderResult RenderInventory(EggIncAccount account) {
+            var orderedList = GetOrderedInventory(account);
+            if(orderedList is null || orderedList.Count == 0) return new RenderResult { Error = "No artifacts to display." };
+            var (rows, columns) = FindClosestGridSize(orderedList.Count);
+            return RenderInventory(account, new InventoryCreatorConfig(100, 30, rows, columns));
+        }
+
+        public RenderResult RenderInventory(EggIncAccount account, InventoryCreatorConfig config) {
+            if(config is null) return new RenderResult { Error = "Config was null." };
+            if(!config.IsValid(out var configError)) return new RenderResult { Error = configError };
+
+            var orderedList = GetOrderedInventory(account);
+            if(orderedList is null) return new RenderResult { Error = "Could not read the artifact inventory." };
+
+            var fontPath = WWWPath("Always Together.otf");
+            if(fontPath is null) return new RenderResult { Error = "`Always Together.otf` could not be found." };
+            var font = new FontCollection().Add(fontPath).CreateFont(config.TextFontSize, FontStyle.Bold);
+
+            using var baseImage = new Image<Rgba32>(config.TotalWidth, config.TotalHeight);
+            baseImage.Mutate(x => x.Fill(Color.ParseHex(BackgroundHex)));
+
+            var manifest = new ArtifactOverlayManifest { Width = config.TotalWidth, Height = config.TotalHeight };
+
+            var index = 0;
+            foreach(var groupedAf in orderedList) {
+                var artifact = groupedAf.Artifact;
+                var afCount = groupedAf.Count;
+                var (x, y) = GetPositionInGrid(index, config.Rows, config.Columns, config.AFSize, config.Padding);
+
+                // Stacked duplicates (count > 1) are stoneless, so a count badge takes the corner instead
+                // of stone icons. PaintCell still records the hotspot with the right copy count.
+                var drawStones = afCount == 1;
+                if(PaintCell(baseImage, manifest, artifact, afCount, x, y, config.AFSize, config.Padding, config.StoneSize, config.AFCornerRadius, drawStones) && afCount != 1) {
+                    DrawCountBadge(baseImage, font, afCount, x, y, config);
+                }
+                index++;
+            }
+
+            return new RenderResult { Jpeg = Encode(baseImage), Manifest = manifest };
+        }
+
+        // A single farm's active artifacts as one row of slots, with the same hover targets. Used inline by
+        // the Ships & Farms cards in place of the old text list.
+        public RenderResult RenderSet(IReadOnlyList<EggIncArtifactInstance> artifacts) {
+            var slots = artifacts?.Where(a => a is not null).ToList() ?? new List<EggIncArtifactInstance>();
+            if(slots.Count == 0) return new RenderResult { Error = "No artifacts." };
+
+            const int afSize = 100;
+            const int padding = 20;
+            var stoneSize = (int)(afSize / 4.5);
+            var cornerRadius = afSize / 4;
+
+            var width = (slots.Count * afSize) + (padding * (slots.Count + 1));
+            var height = afSize + (padding * 2);
+
+            using var baseImage = new Image<Rgba32>(width, height);
+            baseImage.Mutate(x => x.Fill(Color.ParseHex(BackgroundHex)));
+
+            var manifest = new ArtifactOverlayManifest { Width = width, Height = height };
+
+            for(var i = 0; i < slots.Count; i++) {
+                var x = padding + i * (afSize + padding);
+                PaintCell(baseImage, manifest, slots[i], 1, x, padding, afSize, padding, stoneSize, cornerRadius, drawStones: true);
+            }
+
+            return new RenderResult { Jpeg = Encode(baseImage), Manifest = manifest };
+        }
+
+        // Paints one artifact cell (rarity background + artifact, plus stone icons in the corner) and
+        // records its hover target. Returns false when the artifact sprite is missing so callers can skip
+        // any follow-up drawing for that cell.
+        private bool PaintCell(Image<Rgba32> baseImage, ArtifactOverlayManifest manifest, EggIncArtifactInstance artifact, int count, int x, int y, int afSize, int padding, int stoneSize, int cornerRadius, bool drawStones) {
+            var isFrag = artifact.Artifact.Contains("FRAGMENT", StringComparison.CurrentCultureIgnoreCase);
+            var afName = artifact.Artifact.ToString().ToUpper().Replace(" ", "_").Replace("'", "").Replace("_FRAGMENT", "");
+            var afTier = isFrag ? 1 : (afName.Contains("_STONE") ? artifact.Tier + 1 : artifact.Tier);
+
+            var afImagePath = WWWPath("images", "artifacts", afName, $"{afName}_{afTier}.png");
+            if(afImagePath is null) return false;
+            using var afImage = Image.Load(afImagePath);
+            afImage.Mutate(i => i.Resize(new Size(afSize, afSize)));
+
+            // One hotspot per cell. Its tooltip lists the artifact and any slotted stones, so the small
+            // stone icons drawn in the corner don't need separate hover targets.
+            manifest.Hotspots.Add(MakeHotspot(x, y, afSize, afSize, manifest, ArtifactDisplay.TooltipHtml(artifact, count)));
+
+            using var backgroundImage = BackgroundImage(RarityColor(artifact.Rarity), afSize, cornerRadius);
+            backgroundImage.Mutate(i => i.DrawImage(afImage, new Point(0, 0), 1f));
+            baseImage.Mutate(b => b.DrawImage(backgroundImage, new Point(x, y), 1f));
+
+            if(drawStones) {
+                var stoneIndex = 1;
+                foreach(var stone in artifact.Stones ?? new List<EggIncArtifactInstance>()) {
+                    var stoneName = stone.Artifact.ToString().ToUpper().Replace(" ", "_");
+                    var stonePath = WWWPath("images", "artifacts", stoneName, $"{stoneName}_{stone.Tier + 1}.png");
+                    if(stonePath is null) continue;
+                    using var stoneImage = Image.Load(stonePath);
+                    stoneImage.Mutate(i => i.Resize(new Size(stoneSize, stoneSize), true));
+                    var sx = x + afSize - (int)(padding * 0.5) - (stoneSize * stoneIndex);
+                    var sy = (int)(y + afSize - (padding * 1.5));
+                    baseImage.Mutate(b => b.DrawImage(stoneImage, new Point(sx, sy), 1f));
+                    stoneIndex++;
+                }
+            }
+            return true;
+        }
+
+        private static byte[] Encode(Image<Rgba32> image) {
+            using var ms = new MemoryStream();
+            image.Save(ms, new JpegEncoder());
+            return ms.ToArray();
+        }
+
+        private static void DrawCountBadge(Image<Rgba32> baseImage, Font font, int afCount, int x, int y, InventoryCreatorConfig config) {
+            var text = afCount.ToString();
+            var textWidth = Math.Max(config.TextHeight, (text.Length * config.TextBaseWidth) + config.TextBaseWidth);
+            using var textImage = new Image<Rgba32>(textWidth, config.TextHeight);
+            textImage.Mutate(c => c
+                .Fill(Color.ParseHex("#4f4f4f"))
+                .Fill(Color.Transparent, new SixLabors.ImageSharp.Drawing.RectangularPolygon(config.TextCornerRadius, config.TextCornerRadius, textWidth - config.TextCornerRadius, config.TextCornerRadius)));
+            textImage.Mutate(c => c.ApplyRoundedCorners(config.TextCornerRadius));
+            var center = new PointF(textImage.Width / 2f, textImage.Height / 2f);
+            var measured = TextMeasurer.MeasureSize(text, new TextOptions(font));
+            textImage.Mutate(c => c.DrawText(text, font, Color.White, new PointF(center.X - measured.Width / 2, center.Y - measured.Height / 2)));
+
+            var baseCenter = new Point(x + config.AFSize, y + config.AFSize);
+            var textPosition = new Point(baseCenter.X - (int)(textImage.Width / 1.5), baseCenter.Y - (int)(textImage.Height / 1.5));
+            baseImage.Mutate(b => b.DrawImage(textImage, textPosition, 1f));
+        }
+
+        private static Color RarityColor(int rarity) => rarity switch {
+            1 => Color.ParseHex("#383834"),
+            2 => Color.ParseHex("#6cb6d9"),
+            3 => Color.ParseHex("#b72de0"),
+            4 => Color.ParseHex("#f2d61b"),
+            _ => Color.ParseHex("#383834")
+        };
+
+        // Pixel rect -> percentage-of-image hotspot.
+        private static ArtifactHotspot MakeHotspot(int x, int y, int w, int h, ArtifactOverlayManifest manifest, string tip) => new() {
+            X = Round(x * 100.0 / manifest.Width),
+            Y = Round(y * 100.0 / manifest.Height),
+            W = Round(w * 100.0 / manifest.Width),
+            H = Round(h * 100.0 / manifest.Height),
+            Tip = tip
+        };
+
+        private static double Round(double v) => Math.Round(v, 3);
+
+        private string WWWPath(params string[] parts) {
+            var path = _env.WebRootPath;
+            if(parts is { Length: > 0 }) path = System.IO.Path.Combine(path, System.IO.Path.Combine(parts));
+            return System.IO.File.Exists(path) ? path : null;
+        }
+    }
+}

--- a/EGG9000.Site/Views/MyFarms/-ArtifactCombos.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ArtifactCombos.cshtml
@@ -5,6 +5,7 @@
 @using EGG9000.Site.Controllers;
 @using System.Globalization;
 @using EGG9000.Common.Coops;
+@using EGG9000.Common.Helpers.ArtifactImaging;
 @inject DiscordSocketClient DiscordClient
 @model (CustomBackup Backup, List<Contract> Contracts, List<Coop> Coops, DBUser user, List<DBCustomEgg> CustomEggs)
 
@@ -24,20 +25,6 @@
             </div>
         </td>
     }
-    string artifactTemplate(EggIncArtifactInstance artifact) {
-        if (artifact == null) {
-            return "";
-        } else if (artifact.Boost == EggIncBoostTypeEnum.HostArtifactsOnElightenment) {
-            return $"{Math.Round((artifact.Value) * 100)}%";
-        } else if (artifact.Additive) {
-            return $"+{artifact.Value}";
-        } else if (+artifact.Value < 2) {
-            return $"+{Math.Round((artifact.Value - 1) * 100)}%";
-        } else {
-            return $"{artifact.Value}x";
-        }
-    }
-
     string artifactImage(EggIncArtifactInstance artifact, bool stone) {
         if (artifact == null) {
             return "";
@@ -64,11 +51,9 @@
                 subClass = "afx-stone";
             }
             var image = artifactImage(artifact, stone);
-            var size = stone ? 15 : 70;
-            var textInfo = new CultureInfo("en-US", false).TextInfo;
-            var name = textInfo.ToTitleCase(EggIncArtifacts.GetProperNameFromJson(artifact)) + " " + artifactTemplate(artifact);
-            <div class="rounded-full @(bgClass)">
-                <img class="position-absolute @subClass" src="@image" title="@name" />
+            <div class="rounded-full has-tip @(bgClass)">
+                <img class="position-absolute @subClass" src="@image" />
+                <span class="afx-tip-content">@Html.Raw(ArtifactDisplay.TooltipHtml(artifact))</span>
             </div>
         }
     }

--- a/EGG9000.Site/Views/MyFarms/-ArtifactInventory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ArtifactInventory.cshtml
@@ -1,0 +1,18 @@
+@model string
+
+@*
+    The inventory image is heavy to generate, so we don't render it on page load. The container below
+    just carries the account id; artifact-overlay.js fetches the image plus its hover-target manifest
+    from /MyFarms/InventoryOverlay the first time this tab is actually opened, then lays the hotspots
+    over the image so each artifact and stone shows its name on hover.
+*@
+<div class="card" style="margin-top:15px">
+    <h4 class="card-header">Inventory</h4>
+    <div class="card-body">
+        <ul>
+            <li>Every artifact you own, grouped by rarity</li>
+            <li>Hover over an artifact or stone to see what it is</li>
+        </ul>
+        <div class="afx-inventory" data-eid="@Model">Open this tab to load your inventory.</div>
+    </div>
+</div>

--- a/EGG9000.Site/Views/MyFarms/-ArtifactSetImage.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ArtifactSetImage.cshtml
@@ -1,0 +1,23 @@
+@using System.Globalization
+@model EGG9000.Site.Services.ArtifactImageRenderer.RenderResult
+
+@*
+    Renders a generated artifact-set image with the same hover overlay as the inventory tab, but built
+    server-side (the set is small, so there's no need for the lazy fetch the inventory uses). The hotspot
+    divs carry their tooltip markup in a hidden .afx-tip-content child; artifact-overlay.js picks any
+    .has-tip element up globally, so these work with no extra wiring.
+*@
+@if (Model is not null && Model.Ok)
+{
+    var b64 = Convert.ToBase64String(Model.Jpeg);
+    <div class="afx-overlay-wrap afx-set-wrap">
+        <img class="afx-overlay-img" src="data:image/jpeg;base64,@b64" alt="Active artifacts" />
+        @foreach (var h in Model.Manifest.Hotspots)
+        {
+            <div class="afx-hotspot has-tip"
+                 style="left:@h.X.ToString(CultureInfo.InvariantCulture)%;top:@h.Y.ToString(CultureInfo.InvariantCulture)%;width:@h.W.ToString(CultureInfo.InvariantCulture)%;height:@h.H.ToString(CultureInfo.InvariantCulture)%">
+                <span class="afx-tip-content">@Html.Raw(h.Tip)</span>
+            </div>
+        }
+    </div>
+}

--- a/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
@@ -8,75 +8,13 @@
 @using static Ei.MissionInfo.Types;
 @using static EGG9000.Common.Helpers.MissionHelpers;
 @inject DiscordSocketClient DiscordClient
+@inject EGG9000.Site.Services.ArtifactImageRenderer ArtifactRenderer
 @model (int Index, CustomBackup Backup,  List<Coop> JoinedCoops, List<Contract> Contracts, List<DBCustomEgg> CustomEggs)
 
 @{
     string properCaseAndSuffix(string inputString, int number){
         var suffix = (number == 0 || number > 1) ? "s" : "";
         return inputString.FirstCharToUpper() + suffix;
-    }
-
-    string properSpacing(string input) {
-        StringBuilder result = new StringBuilder(input.Length * 2);
-        result.Append(input[0]); // Add the first character as is
-        for (int i = 1; i < input.Length; i++) {
-            if (char.IsUpper(input[i])) result.Append(' ');
-            result.Append(input[i]);
-        }
-        return result.ToString();
-    }
-
-    void artifactBackground(EggIncArtifactInstance artifact, bool stone) {
-        if (artifact == null) {
-            <div></div>
-        } else {
-            var subClass = "afx-img";
-            var bgClass = artifact.Rarity switch {
-                1 => "bg-common afx-bg", //Common
-                2 => "bg-rare afx-bg", //Rare
-                3 => "bg-epic afx-bg", //Epic
-                4 => "bg-legendary afx-bg", //Legendary
-                _ => "bg-common afx-bg" //Default to gray
-            };
-            if (stone) {
-                bgClass = "afx-stone";
-                subClass = "afx-stone";
-            }
-            var image = artifactImage(artifact, stone);
-            var size = stone ? 15 : 70;
-            var textInfo = new CultureInfo("en-US", false).TextInfo;
-            <div class="rounded-full @(bgClass)">
-                <img class="position-absolute @subClass" src="@image" />
-            </div>
-        }
-    }
-
-    string artifactImage(EggIncArtifactInstance artifact, bool stone) {
-        if (artifact == null) {
-            return "";
-        } else {
-            var properName = EggIncArtifacts.GetNameFromJson(artifact).Replace("-", "_").ToUpper();
-            return "/images/artifacts/" + properName + "/" + properName + "_" + (artifact.Tier + (stone ? 1 : 0)) + ".png";
-        }
-    }
-
-    void artifactTemplate(EggIncArtifactInstance artifact, bool stone) {
-        <tr>
-            <td>@{artifactBackground(artifact, stone);}</td>
-            <td>@artifact.Artifact</td>
-                @if (artifact.Boost == EggIncBoostTypeEnum.HostArtifactsOnElightenment) {
-                    <td>@Math.Round((artifact.Value) * 100)%</td>
-                } else if(artifact.Boost == EggIncBoostTypeEnum.ResearchCost) {
-                            <td>-@((artifact.Value - 1).ToString("P0"))</td>
-                } else if (artifact.Additive) {
-                            <td>+@artifact.Value</td>
-                } else if (+artifact.Value < 2) {
-                            <td>+@Math.Round((artifact.Value - 1) * 100)%</td>
-                } else {
-                            <td>@(artifact.Value)x</td>
-                }
-            <td>@properSpacing(artifact.Boost.ToString().Replace("Members", ""))</td>
-        </tr>
     }
 
     int index = Model.Index;
@@ -690,28 +628,14 @@
                     </div>
                 }
             </div>
-            <div class="card-body" style="padding-bottom: 0;">
+            <div class="card-body" style="padding-bottom: 12px;">
                 <h6>Artifacts</h6>
-            </div>
-            <table class="table table-sm" style="margin-bottom: 0;">
                 @if (farm.Artifacts.Count == 0) {
-                    <tr><td><i>No Artifacts</i></td></tr>
+                    <i>No Artifacts</i>
+                } else {
+                    await Html.RenderPartialAsync("-ArtifactSetImage", ArtifactRenderer.RenderSet(farm.Artifacts));
                 }
-                @foreach (var artifact in farm.Artifacts) {
-                    artifactTemplate(artifact, false);
-                    @if (artifact.Stones != null && artifact.Stones.Count > 0) {
-                        <tr>
-                            <td colspan="99" style="padding-left: 10px; padding-top: 0; ">
-                                <table>
-                                    @foreach (var stone in artifact.Stones) {
-                                        artifactTemplate(stone, true);
-                                    }
-                                </table>
-                            </td>
-                        </tr>
-                    }
-                }
-            </table>
+            </div>
         </div>
     }
 }

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -382,9 +382,9 @@
                 <li class="nav-item">
                     <a class="nav-link" data-toggle="tab" href="#colleggtibles@(index)" role="tab" aria-selected="false">Colleggtibles</a>
                 </li>
-                <!--<li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#inventoryview(index)" role="tab" aria-selected="false">Inventory View</a>
-                </li>-->
+                <li class="nav-item">
+                    <a class="nav-link" data-toggle="tab" href="#inventory@(index)" role="tab" aria-selected="false">Inventory</a>
+                </li>
             </ul>
 
             <div class="tab-content">
@@ -517,12 +517,18 @@
                         await Html.RenderPartialAsync("-Colleggtibles", (backup, Model.CustomEggs));
                     }
                 </div>
+                <div class="tab-pane" id="inventory@(index)" role="tabpanel">
+                    @{
+                        await Html.RenderPartialAsync("-ArtifactInventory", account.Id);
+                    }
+                </div>
             </div>
         </div>
     }
 </div>
 
 @section Scripts {
+    <script src="~/js/artifact-overlay.js" asp-append-version="true"></script>
     <script>
 
         function formatEpochToLocalDateTime(epochSeconds) {

--- a/EGG9000.Site/Views/Shared/_Layout.cshtml
+++ b/EGG9000.Site/Views/Shared/_Layout.cshtml
@@ -7,7 +7,7 @@
 
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@forevolve/bootstrap-dark@1.0.0/dist/css/toggle-bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@forevolve/bootstrap-dark@1.0.0/dist/css/toggle-bootstrap-dark.min.css" />
-	<link rel="stylesheet" href="~/css/site.css" />
+	<link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 
 	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 	<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">

--- a/EGG9000.Site/wwwroot/css/site.css
+++ b/EGG9000.Site/wwwroot/css/site.css
@@ -125,6 +125,112 @@ body {
     }
 }
 
+/* Rich hover tooltip shared by the combos tiles and the inventory overlay hotspots. The markup lives
+   in a hidden .afx-tip-content child of each .has-tip element; artifact-overlay.js lifts it into a
+   single floating .afx-tooltip that follows the cursor.
+------------------------------------------- */
+
+.has-tip {
+    position: relative;
+}
+
+.afx-tip-content {
+    display: none;
+}
+
+.afx-tooltip {
+    position: fixed;
+    z-index: 1080;
+    pointer-events: none;
+    max-width: 280px;
+    background: rgba(18, 18, 20, 0.97);
+    color: #e9e9e9;
+    border: 1px solid #555;
+    border-radius: 8px;
+    padding: 8px 10px;
+    font-size: 0.82rem;
+    line-height: 1.35;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
+}
+
+.afx-tip-title {
+    font-weight: 600;
+    margin-bottom: 2px;
+}
+
+.afx-tip-tier {
+    color: #9a9a9a;
+    font-weight: 400;
+}
+
+.afx-tip-count {
+    color: #9a9a9a;
+}
+
+.afx-tip-effect {
+    color: #d8d8d8;
+}
+
+.afx-tip-stone {
+    color: #bdbdbd;
+    font-style: italic;
+    padding-left: 8px;
+}
+
+/* The value (e.g. +20%, Guaranteed) is highlighted green, matching the in-game artifact card. */
+.afx-tip-value {
+    color: #4ade80;
+    font-style: normal;
+}
+
+/* Rarity word colours, matching the artifact thumbnail backgrounds. */
+.afx-rarity-1 { color: #b9b9b9; }
+.afx-rarity-2 { color: #6ab6ff; }
+.afx-rarity-3 { color: #c03fe2; }
+.afx-rarity-4 { color: #eeab42; }
+
+/* Inventory image with its grid of invisible hover targets
+------------------------------------------- */
+
+/* fit-content + max-width:100% lets the box shrink to the image yet never overflow the column.
+   inline-block here would trigger the classic max-width image-overflow bug, so use block. */
+.afx-overlay-wrap {
+    position: relative;
+    display: block;
+    width: fit-content;
+    max-width: 100%;
+    line-height: 0;
+}
+
+/* width:100% makes the image fill the (already column-capped) wrap, so the percentage hotspots stay
+   aligned to the artwork at any size. */
+.afx-overlay-img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
+.afx-hotspot {
+    position: absolute;
+    cursor: help;
+    border-radius: 6px;
+}
+
+.afx-hotspot:hover {
+    outline: 2px solid rgba(255, 255, 255, 0.65);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+/* The Ships & Farms active-artifact set image sits under its "Artifacts" heading. */
+.afx-set-wrap {
+    margin-top: 4px;
+}
+
+.afx-hotspot-stone:hover {
+    outline-color: rgba(255, 255, 255, 0.85);
+}
+
 .copy-notification {
     display: none;
     position: fixed;

--- a/EGG9000.Site/wwwroot/css/site.css
+++ b/EGG9000.Site/wwwroot/css/site.css
@@ -140,9 +140,12 @@ body {
 
 .afx-tooltip {
     position: fixed;
+    top: 0;
+    left: 0;
+    will-change: transform;
     z-index: 1080;
     pointer-events: none;
-    max-width: 280px;
+    max-width: 520px;
     background: rgba(18, 18, 20, 0.97);
     color: #e9e9e9;
     border: 1px solid #555;
@@ -153,9 +156,12 @@ body {
     box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5);
 }
 
+/* Name, tier and rarity always share the first line; the tooltip widens to fit rather than wrapping the
+   rarity down. Mobile is the only place we let it wrap (see media query below). */
 .afx-tip-title {
     font-weight: 600;
     margin-bottom: 2px;
+    white-space: nowrap;
 }
 
 .afx-tip-tier {
@@ -172,9 +178,15 @@ body {
 }
 
 .afx-tip-stone {
-    color: #bdbdbd;
-    font-style: italic;
-    padding-left: 8px;
+    color: #c8c8c8;
+    padding-left: 10px;
+}
+
+.afx-tip-icon {
+    width: 1.15em;
+    height: 1.15em;
+    vertical-align: -0.22em;
+    margin-right: 1px;
 }
 
 /* The value (e.g. +20%, Guaranteed) is highlighted green, matching the in-game artifact card. */
@@ -188,6 +200,17 @@ body {
 .afx-rarity-2 { color: #6ab6ff; }
 .afx-rarity-3 { color: #c03fe2; }
 .afx-rarity-4 { color: #eeab42; }
+
+/* On phones a long name genuinely can't fit beside the rarity, so let the title wrap there. */
+@media (max-width: 768px) {
+    .afx-tooltip {
+        max-width: 90vw;
+    }
+
+    .afx-tip-title {
+        white-space: normal;
+    }
+}
 
 /* Inventory image with its grid of invisible hover targets
 ------------------------------------------- */
@@ -219,7 +242,6 @@ body {
 
 .afx-hotspot:hover {
     outline: 2px solid rgba(255, 255, 255, 0.65);
-    background: rgba(255, 255, 255, 0.08);
 }
 
 /* The Ships & Farms active-artifact set image sits under its "Artifacts" heading. */

--- a/EGG9000.Site/wwwroot/js/artifact-overlay.js
+++ b/EGG9000.Site/wwwroot/js/artifact-overlay.js
@@ -9,41 +9,50 @@
 (function () {
     // -- Floating tooltip ---------------------------------------------------------------------------
     // One element reused for every hover target on the page. Any element with class .has-tip that
-    // contains a hidden .afx-tip-content child shows that content on hover and follows the cursor.
+    // contains a hidden .afx-tip-content child shows that content on hover.
+    //
+    // The tooltip is ANCHORED to the hovered element, not the cursor. A cursor-following tooltip lags a
+    // frame behind the pointer and visibly chases it, which reads as jitter no matter how cheap the math
+    // is. Anchoring positions the tooltip once on enter and then leaves it alone while the pointer moves
+    // within the item, so there is zero per-move work and nothing to stutter.
     var tip = null;
+    var active = null;   // the .has-tip currently being hovered
 
     function ensureTip() {
         if (tip) return tip;
         tip = document.createElement('div');
         tip.className = 'afx-tooltip';
         tip.style.display = 'none';
+        tip.style.left = '0';
+        tip.style.top = '0';
         document.body.appendChild(tip);
         return tip;
     }
 
-    function showTip(html, x, y) {
+    function showTipFor(el, html) {
         var t = ensureTip();
         t.innerHTML = html;
         t.style.display = 'block';
-        moveTip(x, y);
+
+        var r = el.getBoundingClientRect();
+        var tw = t.offsetWidth;
+        var th = t.offsetHeight;
+        var pad = 8;
+
+        // Prefer directly above the item, left-aligned to it; drop below when there's no room above, and
+        // nudge horizontally so we never spill off the viewport.
+        var left = r.left;
+        var top = r.top - th - pad;
+        if (top < 4) top = r.bottom + pad;
+        if (left + tw > window.innerWidth - 4) left = window.innerWidth - 4 - tw;
+        if (left < 4) left = 4;
+
+        t.style.transform = 'translate3d(' + Math.round(left) + 'px,' + Math.round(top) + 'px,0)';
     }
 
     function hideTip() {
+        active = null;
         if (tip) tip.style.display = 'none';
-    }
-
-    function moveTip(x, y) {
-        if (!tip || tip.style.display === 'none') return;
-        var pad = 14;
-        var rect = tip.getBoundingClientRect();
-        // Prefer above-right of the cursor; flip when we'd run off an edge.
-        var left = x + pad;
-        var top = y - rect.height - pad;
-        if (left + rect.width > window.innerWidth - 4) left = x - rect.width - pad;
-        if (left < 4) left = 4;
-        if (top < 4) top = y + pad;
-        tip.style.left = left + 'px';
-        tip.style.top = top + 'px';
     }
 
     function tipHtmlFor(el) {
@@ -53,14 +62,12 @@
 
     document.addEventListener('mouseover', function (e) {
         var el = e.target.closest ? e.target.closest('.has-tip') : null;
-        if (!el) return;
+        if (!el || el === active) return;
         var html = tipHtmlFor(el);
-        if (html) showTip(html, e.clientX, e.clientY);
-    });
-
-    document.addEventListener('mousemove', function (e) {
-        if (!tip || tip.style.display === 'none') return;
-        if (e.target.closest && e.target.closest('.has-tip')) moveTip(e.clientX, e.clientY);
+        if (html) {
+            active = el;
+            showTipFor(el, html);
+        }
     });
 
     document.addEventListener('mouseout', function (e) {

--- a/EGG9000.Site/wwwroot/js/artifact-overlay.js
+++ b/EGG9000.Site/wwwroot/js/artifact-overlay.js
@@ -1,0 +1,161 @@
+// Lazily loads the MyFarms inventory image, lays a grid of invisible hover targets over it, and drives
+// the rich hover tooltip shared with the artifact-combos tiles.
+//
+// The server hands back a JPEG (base64) plus a manifest: a list of hotspots whose positions are
+// expressed as percentages of the image size. Because the image scales responsively, percentage
+// hotspots scale right along with it, so the hover targets always line up with the artwork without any
+// resize math here. Each hotspot also carries a chunk of tooltip HTML (name, rarity, effect, stones)
+// which we stash in a hidden child element and surface through the floating tooltip below.
+(function () {
+    // -- Floating tooltip ---------------------------------------------------------------------------
+    // One element reused for every hover target on the page. Any element with class .has-tip that
+    // contains a hidden .afx-tip-content child shows that content on hover and follows the cursor.
+    var tip = null;
+
+    function ensureTip() {
+        if (tip) return tip;
+        tip = document.createElement('div');
+        tip.className = 'afx-tooltip';
+        tip.style.display = 'none';
+        document.body.appendChild(tip);
+        return tip;
+    }
+
+    function showTip(html, x, y) {
+        var t = ensureTip();
+        t.innerHTML = html;
+        t.style.display = 'block';
+        moveTip(x, y);
+    }
+
+    function hideTip() {
+        if (tip) tip.style.display = 'none';
+    }
+
+    function moveTip(x, y) {
+        if (!tip || tip.style.display === 'none') return;
+        var pad = 14;
+        var rect = tip.getBoundingClientRect();
+        // Prefer above-right of the cursor; flip when we'd run off an edge.
+        var left = x + pad;
+        var top = y - rect.height - pad;
+        if (left + rect.width > window.innerWidth - 4) left = x - rect.width - pad;
+        if (left < 4) left = 4;
+        if (top < 4) top = y + pad;
+        tip.style.left = left + 'px';
+        tip.style.top = top + 'px';
+    }
+
+    function tipHtmlFor(el) {
+        var holder = el.querySelector(':scope > .afx-tip-content');
+        return holder ? holder.innerHTML : '';
+    }
+
+    document.addEventListener('mouseover', function (e) {
+        var el = e.target.closest ? e.target.closest('.has-tip') : null;
+        if (!el) return;
+        var html = tipHtmlFor(el);
+        if (html) showTip(html, e.clientX, e.clientY);
+    });
+
+    document.addEventListener('mousemove', function (e) {
+        if (!tip || tip.style.display === 'none') return;
+        if (e.target.closest && e.target.closest('.has-tip')) moveTip(e.clientX, e.clientY);
+    });
+
+    document.addEventListener('mouseout', function (e) {
+        var from = e.target.closest ? e.target.closest('.has-tip') : null;
+        if (!from) return;
+        var to = e.relatedTarget && e.relatedTarget.closest ? e.relatedTarget.closest('.has-tip') : null;
+        if (to !== from) hideTip();
+    });
+
+    // -- Inventory overlay --------------------------------------------------------------------------
+    function buildOverlay(container, data) {
+        container.innerHTML = '';
+
+        if (!data || data.error) {
+            container.textContent = (data && data.error) ? data.error : 'Could not load inventory.';
+            return;
+        }
+
+        var manifest = data.manifest || {};
+        var hotspots = manifest.hotspots || [];
+
+        var wrap = document.createElement('div');
+        wrap.className = 'afx-overlay-wrap';
+
+        var img = document.createElement('img');
+        img.className = 'afx-overlay-img';
+        img.alt = 'Artifact inventory';
+        img.src = 'data:image/jpeg;base64,' + data.imageB64;
+        wrap.appendChild(img);
+
+        hotspots.forEach(function (h) {
+            var spot = document.createElement('div');
+            spot.className = 'afx-hotspot has-tip';
+            spot.style.left = h.x + '%';
+            spot.style.top = h.y + '%';
+            spot.style.width = h.w + '%';
+            spot.style.height = h.h + '%';
+
+            var content = document.createElement('span');
+            content.className = 'afx-tip-content';
+            content.innerHTML = h.tip || '';
+            spot.appendChild(content);
+
+            wrap.appendChild(spot);
+        });
+
+        container.appendChild(wrap);
+    }
+
+    function load(container) {
+        if (container.getAttribute('data-loaded') === 'true' || container.getAttribute('data-loading') === 'true') {
+            return;
+        }
+        var eid = container.getAttribute('data-eid');
+        if (!eid) {
+            return;
+        }
+
+        container.setAttribute('data-loading', 'true');
+        container.textContent = 'Loading inventory...';
+
+        fetch('/MyFarms/InventoryOverlay?eid=' + encodeURIComponent(eid), {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        })
+            .then(function (r) { return r.json(); })
+            .then(function (d) {
+                container.setAttribute('data-loaded', 'true');
+                container.removeAttribute('data-loading');
+                buildOverlay(container, d);
+            })
+            .catch(function () {
+                container.removeAttribute('data-loading');
+                container.textContent = 'Could not load inventory.';
+            });
+    }
+
+    // Load any inventory container that is currently visible (its tab is the active one). offsetParent
+    // is null for elements inside a hidden tab-pane, which is exactly how we tell "this tab is open".
+    function scan() {
+        var containers = document.querySelectorAll('.afx-inventory');
+        for (var i = 0; i < containers.length; i++) {
+            if (containers[i].offsetParent !== null) {
+                load(containers[i]);
+            }
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        if (window.jQuery) {
+            // Bootstrap fires this on the tab link once its pane is shown.
+            window.jQuery(document).on('shown.bs.tab', scan);
+        }
+        // Covers the case where an inventory tab is already the active one on first paint.
+        scan();
+    });
+
+    window.ArtifactOverlay = { scan: scan };
+})();


### PR DESCRIPTION
- Artifact Combos and MyFarms Farm artifacts were replaced with the same dynamic image generation that drives `/savedafsets`
<img width="1128" height="555" alt="image" src="https://github.com/user-attachments/assets/26ca7513-3405-4721-8d26-0efed65a4173" />

- Added `Inventory` tab to MyFarms, which uses the same display logic at a larger scale
<img width="1143" height="408" alt="image" src="https://github.com/user-attachments/assets/872196f2-a5be-4cd9-a984-257cfe9271b5" />
