### PR TITLE
Fix: CS leaderboard on site

### DIFF
--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -263,10 +263,6 @@ namespace EGG9000.Common.Database {
             //GradeProgress = backup.Contracts.LastCpi?.GradeProgress ?? 0;
             ClientVersion = (byte)backup.Version;
 
-            TotalCS = backup.Contracts.LastCpi?.TotalCxp ?? -1;
-            SeasonCS = backup.Contracts.LastCpi?.SeasonCxp ?? -1;
-
-
             VirtueEggsDelivered = backup.Virtue?.EggsDelivered.ToArray() ?? Array.Empty<double>();
             Resets = backup.Virtue?.Resets ?? 0;
             ShiftCount = backup.Virtue?.ShiftCount ?? 0;

--- a/EGG9000.Common/Helpers/AccountRefresh.cs
+++ b/EGG9000.Common/Helpers/AccountRefresh.cs
@@ -55,8 +55,8 @@ namespace EGG9000.Common.Helpers {
                 logger.LogTrace("Skipping non-final grade ({Status}) for user {User} ({Account})", info.Status, user.DiscordUsername, account.Name);
                 return false;
             }
-            // Update TotalCS and SeasonCS in backup so that CS leaderboard shows all the users 
-            if(account.Backup is not null) {
+            var csChanged = account.Backup is not null && (account.Backup.TotalCS != info.TotalCxp || account.Backup.SeasonCS != info.SeasonCxp);
+            if(csChanged) {
                 account.Backup.TotalCS = info.TotalCxp;
                 account.Backup.SeasonCS = info.SeasonCxp;
             }
@@ -77,9 +77,10 @@ namespace EGG9000.Common.Helpers {
                     mutated = true;
                     logger.LogInformation("Re-stamped PromotionTime for {User} ({Account}) to keep authoritative grade {Grade}", user.DiscordUsername, account.Name, info.Grade);
                 } else {
-                    // No grade change, but we still need to call UpdateAccounts to ensure the account blob is repacked with the updated TotalCS and SeasonCS.
-                    user.UpdateAccounts();
-                    mutated = account.Backup is not null;
+                    if(csChanged) {
+                        user.UpdateAccounts();
+                        mutated = true;
+                    }
                     logger.LogInformation("No grade change for user {User} ({Account}) grade: {Grade}", user.DiscordUsername, account.Name, info.Grade);
                 }
             }

--- a/EGG9000.Common/Helpers/AccountRefresh.cs
+++ b/EGG9000.Common/Helpers/AccountRefresh.cs
@@ -55,6 +55,11 @@ namespace EGG9000.Common.Helpers {
                 logger.LogTrace("Skipping non-final grade ({Status}) for user {User} ({Account})", info.Status, user.DiscordUsername, account.Name);
                 return false;
             }
+            // Update TotalCS and SeasonCS in backup so that CS leaderboard shows all the users 
+            if(account.Backup is not null) {
+                account.Backup.TotalCS = info.TotalCxp;
+                account.Backup.SeasonCS = info.SeasonCxp;
+            }
 
             // get_contract_player_info.Grade is the authoritative current grade. When it differs from
             // LastGrade the player was promoted, so stamp PromotionTime - otherwise GetGrade's
@@ -72,6 +77,9 @@ namespace EGG9000.Common.Helpers {
                     mutated = true;
                     logger.LogInformation("Re-stamped PromotionTime for {User} ({Account}) to keep authoritative grade {Grade}", user.DiscordUsername, account.Name, info.Grade);
                 } else {
+                    // No grade change, but we still need to call UpdateAccounts to ensure the account blob is repacked with the updated TotalCS and SeasonCS.
+                    user.UpdateAccounts();
+                    mutated = account.Backup is not null;
                     logger.LogInformation("No grade change for user {User} ({Account}) grade: {Grade}", user.DiscordUsername, account.Name, info.Grade);
                 }
             }


### PR DESCRIPTION
Moved totalCS and seasonCS into ApplyExtrasAsync so that these update when there is a CPI fetch. 