### PR TITLE
Chore: update deps

### DIFF
--- a/EGG9000.Site/Areas/Identity/Pages/Account/Manage/_StatusMessage.cshtml
+++ b/EGG9000.Site/Areas/Identity/Pages/Account/Manage/_StatusMessage.cshtml
@@ -3,8 +3,8 @@
 @if (!String.IsNullOrEmpty(Model))
 {
     var statusMessageClass = Model.StartsWith("Error") ? "danger" : "success";
-    <div class="alert alert-@statusMessageClass alert-dismissible" role="alert">
-        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <div class="alert alert-@statusMessageClass alert-dismissible fade show" role="alert">
         @Model
+        <button type="button" class="btn-close shadow-none" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
 }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -263,7 +263,7 @@ namespace EGG9000.Site.Controllers {
             await _db.SaveChangesAsyncRetry(2);
             var guildKey = _db.InvalidateEventCustomizations(guild);
             await _publishEndpoint.Publish(new ExpireCacheMessage(guildKey));
-            return Content("Success");
+            return Json(new { });
         }
 
         public class FAQCustomizationModel() {
@@ -344,7 +344,7 @@ namespace EGG9000.Site.Controllers {
             var guildKey = _db.InvalidateFAQTopics(guild);
             await _publishEndpoint.Publish(new ExpireCacheMessage(guildKey));
             await _db.SaveChangesAsync();
-            return Content("Success");
+            return Json(new { });
         }
 
         [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin")]

--- a/EGG9000.Site/Views/Admin/ConfigureServer.cshtml
+++ b/EGG9000.Site/Views/Admin/ConfigureServer.cshtml
@@ -70,28 +70,22 @@
 		white-space: nowrap;
 		text-align: center;
 		position: absolute;
+		background-color: rgba(130, 135, 140, 0.95);
 	}
 
-		.tooltiptext-custom .bootstrap-dark {
-			background-color: rgba(33, 37, 41, 0.95);
-		}
-
-		.tooltiptext-custom .bootstrap {
-			background-color: rgba(130, 135, 140, 0.95);
-		}
+	[data-bs-theme="dark"] .tooltiptext-custom {
+		background-color: rgba(33, 37, 41, 0.95);
+	}
 
 
-	.bootstrap-dark .speech-bubble {
+	[data-bs-theme="dark"] .speech-bubble {
 		background-color: rgba(33, 37, 41, 0.95);
 		color: white !important;
 	}
 
-	.bootstrap .speech-bubble {
+	.speech-bubble {
 		background-color: rgba(130, 135, 140, 0.95);
 		color: black !important;
-	}
-
-	.speech-bubble {
 		position: relative;
 		padding: 10px;
 		margin: 10px auto;
@@ -112,23 +106,17 @@
 	.custom-input {
 		display: inline-block;
 		padding: 4px;
-		border: 1px solid #ccc;
+		border: 1px solid #007bff;
 		border-radius: 3px;
 		color: #333;
 		background-color: #fff;
 		transition: border-color 0.3s;
 	}
 
-	.bootstrap-dark .custom-input {
+	[data-bs-theme="dark"] .custom-input {
 		border-color: #343a40;
 		color: #fff;
 		background-color: #343a40;
-	}
-
-	.bootstrap .custom-input {
-		border-color: #007bff;
-		color: #333;
-		background-color: #fff;
 	}
 
 </style>

--- a/EGG9000.Site/Views/Admin/EventCustomization.cshtml
+++ b/EGG9000.Site/Views/Admin/EventCustomization.cshtml
@@ -28,22 +28,15 @@
         white-space: nowrap;
         text-align: center; /* Center the text within the tooltip */
         position: absolute;
+        background-color: rgba(130, 135, 140, 0.95);
     }
 
-        .tooltiptext-custom .bootstrap-dark {
+        [data-bs-theme="dark"] .tooltiptext-custom {
             background-color: rgba(33, 37, 41, 0.95);
         }
 
-        .tooltiptext-custom .bootstrap {
-            background-color: rgba(130, 135, 140, 0.95);
-        }
-
-    .bootstrap-dark .speech-bubble {
+    [data-bs-theme="dark"] .speech-bubble {
         background-color: rgba(33, 37, 41, 0.95);
-    }
-
-    .bootstrap .speech-bubble {
-        background-color: rgba(130, 135, 140, 0.95);
     }
 
     .speech-bubble {
@@ -51,6 +44,7 @@
         padding: 10px;
         margin: 10px auto; /* Center the bubble horizontally */
         border-radius: 5px; /* Rounded corners for the bubble */
+        background-color: rgba(130, 135, 140, 0.95);
     }
 
         /* Create the triangle */
@@ -66,7 +60,7 @@
         }
 </style>
 
-<div ng-controller="AdminPage">
+<div x-data="eventCustomizationPage()">
     <h2>Event Customization</h2>
 
     <table class="table table-striped table-hover">
@@ -81,115 +75,122 @@
             </tr>
         </thead>
         <tbody>
-            <tr ng-repeat="item in items" ng-click="EditItem(item)">
-                <td>{{item.type}}</td>
-                <td>{{item.priority}}</td>
-                <td>{{item.description}}</td>
-                <td>{{item.Tips.length}}</td>
-                <td style="max-width: 50px;"><img ng-src="{{item.thumbnailURL}}" class="img-thumbnail" /></td>
-                <td>{{item.emoji}}</td>
-            </tr>
+            <template x-for="item in items" :key="item.type">
+                <tr @@click="editItem(item)" style="cursor:pointer;">
+                    <td x-text="item.type"></td>
+                    <td x-text="item.priority"></td>
+                    <td x-text="item.description"></td>
+                    <td x-text="item.Tips.length"></td>
+                    <td style="max-width: 50px;"><img :src="item.thumbnailURL" class="img-thumbnail" /></td>
+                    <td x-text="item.emoji"></td>
+                </tr>
+            </template>
         </tbody>
     </table>
 
-    <script type="text/ng-template" id="Edit.html">
-        <style>
-            .modal-body {
-                max-height: calc(100vh - 180px);
-                overflow-y: auto;
-            }
+    <div class="modal fade" id="editEventModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <style>
+                    .modal-body {
+                        max-height: calc(100vh - 180px);
+                        overflow-y: auto;
+                    }
+                    .tip-container {
+                        border: 1px solid #ccc;
+                        border-radius: 8px;
+                        margin-bottom: 10px;
+                        padding: 10px;
+                    }
+                    .tip-item {
+                        margin-bottom: 10px;
+                    }
+                </style>
+                <div class="modal-header d-flex justify-content-between align-items-center">
+                    <span>Edit Item</span>
+                    <button type="button" class="btn-close" @@click="cancel()" aria-label="Close"></button>
+                </div>
+                <div class="modal-body overflow-auto">
+                    <template x-if="selectedItem">
+                        <div>
+                            <div class="form-group mb-3">
+                                <label>Type</label>
+                                <input class="form-control" disabled :value="selectedItem.type" />
+                            </div>
+                            <div class="form-group mb-3">
+                                <label>Priority (Positive Numbers will stack Emoji)</label>
+                                <input class="form-control" type="number" x-model.number="selectedItem.priority" />
+                            </div>
+                            <div class="form-group mb-3">
+                                <label for="Description">Description</label>
+                                <textarea spellcheck="false" class="form-control" id="Description" x-model="selectedItem.description"></textarea>
+                            </div>
+                            <div class="form-group mb-3">
+                                <label>ThumbnailUrl</label>
+                                <input class="form-control" x-model="selectedItem.thumbnailURL" />
+                            </div>
+                            <div class="form-group mb-3">
+                                <label>Emoji</label>
+                                <input class="form-control" x-model="selectedItem.emoji" />
+                            </div>
 
-            .tip-container {
-                border: 1px solid #ccc;
-                border-radius: 8px;
-                margin-bottom: 10px;
-                padding: 10px;
-            }
+                            <hr class="mt-1 mb-1">
+                            <h3>Tips</h3>
+                            <template x-for="(tip, idx) in selectedItem.Tips" :key="idx">
+                                <div class="tip-container">
+                                    <div class="form-group tip-item">
+                                        <label>Title</label>
+                                        <input class="form-control" x-model="tip.Name" />
+                                    </div>
+                                    <div class="form-group tip-item">
+                                        <label>Text</label>
+                                        <textarea spellcheck="false" class="form-control" x-model="tip.Value"></textarea>
+                                    </div>
+                                    <div class="form-group tip-item">
+                                        <label>Remove Tip</label><br>
+                                        <button class="btn btn-danger" @@click="removeTip(idx)">X</button>
+                                    </div>
+                                </div>
+                            </template>
+                            <button class="mt-2 btn btn-success" @@click="selectedItem.Tips.push({})">+ Add Tip</button>
 
-            .tip-item {
-                margin-bottom: 10px;
-            }
-        </style>
-        <div class="modal-header d-flex justify-content-between align-items-center">
-            <span>Edit Item</span>
-            <button type="button" class="close" ng-click="Cancel()" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
+                            <hr class="mt-1 mb-1">
+                            <h3>Notifications</h3>
+                            <template x-for="(notification, idx) in (selectedItem.settings.notifications || [])" :key="idx">
+                                <div class="pb-2">
+                                    <div class="row align-items-center">
+                                        <div class="col">
+                                            <label>Role ID</label>
+                                            <input class="form-control" x-model="notification.roleIdString" />
+                                        </div>
+                                        <div class="col">
+                                            <label class="tooltip-custom">
+                                                Min Value (-1 for Ultra pings in event channel)
+                                                <span class="tooltiptext-custom speech-bubble">
+                                                    The minimum value the event must be to ping this role. <br>
+                                                    For example, to ping a role specifically <br>for 3x prestige you would enter 3
+                                                </span>
+                                            </label>
+                                            <input class="form-control" x-model.number="notification.minValue" />
+                                        </div>
+                                        <div class="col">
+                                            <label>Remove</label><br>
+                                            <button class="btn btn-danger" @@click="selectedItem.settings.notifications.splice(idx, 1)">X</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                            <button class="mt-2 btn btn-success" @@click="addNotification()">+ Add Notification</button>
+                        </div>
+                    </template>
+                </div>
+                <div class="modal-footer">
+                    <button class="btn btn-success" @@click="save()">Save</button>
+                    <button class="btn btn-secondary" @@click="cancel()">Cancel</button>
+                </div>
+            </div>
         </div>
-        <div class="modal-body overflow-auto">
-            <div class="form-group">
-                <label>Type</label>
-                <input class="form-control" disabled ng-model="item.type" />
-            </div>
-            <div class="form-group">
-                <label>Priority (Positive Numbers will stack Emoji)</label>
-                <input class="form-control" type="number" ng-model="item.priority" />
-            </div>
-            <div class="form-group">
-                <label for="Description">Description</label>
-                <textarea spellcheck="false" class="form-control" id="Description" ng-model="item.description"></textarea>
-            </div>
-            <div class="form-group">
-                <label>ThumbnailUrl</label>
-                <input class="form-control" ng-model="item.thumbnailURL" />
-            </div>
-            <div class="form-group">
-                <label>Emoji</label>
-                <input class="form-control" ng-model="item.emoji" />
-            </div>
-
-            <hr class="mt-1 mb-1">
-            
-            <h3>Tips</h3>
-            <div ng-repeat="tip in item.Tips track by $index" class="tip-container">
-                <div class="form-group tip-item">
-                    <label>Title</label>
-                    <input class="form-control" ng-model="tip.Name" />
-                </div>
-                <div class="form-group tip-item">
-                    <label>Text</label>
-                    <textarea spellcheck="false" class="form-control" ng-model="tip.Value"></textarea>
-                </div>
-                <div class="form-group tip-item">
-                    <label>Remove Tip</label> <br>
-                    <button class="btn btn-danger" ng-click="RemoveTip($index)">X</button>
-                </div>
-            </div>
-
-            <button class="mt-2 btn btn-success" ng-click="AddTip()">+ Add Tip</button>
-
-            <hr class="mt-1 mb-1">
-
-            <h3>Notifications</h3>
-            <div class="pb-2" ng-repeat="notification in item.settings.notifications track by $index">
-                <div class="row align-items-center">
-                    <div class="col">
-                        <label for="roleId{{$index}}">Role ID</label>
-                        <input id="roleId{{$index}}" class="form-control" ng-model="notification.roleIdString" />
-                    </div>
-                    <div class="col">
-                        <label for="minValue{{$index}}" class="tooltip-custom">
-                            Min Value (-1 for Ultra pings in event channel)
-                            <span class="tooltiptext-custom speech-bubble">
-                                The minimum value the event must be to ping this role. <br>
-                                For example, to ping a role specifically <br>for 3x prestige you would enter 3
-                            </span>
-                        </label>
-                        <input id="minValue{{$index}}" class="form-control" ng-model="notification.minValue" />
-                    </div>
-                    <div class="col">
-                        <label for="removeNotif{{$index}}">Remove</label> <br>
-                        <button id="removeNotif{{$index}}" class="btn btn-danger" ng-click="$parent.item.settings.notifications.splice($index, 1)">X</button>
-                    </div>
-                </div>
-            </div>
-            <button class="mt-2 btn btn-success" ng-click="item.settings.notifications.push({})">+ Add Notification</button>
-        </div>        
-        <div class="modal-footer">
-            <button class="btn btn-success" ng-click="Save()">Save</button>
-            <button class="btn btn-default" ng-click="Cancel()">Cancel</button>
-        </div>
-    </script>
+    </div>
 </div>
 @section Scripts {
     <style>
@@ -202,63 +203,76 @@
         }
     </style>
 
-
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('AdminPage', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-                $scope.items = @Html.Raw(Json.Serialize(Model));
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('eventCustomizationPage', () => ({
+                items: [],
+                selectedItem: null,
+                savedItem: null,
+                _modal: null,
 
-                angular.forEach($scope.items, function (item) {
-                    item.Tips = JSON.parse(item.fields || '[]');
-                });
-
-                $scope.EditItem = function EditItem(item) {
-                    $uibModal.open({
-                        templateUrl: 'Edit.html',
-                        size: 'lg',
-                        backdrop: 'static',
-                        animation: false,
-                        controller: function ($scope, $uibModalInstance) {
-                            $scope.item = item;
-                            if($scope.item.settings.notifications == null) {
-                                $scope.item.settings.notifications = [];
-                            }
-
-                            $scope.saved = angular.copy(item);
-
-                            $scope.AddTip = function AddTip() {
-                                $scope.item.Tips.push({});
-                            };
-
-                            $scope.RemoveTip = function (index) {
-                                if (confirm("Are you sure you want to delete the tip?")) {
-                                    $scope.item.Tips.splice(index, 1);
-                                }
-                            }
-
-                            $scope.Save = function Save() {
-                                $scope.item.Fields = JSON.stringify($scope.item.Tips);
-                                $scope.item._settings = JSON.stringify($scope.item.settings);
-                                console.log($scope.item);
-                                $http({ method: 'POST', data: item, url: '/admin/saveeventcustomization/' })
-                                    .then(function successCallback(response) {
-                                        if (response.data.Error) {
-                                            alert(response.data.Error);
-                                            return;
-                                        }
-                                        $uibModalInstance.close();
-                                    }, function errorCallback(response) {
-                                        alert('Error Saving');
-                                    });
-                            };
-
-                            $scope.Cancel = function Cancel() {
-                                _.assign(item, $scope.saved);
-                                $uibModalInstance.close();
-                            };
-                        }
+                init() {
+                    const _raw = @Html.Raw(Json.Serialize(Model));
+                    this.items = _raw.map(item => ({
+                        ...item,
+                        Tips: JSON.parse(item.fields || '[]'),
+                        settings: item.settings || { notifications: [] }
+                    }));
+                    this._modal = new bootstrap.Modal(document.getElementById('editEventModal'));
+                    document.getElementById('editEventModal').addEventListener('hidden.bs.modal', () => {
+                        this.selectedItem = null;
                     });
-                };
-            }]);
+                },
+
+                editItem(item) {
+                    if (!item.settings) item.settings = {};
+                    if (!item.settings.notifications) item.settings.notifications = [];
+                    this.savedItem = JSON.parse(JSON.stringify(item));
+                    this.selectedItem = item;
+                    this._modal.show();
+                },
+
+                removeTip(index) {
+                    if (confirm('Are you sure you want to delete the tip?')) {
+                        this.selectedItem.Tips.splice(index, 1);
+                    }
+                },
+
+                addNotification() {
+                    if (!this.selectedItem.settings.notifications) {
+                        this.selectedItem.settings.notifications = [];
+                    }
+                    this.selectedItem.settings.notifications.push({});
+                },
+
+                async save() {
+                    this.selectedItem.Fields = JSON.stringify(this.selectedItem.Tips);
+                    this.selectedItem._settings = JSON.stringify(this.selectedItem.settings);
+                    try {
+                        const r = await fetch('/admin/saveeventcustomization/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(this.selectedItem)
+                        });
+                        const data = await r.json();
+                        if (data.Error) {
+                            alert(data.Error);
+                            return;
+                        }
+                        this._modal.hide();
+                    } catch (e) {
+                        alert('Error Saving');
+                        console.error(e);
+                    }
+                },
+
+                cancel() {
+                    if (this.savedItem && this.selectedItem) {
+                        Object.assign(this.selectedItem, this.savedItem);
+                    }
+                    this._modal.hide();
+                }
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Admin/FAQCustomization.cshtml
+++ b/EGG9000.Site/Views/Admin/FAQCustomization.cshtml
@@ -1,44 +1,50 @@
-﻿@model EGG9000.Site.Controllers.AdminController.FAQCustomizationModel
+@model EGG9000.Site.Controllers.AdminController.FAQCustomizationModel
 @using System.Security.Claims;
 @{
     ViewData["Title"] = "FAQ Customization";
 }
 
-<div ng-controller="AdminPage">
-    <div ng-if="@Model.GuildId != @Model.PalaceGuildId" style="display: flex; align-items: center; justify-content: space-between;">
-        <h2>Palace FAQs</h2>
-        <input class="form-control" ng-model="palaceSearchTerm" style="width: 500px" placeholder="Search (Name, Keywords, Explanation)" name="palaceSearchTerm" />
-    </div>
-    <table ng-if="@Model.GuildId != @Model.PalaceGuildId" class="table table-striped table-hover">
-        <thead>
-            <tr>
-                <th>Name</th>
-                <th>Keywords</th>
-                <th>Weight</th>
-                <th colspan="2">Explanation</th>
-                <th>Staff Only</th>
-                <th>Subscribed</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr ng-if="filteredPalaceItems.length == 0">
-                <td colspan="7" style="text-align: center; font-weight: bold;">No items to show.</td>
-            </tr>
-            <tr ng-else ng-repeat="faqItem in filteredPalaceItems = (palaceItems | filter:palaceFilter)" ng-click="EditItem(faqItem, true)">
-                <td>{{faqItem.name}}</td>
-                <td>{{faqItem.Keywords.join(", ")}}</td>
-                <td>{{faqItem.weight}}</td>
-                <td colspan="2">{{minifyIfOver(faqItem.explanation)}}</td>
-                <td>{{faqItem.staffOnly ? 'Yes' : 'No'}}</td>
-                <td>{{faqItem.subscribed ? 'Yes' : 'No'}}</td>
-            </tr>
-        </tbody>
-    </table>
-    <hr ng-if="@Model.GuildId != @Model.PalaceGuildId" />
+<div x-data="faqCustomizationPage()">
+    @if (Model.GuildId != Model.PalaceGuildId) {
+        <div style="display: flex; align-items: center; justify-content: space-between;">
+            <h2>Palace FAQs</h2>
+            <input class="form-control" x-model="palaceSearchTerm" style="width: 500px" placeholder="Search (Name, Keywords, Explanation)" name="palaceSearchTerm" />
+        </div>
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Keywords</th>
+                    <th>Weight</th>
+                    <th colspan="2">Explanation</th>
+                    <th>Staff Only</th>
+                    <th>Subscribed</th>
+                </tr>
+            </thead>
+            <tbody>
+                <template x-if="filteredPalaceItems().length === 0">
+                    <tr>
+                        <td colspan="7" style="text-align: center; font-weight: bold;">No items to show.</td>
+                    </tr>
+                </template>
+                <template x-for="faqItem in filteredPalaceItems()" :key="faqItem.name">
+                    <tr @@click="editItem(faqItem, true)" style="cursor:pointer;">
+                        <td x-text="faqItem.name"></td>
+                        <td x-text="faqItem.Keywords.join(', ')"></td>
+                        <td x-text="faqItem.weight"></td>
+                        <td colspan="2" x-text="minifyIfOver(faqItem.explanation)"></td>
+                        <td x-text="faqItem.staffOnly ? 'Yes' : 'No'"></td>
+                        <td x-text="faqItem.subscribed ? 'Yes' : 'No'"></td>
+                    </tr>
+                </template>
+            </tbody>
+        </table>
+        <hr />
+    }
 
     <div style="display: flex; align-items: center; justify-content: space-between;">
         <h2>@Model.GuildName FAQs</h2>
-        <input class="form-control" ng-model="guildSearchTerm" style="width: 500px" placeholder="Search (Name, Keywords, Explanation)" name="guildSearchTerm" />
+        <input class="form-control" x-model="guildSearchTerm" style="width: 500px" placeholder="Search (Name, Keywords, Explanation)" name="guildSearchTerm" />
     </div>
     <table class="table table-striped table-hover">
         <thead>
@@ -52,20 +58,24 @@
             </tr>
         </thead>
         <tbody>
-            <tr ng-if="filteredGuildItems.length == 0">
-                <td colspan="8" style="text-align: center; font-weight: bold;">No items to show.</td>
-            </tr>
-            <tr ng-else ng-repeat="faqItem in filteredGuildItems = (items | filter:guildFilter)" ng-click="EditItem(faqItem, false)">
-                <td>{{faqItem.name}}</td>
-                <td>{{faqItem.Keywords.join(", ")}}</td>
-                <td>{{faqItem.weight}}</td>
-                <td colspan="2">{{minifyIfOver(faqItem.explanation)}}</td>
-                <td>{{faqItem.staffOnly ? 'Yes' : 'No'}}</td>
-                <td>{{faqItem.createdBy}}</td>
-            </tr>
+            <template x-if="filteredGuildItems().length === 0">
+                <tr>
+                    <td colspan="7" style="text-align: center; font-weight: bold;">No items to show.</td>
+                </tr>
+            </template>
+            <template x-for="faqItem in filteredGuildItems()" :key="faqItem.name">
+                <tr @@click="editItem(faqItem, false)" style="cursor:pointer;">
+                    <td x-text="faqItem.name"></td>
+                    <td x-text="faqItem.Keywords.join(', ')"></td>
+                    <td x-text="faqItem.weight"></td>
+                    <td colspan="2" x-text="minifyIfOver(faqItem.explanation)"></td>
+                    <td x-text="faqItem.staffOnly ? 'Yes' : 'No'"></td>
+                    <td x-text="faqItem.createdBy"></td>
+                </tr>
+            </template>
             <tr>
                 <td colspan="7" style="text-align: center;">
-                    <button ng-click="EditItem(null)" class="btn btn-primary" style="display: inline-block;">
+                    <button @@click="editItem(null, false)" class="btn btn-primary" style="display: inline-block;">
                         Add FAQ Topic
                     </button>
                 </td>
@@ -73,427 +83,380 @@
         </tbody>
     </table>
 
-    <script type="text/ng-template" id="Edit.html">
-        <style>
-            .modal-body {
-                max-height: calc(100vh - 180px);
-                overflow-y: auto;
-            }
-
-            .grid-container {
-                display: grid;
-                grid-template-columns: repeat(2, 1fr);
-                gap: 10px;
-                margin-top: 10px;
-            }
-
-            .grid-item {
-                display: flex;
-                flex-direction: column;
-            }
-
-                .grid-item label {
-                    margin-bottom: 5px;
-                }
-        </style>
-
-        <div class="modal-header d-flex justify-content-between align-items-center">
-            <span ng-if="!newItem">FAQ Topic - {{ item.name }}</span>
-            <span ng-if="newItem">New FAQ Topic</span>
-            <button type="button" class="close" ng-click="Cancel()" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-
-        <div class="modal-body overflow-auto">
-            <div class="form-group">
-                <label>
-                    Name <span style="color:red">*</span><br />
-                    <span style="font-size: 0.9rem; color: gray;">
-                                Will be displayed on the Discord embed. Max length of @Model.KeywordMaxLength.
-                    </span>
-                </label>
-                <input ng-disabled="isSubscribe" maxlength="@Model.KeywordMaxLength" autocomplete="off" aria-autocomplete="none" class="form-control" ng-model="item.name" />
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Keywords <span style="color:red">*</span><br />
-                    <span style="font-size: 0.9rem; color: gray;">
-                        These are how users will search for the topic. Formatting will be coerced.
-                    </span>
-                </label><br>
-                <div ng-repeat="keyword in item.Keywords track by $index" style="display: flex; align-items: center; margin-bottom: 5px;">
-                    <input ng-disabled="isSubscribe" maxlength="@Model.KeywordMaxLength" autocomplete="off" aria-autocomplete="none" type="text" class="form-control" ng-model="item.Keywords[$index]" ng-blur="formatKeyword($index)" style="margin-right: 10px;" />
-                    <button ng-if="!isSubscribe" type="button" class="btn btn-danger" ng-click="removeKeyword($index)">Remove</button>
-                </div>
-                <button ng-if="!isSubscribe" type="button" class="btn btn-primary" ng-click="addKeyword()">Add Keyword</button>
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Weight<br>
-                    <span style="font-size: 0.9rem; color: gray;">
-                        Importance while topics are being looked for. Higher weight will make an item appear first.
-                    </span>
-                </label>
-                <input ng-disabled="isSubscribe" class="form-control" type="number" ng-model="item.weight" />
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Explanation <span style="color:red">*</span><br />
-                    <span style="font-size: 0.9rem; color: gray;">
-                        The "answer" text a user should be displayed while searching for the topic on Discord.
-                    </span>
-                    <span style="margin-bottom: 10px;">
-                        <br />
-                        <a href="javascript:void(0);" class="text-info" data-toggle="collapse" data-target="#preprocessorDescription" aria-expanded="false" aria-controls="preprocessorDescription">
-                            <span id="toggleText">Custom Preprocessor Information</span>
-                            <i class="fas fa-chevron-right" id="toggleIcon"></i>
-                        </a>
-                        <span class="collapse" id="preprocessorDescription">
-                            <span style="display: block; padding: 10px; border: 1px solid #ccc; background-color: #f9f9f9;" ng-non-bindable>
-                                <code>{{emoji:emoji_name}}</code> will insert any matching emoji from the server in question.<br/>
-                                <code>{{command:command_name}}</code> will insert a clickable command, if found - otherwise a discord in-line code block.<br/>
-                            </span>
+    <div class="modal fade" id="editFaqModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <style>
+                    .modal-body { max-height: calc(100vh - 180px); overflow-y: auto; }
+                    .grid-container { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-top: 10px; }
+                    .grid-item { display: flex; flex-direction: column; }
+                    .grid-item label { margin-bottom: 5px; }
+                </style>
+                <div class="modal-header d-flex justify-content-between align-items-center">
+                    <template x-if="selectedItem">
+                        <span>
+                            <span x-show="!isSubscribe && !newItem" x-text="'FAQ Topic - ' + selectedItem.name"></span>
+                            <span x-show="!isSubscribe && newItem">New FAQ Topic</span>
+                            <span x-show="isSubscribe">Subscribe to FAQ Topic</span>
                         </span>
-                    </span>
-                </label>
-                <textarea rows="8" ng-disabled="isSubscribe" autocomplete="off" aria-autocomplete="none" spellcheck="false" class="form-control" ng-model="item.explanation"></textarea>
-                <div style="font-size: 0.9rem; margin-top: 5px;"
-                     ng-style="{
-                         'color': item.explanation.length > 1024 ? 'red' :
-                                  item.explanation.length >= 950 ? 'orange' : 'green'
-                     }">
-                    <!-- Color text green if below 900, yellow if 900+, red if 1024+ -->
-                    Character Count: {{ item.explanation.length }} / 1024
-                    <br ng-if="item.explanation.length > 950">
-                    <span ng-show="item.explanation.length > 950 && item.explanation.length <= 1024" style="color: orange;">
-                        You are approaching the 1024 character limit.<br>If you have any formatting, this may surpass the character limit in Discord embeds.
-                    </span>
-                    <span ng-show="item.explanation.length > 1024" style="color: red;">
-                        You have exceeded the character limit!<br>Users may not be able to see this topic's information from Discord!
-                    </span>
+                    </template>
+                    <button type="button" class="btn-close" @@click="cancel()" aria-label="Close"></button>
                 </div>
-            </div>
+                <div class="modal-body overflow-auto">
+                    <template x-if="selectedItem">
+                        <div>
+                            <div class="form-group mb-3">
+                                <label>
+                                    Name <span style="color:red">*</span><br />
+                                    <span style="font-size: 0.9rem; color: gray;">
+                                        Will be displayed on the Discord embed. Max length of @Model.KeywordMaxLength.
+                                    </span>
+                                </label>
+                                <input :disabled="isSubscribe" maxlength="@Model.KeywordMaxLength" autocomplete="off" class="form-control" x-model="selectedItem.name" />
+                            </div>
 
-            <div class="form-group">
-                <label>
-                    Staff Only <input ng-disabled="isSubscribe" type="checkbox" ng-model="item.staffOnly" style="margin-left: 2%;"><br>
-                    <span style="font-size: 0.9rem; color: gray;">
-                        If true, will only be findable by users with the "Moderate Members" Discord permission.
-                    </span>
-                </label>
-            </div>
+                            <div class="form-group mb-3">
+                                <label>
+                                    Keywords <span style="color:red">*</span><br />
+                                    <span style="font-size: 0.9rem; color: gray;">These are how users will search for the topic. Formatting will be coerced.</span>
+                                </label><br>
+                                <template x-for="(keyword, kIdx) in selectedItem.Keywords" :key="kIdx">
+                                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                                        <input :disabled="isSubscribe" maxlength="@Model.KeywordMaxLength" autocomplete="off" type="text" class="form-control" x-model="selectedItem.Keywords[kIdx]" @@blur="formatKeyword(kIdx)" style="margin-right: 10px;" />
+                                        <button x-show="!isSubscribe" type="button" class="btn btn-danger" @@click="removeKeyword(kIdx)">Remove</button>
+                                    </div>
+                                </template>
+                                <button x-show="!isSubscribe" type="button" class="btn btn-primary" @@click="selectedItem.Keywords.push('')">Add Keyword</button>
+                            </div>
 
-            <div class="form-group">
-                <label>
-                    Embedded Image URL<br>
-                    <span style="font-size: 0.9rem; color: gray;">
-                        Will be displayed at the bottom of the Discord embed.<br>
-                        Should match the formatting <code>https://awebsite.com/image.jpg</code> for most consistent results.
-                    </span>
-                </label>
-                <input ng-disabled="isSubscribe" class="form-control" ng-model="item.imageUrl" ng-change="validateImageUrl()" />
+                            <div class="form-group mb-3">
+                                <label>
+                                    Weight<br>
+                                    <span style="font-size: 0.9rem; color: gray;">Importance while topics are being looked for. Higher weight will make an item appear first.</span>
+                                </label>
+                                <input :disabled="isSubscribe" class="form-control" type="number" x-model.number="selectedItem.weight" />
+                            </div>
 
-                <!-- Image preview pane -->
-                <div ng-if="isValidImageUrl(item.imageUrl)" style="margin-top: 10px;">
-                    <label style="font-size: 0.9rem; color: gray;">Image Preview</label>
-                    <div style="max-width: 65%; max-height: 50%; border: 1px solid #ccc; overflow: hidden; text-align: left;">
-                        <img ng-src="{{ item.imageUrl }}" alt="Image preview" style="width: 100%; height: auto;" />
-                    </div>
+                            <div class="form-group mb-3">
+                                <label>
+                                    Explanation <span style="color:red">*</span><br />
+                                    <span style="font-size: 0.9rem; color: gray;">The "answer" text a user should be displayed while searching for the topic on Discord.</span>
+                                    <span style="margin-bottom: 10px;">
+                                        <br />
+                                        <a href="javascript:void(0);" class="text-info" data-bs-toggle="collapse" data-bs-target="#preprocessorDescription" aria-expanded="false" aria-controls="preprocessorDescription">
+                                            <span id="toggleText">Custom Preprocessor Information</span>
+                                        </a>
+                                        <span class="collapse" id="preprocessorDescription">
+                                            <span style="display: block; padding: 10px; border: 1px solid #ccc; background-color: #f9f9f9;">
+                                                <code>{{emoji:emoji_name}}</code> will insert any matching emoji from the server in question.<br/>
+                                                <code>{{command:command_name}}</code> will insert a clickable command, if found - otherwise a discord in-line code block.<br/>
+                                            </span>
+                                        </span>
+                                    </span>
+                                </label>
+                                <textarea rows="8" :disabled="isSubscribe" autocomplete="off" spellcheck="false" class="form-control" x-model="selectedItem.explanation"></textarea>
+                                <!-- Color text green if below 900, yellow if 900+, red if 1024+ -->
+                                <div style="font-size: 0.9rem; margin-top: 5px;"
+                                     :style="{
+                                         'color': selectedItem.explanation.length > 1024 ? 'red' :
+                                                  selectedItem.explanation.length >= 950 ? 'orange' : 'green'
+                                     }">
+                                    Character Count: <span x-text="selectedItem.explanation.length"></span> / 1024
+                                    <span x-show="selectedItem.explanation.length > 950 && selectedItem.explanation.length <= 1024" style="color: orange; display: block;">
+                                        You are approaching the 1024 character limit.<br>If you have any formatting, this may surpass the character limit in Discord embeds.
+                                    </span>
+                                    <span x-show="selectedItem.explanation.length > 1024" style="color: red; display: block;">
+                                        You have exceeded the character limit!<br>Users may not be able to see this topic's information from Discord!
+                                    </span>
+                                </div>
+                            </div>
+
+                            <div class="form-group mb-3">
+                                <label>
+                                    Staff Only <input :disabled="isSubscribe" type="checkbox" x-model="selectedItem.staffOnly" style="margin-left: 2%;"><br>
+                                    <span style="font-size: 0.9rem; color: gray;">If true, will only be findable by users with the "Moderate Members" Discord permission.</span>
+                                </label>
+                            </div>
+
+                            <div class="form-group mb-3">
+                                <label>
+                                    Embedded Image URL<br>
+                                    <span style="font-size: 0.9rem; color: gray;">Will be displayed at the bottom of the Discord embed.</span>
+                                </label>
+                                <input :disabled="isSubscribe" class="form-control" x-model="selectedItem.imageUrl" />
+                                <!-- Image preview pane -->
+                                <div x-show="isValidImageUrl(selectedItem.imageUrl)" style="margin-top: 10px;">
+                                    <label style="font-size: 0.9rem; color: gray;">Image Preview</label>
+                                    <div style="max-width: 65%; max-height: 50%; border: 1px solid #ccc; overflow: hidden; text-align: left;">
+                                        <img :src="selectedItem.imageUrl" alt="Image preview" style="width: 100%; height: auto;" />
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="form-group mb-3">
+                                <label>
+                                    Discord Embed Color<br>
+                                    <span style="font-size: 0.9rem; color: gray;">Should be in hex format (e.g., <code>#AABBCC</code>). Default: <code>#607D8B</code>.</span>
+                                </label>
+                                <div style="display: flex; align-items: center;">
+                                    <input :disabled="isSubscribe" autocomplete="off" type="text" class="form-control" x-model="selectedItem.embedColorHex" @@input="formatColor()" style="margin-right: 10px;" />
+                                    <input :disabled="isSubscribe" autocomplete="off" type="color" x-model="selectedItem.embedColorHex" @@input="formatColor()" />
+                                </div>
+                            </div>
+
+                            <div class="form-group mb-3">
+                                <label>Created by<br /><span style="font-size: 0.9rem; color: gray;">Only stored for record keeping purposes.</span></label>
+                                <div class="grid-container">
+                                    <div class="grid-item"><label>Discord Name</label><input disabled class="form-control" :value="selectedItem.createdBy" /></div>
+                                    <div class="grid-item"><label>Discord ID</label><input disabled class="form-control" :value="selectedItem.createdByIdString" /></div>
+                                    <div class="grid-item"><label>Server Name</label><input disabled class="form-control" :value="selectedItem.guildName" /></div>
+                                    <div class="grid-item"><label>Server ID</label><input disabled class="form-control" :value="selectedItem.guildIdString" /></div>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
                 </div>
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Discord Embed Color<br>
-                    <span style="font-size: 0.9rem; color: gray;">
-                        Should be in hex format (e.g., <code>#AABBCC</code>). Will default to <code>DarkGrey</code> (<code>#607D8B</code>) if not otherwise set.
-                    </span>
-                </label>
-                <div style="display: flex; align-items: center;">
-                    <input ng-disabled="isSubscribe" autocomplete="off" aria-autocomplete="none" type="text" class="form-control" ng-model="item.embedColorHex" ng-change="updateColor()" style="margin-right: 10px;" />
-                    <input ng-disabled="isSubscribe" autocomplete="off" aria-autocomplete="none" type="color" ng-model="item.embedColorHex" ng-change="formatColor()" />
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Created by<br />
-                    <span style="font-size: 0.9rem; color: gray;">
-                        Only stored for record keeping purposes.
-                    </span>
-                </label>
-                <div class="grid-container">
-                    <div class="grid-item">
-                        <label>Discord Name</label>
-                        <input disabled class="form-control" ng-model="item.createdBy" />
-                    </div>
-                    <div class="grid-item">
-                        <label>Discord ID</label>
-                        <input disabled class="form-control" ng-model="item.createdByIdString" />
-                    </div>
-                    <div class="grid-item">
-                        <label>Server Name</label>
-                        <input disabled class="form-control" ng-model="item.guildName" />
-                    </div>
-                    <div class="grid-item">
-                        <label>Server ID</label>
-                        <input disabled class="form-control" ng-model="item.guildIdString" />
+                <div class="modal-footer" style="display: flex; justify-content: space-between; align-items: center;">
+                    <span style="color: red;">* Required field</span>
+                    <div style="display: flex; gap: 10px;">
+                        <button x-show="isSubscribe && selectedItem && !selectedItem.subscribed" class="btn btn-success" :disabled="isInsertDisabled()" @@click="subscribe()">Subscribe</button>
+                        <button x-show="isSubscribe && selectedItem && selectedItem.subscribed" class="btn btn-danger" :disabled="isInsertDisabled()" @@click="unsubscribe()">Unsubscribe</button>
+                        <button x-show="!isSubscribe" class="btn btn-success" :disabled="isInsertDisabled()" @@click="saveItem()">Save</button>
+                        <button class="btn btn-warning" @@click="cancel()">Cancel</button>
+                        @if (User.IsInRole("Admin")) {
+                        <button x-show="!isSubscribe" class="btn btn-danger" @@click="deleteItem()">Delete</button>
+                        } else {
+                        <button x-show="!isSubscribe && selectedItem && selectedItem.byUser" class="btn btn-danger" @@click="deleteItem()">Delete</button>
+                        }
                     </div>
                 </div>
             </div>
         </div>
-
-        <div class="modal-footer ng-scope" style="display: flex; justify-content: space-between; align-items: center;">
-            <span style="color: red;">* Required field</span>
-            <div style="display: flex; gap: 10px;">
-                <button ng-if="isSubscribe && !item.subscribed" class="btn btn-success" ng-disabled="IsInsertDisabled()" ng-click="Subscribe()">Subscribe</button>
-                <button ng-if="isSubscribe && item.subscribed" class="btn btn-danger" ng-disabled="IsInsertDisabled()" ng-click="Unsubscribe()">Unsubscribe</button>
-                <button ng-if="!isSubscribe" class="btn btn-success" ng-disabled="IsInsertDisabled()" ng-click="Save()">Save</button>
-                <button class="btn btn-warning" ng-click="Cancel()">Cancel</button>
-                <button class="btn btn-danger" ng-if="!isSubscribe && (@User.IsInRole("Admin") || item.byUser)" ng-click="DeleteItem()">Delete</button>
-            </div>
-        </div>
-    </script>
+    </div>
 </div>
+
 @section Scripts {
     <style>
-        .md-errors-spacer {
-            display: none;
-        }
-
-        trix-editor.form-control {
-            height: auto;
-        }
+        .md-errors-spacer { display: none; }
+        trix-editor.form-control { height: auto; }
     </style>
 
-
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('AdminPage', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-                // Setup items from Model
-                $scope.items = @Html.Raw(Json.Serialize(Model.GuildFAQTopics));
-                $scope.palaceItems = @Html.Raw(Json.Serialize(Model.PalaceFAQTopics));
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('faqCustomizationPage', () => ({
+                items: [],
+                palaceItems: [],
+                palaceSearchTerm: '',
+                guildSearchTerm: '',
+                selectedItem: null,
+                savedItem: null,
+                isSubscribe: false,
+                newItem: false,
+                _modal: null,
 
-                angular.forEach($scope.palaceItems, function (palaceItem) {
-                    if (palaceItem.subscribedGuildIds != null && palaceItem.subscribedGuildIds != []) {
-                        palaceItem.subscribed = palaceItem.subscribedGuildIds.includes(@Model.GuildId.ToString())
-                    }
-                });
+                init() {
+                    const _guildRaw = @Html.Raw(Json.Serialize(Model.GuildFAQTopics));
+                    this.items = _guildRaw.map(item => ({
+                        ...item,
+                        Keywords: JSON.parse(item._keywords || '[]'),
+                        byUser: (item.createdByIdString === '@Model.UserDiscordId.ToString()')
+                    }));
 
-                angular.forEach($scope.items, function (item) {
-                    item.Keywords = JSON.parse(item._keywords || '[]');
-                    item.byUser = (item.createdByIdString == '@Model.UserDiscordId');
-                });
+                    const _palaceRaw = @Html.Raw(Json.Serialize(Model.PalaceFAQTopics));
+                    this.palaceItems = _palaceRaw.map(item => ({
+                        ...item,
+                        Keywords: JSON.parse(item._keywords || '[]'),
+                        subscribed: item.subscribedGuildIds != null && item.subscribedGuildIds.includes('@Model.GuildId.ToString()')
+                    }));
 
-                angular.forEach($scope.palaceItems, function (item) {
-                    item.Keywords = JSON.parse(item._keywords || '[]');
-                });
-
-                $scope.minifyIfOver = function (str) {
-                    if (!str) return '';
-                    if (str.length > 200) {
-                        return str.substr(0, 200) + ' [...]';
-                    } else return str;
-                };
-
-                // Filter function for palace items
-                $scope.palaceFilter = function (faqItem) {
-                    if (!$scope.palaceSearchTerm) {
-                        return true;
-                    }
-                    var searchTerm = $scope.palaceSearchTerm.toLowerCase();
-                    return faqItem.name.toLowerCase().includes(searchTerm) ||
-                        faqItem.Keywords.join(", ").toLowerCase().includes(searchTerm) ||
-                        faqItem.explanation.toLowerCase().includes(searchTerm);
-                };
-
-                // Filter function for guild items
-                $scope.guildFilter = function (faqItem) {
-                    if (!$scope.guildSearchTerm) {
-                        return true;
-                    }
-                    var searchTerm = $scope.guildSearchTerm.toLowerCase();
-                    return faqItem.name.toLowerCase().includes(searchTerm) ||
-                        faqItem.Keywords.join(", ").toLowerCase().includes(searchTerm) ||
-                        faqItem.explanation.toLowerCase().includes(searchTerm);
-                };
-
-                // Modal setup
-                $scope.EditItem = function EditItem(item, subscribeModal) {
-                    $uibModal.open({
-                        templateUrl: 'Edit.html',
-                        size: 'lg',
-                        backdrop: 'static',
-                        animation: false,
-                        controller: function ($scope, $uibModalInstance) {
-                            $scope.isSubscribe = subscribeModal;
-                            $scope.isNewItem = !item;
-                            $scope.originalKeywordsCount = item ? item.Keywords.length : 0;
-
-                            // Utility functions
-                            $scope.isValidImageUrl = function (url) {
-                                if (!url) return false;
-                                const imageExtensions = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'];
-                                const urlExtension = url.split('.').pop().toLowerCase();
-                                return imageExtensions.includes(urlExtension);
-                            };
-
-                            $scope.formatColor = function () {
-                                if ($scope.item.embedColorHex && $scope.item.embedColorHex[0] !== '#') {
-                                    $scope.item.embedColorHex = '#' + $scope.item.embedColorHex;
-                                }
-                            };
-
-                            $scope.updateColor = function () {
-                                $scope.formatColor();
-                            };
-
-                            $scope.formatKeyword = function (index) {
-                                $scope.item.Keywords[index] = $scope.item.Keywords[index].toLowerCase().replace(/[^a-z0-9 ]/g, '');
-                            };
-
-                            $scope.addKeyword = function () {
-                                $scope.item.Keywords.push('');
-                            };
-
-                            $scope.removeKeyword = function (index) {
-                                $scope.item.Keywords.splice(index, 1);
-                            };
-
-                            $scope.IsInsertDisabled = function IsInsertDisabled() {
-                                const hexColorRegex = /^#[0-9A-F]{6}$/i;
-                                const isColorValid = !$scope.item.embedColorHex || hexColorRegex.test($scope.item.embedColorHex);
-                                const hasValidKeywords = $scope.item.Keywords.length > 0 && !$scope.item.Keywords.includes('');
-
-                                return (
-                                    $scope.item.name === '' ||
-                                    !hasValidKeywords ||
-                                    $scope.item.explanation === '' ||
-                                    isNaN($scope.item.weight) ||
-                                    !isColorValid
-                                );
-                            };
-
-                            // Item declarations and setup
-                            if (item != null) {
-                                $scope.item = item;
-                                $scope.newItem = false;
-                                $scope.formatColor();
-                            } else {
-                                console.log("Creating new item");
-                                $scope.newItem = true;
-                                $scope.item = {
-                                    internalId: '',
-                                    name: '',
-                                    _keywords: '',
-                                    weight: 0,
-                                    explanation: '',
-                                    staffOnly: false,
-                                    imageUrl: '',
-                                    embedColorHex: '#607D8B',
-                                    createdBy: '@Model.UserDiscordUsername',
-                                    createdByIdString: '@Model.UserDiscordId.ToString()',
-                                    guildName: '@Model.GuildName',
-                                    guildIdString: '@Model.GuildId.ToString()',
-                                    Keywords: [''],
-                                };
-                            }
-
-                            // Action functions
-                            $scope.Save = function Save() {
-                                // Remove empty keywords before saving
-                                $scope.item.Keywords = $scope.item.Keywords
-                                    .filter(keyword => keyword.trim() !== '')  // Remove empty keywords
-                                    .map(keyword => keyword.toLowerCase());   // Normalize keywords to lowercase
-
-                                // Ensure 'uniqueness' - no duplicate keywords
-                                $scope.item.Keywords = [...new Set($scope.item.Keywords)];
-                                $scope.item._keywords = JSON.stringify($scope.item.Keywords);
-
-                                console.log($scope.item);
-                                $http({ method: 'POST', url: '/admin/savefaqtopic/', data: $scope.item, headers: { 'Content-Type': 'application/json' } })
-                                    .then(function successCallback(response) {
-                                        if (response.data.Error) {
-                                            alert(response.data.Error);
-                                            return;
-                                        }
-                                        $uibModalInstance.close();
-                                        location.reload();
-                                    }, function errorCallback(response) {
-                                        alert('Error Saving');
-                                    });
-                            };
-
-                            $scope.Subscribe = function Subscribe() {
-                                // Get the current subscribedGuildIds of the item
-                                let subscribedGuildIds = $scope.item.subscribedGuildIds || [];
-                                // Add Model.GuildId to the list if not already present
-                                if (!subscribedGuildIds.includes(@Model.GuildId)) {
-                                    subscribedGuildIds.push(@Model.GuildId);
-                                }
-                                // Set the new subscribedGuildIds list
-                                $scope.item.subscribedGuildIds = subscribedGuildIds;
-                                $scope.item.subscribed = true;
-
-                                $http({ method: 'POST', url: '/admin/savefaqtopic/', data: $scope.item, headers: { 'Content-Type': 'application/json' } })
-                                    .then(function successCallback(response) {
-                                        if (response.data.Error) {
-                                            alert(response.data.Error);
-                                            return;
-                                        }
-                                    }, function errorCallback(response) {
-                                        alert('Error Saving');
-                                    });
-                            }
-
-                            $scope.Unsubscribe = function Unsubscribe() {
-                                // Get the current subscribedGuildIds of the item
-                                let subscribedGuildIds = $scope.item.subscribedGuildIds || [];
-                                // Remove Model.GuildId from the list
-                                subscribedGuildIds = subscribedGuildIds.filter(guildId => guildId !== @Model.GuildId);
-                                // Set the new subscribedGuildIds list
-                                $scope.item.subscribedGuildIds = subscribedGuildIds;
-                                $scope.item.subscribed = false;
-
-                                $http({ method: 'POST', url: '/admin/savefaqtopic/', data: $scope.item, headers: { 'Content-Type': 'application/json' } })
-                                    .then(function successCallback(response) {
-                                        if (response.data.Error) {
-                                            alert(response.data.Error);
-                                            return;
-                                        }
-                                    }, function errorCallback(response) {
-                                        alert('Error Saving');
-                                    });
-                            }
-
-                            $scope.Cancel = function Cancel() {
-                                $uibModalInstance.close();
-                            };
-
-                            $scope.DeleteItem = function DeleteItem() {
-                                if (confirm("Are you sure you want to delete this item?")) {
-                                    $http({ method: 'POST', url: '/admin/deletefaqtopic/', data: $scope.item, headers: { 'Content-Type': 'application/json' } })
-                                        .then(function successCallback(response) {
-                                            if (response.data.Error) {
-                                                console.error("Error from server:", response.data.Error);
-                                                alert(response.data.Error);
-                                                return;
-                                            }
-                                            $uibModalInstance.close();
-                                            location.reload();
-                                        }, function errorCallback(response) {
-                                            console.error("Error during HTTP request:", response);
-                                            alert('Error Deleting');
-                                        });
-                                }
-                            };
-                        }
+                    this._modal = new bootstrap.Modal(document.getElementById('editFaqModal'));
+                    document.getElementById('editFaqModal').addEventListener('hidden.bs.modal', () => {
+                        this.selectedItem = null;
                     });
-                };
-            }]);
+                },
+
+                filteredPalaceItems() {
+                    if (!this.palaceSearchTerm) return this.palaceItems;
+                    const term = this.palaceSearchTerm.toLowerCase();
+                    return this.palaceItems.filter(item =>
+                        item.name.toLowerCase().includes(term) ||
+                        item.Keywords.join(', ').toLowerCase().includes(term) ||
+                        (item.explanation || '').toLowerCase().includes(term)
+                    );
+                },
+
+                filteredGuildItems() {
+                    if (!this.guildSearchTerm) return this.items;
+                    const term = this.guildSearchTerm.toLowerCase();
+                    return this.items.filter(item =>
+                        item.name.toLowerCase().includes(term) ||
+                        item.Keywords.join(', ').toLowerCase().includes(term) ||
+                        (item.explanation || '').toLowerCase().includes(term)
+                    );
+                },
+
+                minifyIfOver(str) {
+                    if (!str) return '';
+                    return str.length > 200 ? str.substr(0, 200) + ' [...]' : str;
+                },
+
+                editItem(item, isSubscribeModal) {
+                    this.isSubscribe = isSubscribeModal;
+                    this.newItem = !item;
+                    if (item) {
+                        // Deep-clone so cancel() can restore the original values
+                        this.savedItem = JSON.parse(JSON.stringify(item));
+                        this.selectedItem = item;
+                        this.formatColor();
+                    } else {
+                        this.savedItem = null;
+                        this.selectedItem = {
+                            internalId: '',
+                            name: '',
+                            _keywords: '',
+                            weight: 0,
+                            explanation: '',
+                            staffOnly: false,
+                            imageUrl: '',
+                            embedColorHex: '#607D8B',
+                            createdBy: '@Model.UserDiscordUsername',
+                            createdByIdString: '@Model.UserDiscordId.ToString()',
+                            guildName: '@Model.GuildName',
+                            guildIdString: '@Model.GuildId.ToString()',
+                            Keywords: ['']
+                        };
+                    }
+                    this._modal.show();
+                },
+
+                cancel() {
+                    // Restore to pre-edit state so the table row doesn't show dirty data
+                    if (this.savedItem && this.selectedItem) {
+                        Object.assign(this.selectedItem, this.savedItem);
+                    }
+                    this._modal.hide();
+                },
+
+                isValidImageUrl(url) {
+                    if (!url) return false;
+                    const ext = url.split('.').pop().toLowerCase();
+                    return ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'].includes(ext);
+                },
+
+                formatColor() {
+                    if (this.selectedItem && this.selectedItem.embedColorHex && this.selectedItem.embedColorHex[0] !== '#') {
+                        this.selectedItem.embedColorHex = '#' + this.selectedItem.embedColorHex;
+                    }
+                },
+
+                formatKeyword(index) {
+                    this.selectedItem.Keywords[index] = this.selectedItem.Keywords[index].toLowerCase().replace(/[^a-z0-9 ]/g, '');
+                },
+
+                removeKeyword(index) {
+                    this.selectedItem.Keywords.splice(index, 1);
+                },
+
+                isInsertDisabled() {
+                    if (!this.selectedItem) return true;
+                    const hexColorRegex = /^#[0-9A-F]{6}$/i;
+                    const isColorValid = !this.selectedItem.embedColorHex || hexColorRegex.test(this.selectedItem.embedColorHex);
+                    const hasValidKeywords = this.selectedItem.Keywords.length > 0 && !this.selectedItem.Keywords.includes('');
+                    return (
+                        this.selectedItem.name === '' ||
+                        !hasValidKeywords ||
+                        this.selectedItem.explanation === '' ||
+                        isNaN(this.selectedItem.weight) ||
+                        !isColorValid
+                    );
+                },
+
+                async saveItem() {
+                    // Remove empty keywords before saving; ensure uniqueness — no duplicate keywords
+                    this.selectedItem.Keywords = [...new Set(
+                        this.selectedItem.Keywords
+                            .filter(k => k.trim() !== '')   // Remove empty keywords
+                            .map(k => k.toLowerCase())      // Normalize keywords to lowercase
+                    )];
+                    this.selectedItem._keywords = JSON.stringify(this.selectedItem.Keywords);
+                    try {
+                        const r = await fetch('/admin/savefaqtopic/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(this.selectedItem)
+                        });
+                        const data = await r.json();
+                        if (data.Error) { alert(data.Error); return; }
+                        this._modal.hide();
+                        location.reload();
+                    } catch (e) {
+                        alert('Error Saving');
+                        console.error(e);
+                    }
+                },
+
+                async subscribe() {
+                    // Get the current subscribedGuildIds of the item
+                    let ids = this.selectedItem.subscribedGuildIds || [];
+                    const guildIdStr = '@Model.GuildId.ToString()';
+                    // Add Model.GuildId to the list if not already present
+                    if (!ids.includes(guildIdStr)) ids.push(guildIdStr);
+                    // Set the new subscribedGuildIds list
+                    this.selectedItem.subscribedGuildIds = ids;
+                    this.selectedItem.subscribed = true;
+                    try {
+                        const r = await fetch('/admin/savefaqtopic/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(this.selectedItem)
+                        });
+                        const data = await r.json();
+                        if (data.Error) { alert(data.Error); return; }
+                        this._modal.hide();
+                    } catch (e) {
+                        alert('Error Saving');
+                        console.error(e);
+                    }
+                },
+
+                async unsubscribe() {
+                    const guildIdStr = '@Model.GuildId.ToString()';
+                    // Get the current subscribedGuildIds of the item; remove Model.GuildId from the list
+                    this.selectedItem.subscribedGuildIds = (this.selectedItem.subscribedGuildIds || []).filter(id => id !== guildIdStr);
+                    this.selectedItem.subscribed = false;
+                    try {
+                        const r = await fetch('/admin/savefaqtopic/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(this.selectedItem)
+                        });
+                        const data = await r.json();
+                        if (data.Error) { alert(data.Error); return; }
+                        this._modal.hide();
+                    } catch (e) {
+                        alert('Error Saving');
+                        console.error(e);
+                    }
+                },
+
+                async deleteItem() {
+                    if (!confirm('Are you sure you want to delete this item?')) return;
+                    try {
+                        const r = await fetch('/admin/deletefaqtopic/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(this.selectedItem)
+                        });
+                        const data = await r.json();
+                        if (data.Error) { alert(data.Error); return; }
+                        this._modal.hide();
+                        location.reload();
+                    } catch (e) {
+                        alert('Error Deleting');
+                        console.error(e);
+                    }
+                }
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Admin/Index.cshtml
+++ b/EGG9000.Site/Views/Admin/Index.cshtml
@@ -50,7 +50,7 @@
 
 
 <div class="clearfix">
-	<div class="float-left card">
+	<div class="float-start card">
 		<div class="card-body">
 			<h5 class="card-title">
 				Server Stats
@@ -105,7 +105,7 @@
 		</div>
 	</div>
 
-	<div class="float-left card">
+	<div class="float-start card">
 		<div class="card-body">
 			<h5 class="card-title">
 				Recent Contracts
@@ -117,7 +117,7 @@
 		</div>
 	</div>
 	@if (Model.ContractsToScore.Count > 0) {
-		<div class="float-left card">
+		<div class="float-start card">
 			<div class="card-body">
 				<h5 class="card-title">
 					Contracts Ready to Score

--- a/EGG9000.Site/Views/Admin/LatestDemerits.cshtml
+++ b/EGG9000.Site/Views/Admin/LatestDemerits.cshtml
@@ -21,7 +21,7 @@
     </caption>
     <thead>
         <tr>
-            <th class="text-left">Date</th>
+            <th class="text-start">Date</th>
             <th>User</th>
             <th>Reason</th>
             @if (isAdmin)

--- a/EGG9000.Site/Views/Admin/SaveFAQ.cshtml
+++ b/EGG9000.Site/Views/Admin/SaveFAQ.cshtml
@@ -1,27 +1,30 @@
-﻿<div ng-controller="AdminPage">
-<textarea ng-model="json"></textarea>
-    <button ng-click="Save()">Save</button>
+<div x-data="saveFaqPage()">
+<textarea x-model="json"></textarea>
+    <button @@click="save()">Save</button>
 </div>
 
 @section Scripts {
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('AdminPage', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q',
-            function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-                                            // Action functions
-                                $scope.Save = function Save() {
-                                    $http({ method: 'POST', url: '/admin/savefaqtopic/', data: $scope.json, headers: { 'Content-Type': 'application/json' } })
-                                        .then(function successCallback(response) {
-                                            if (response.data.Error) {
-                                                alert(response.data.Error);
-                                                return;
-                                            }
-                                            $uibModalInstance.close();
-                                            location.reload();
-                                        }, function errorCallback(response) {
-                                            alert('Error Saving');
-                                        });
-                                };
-                            }]);
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('saveFaqPage', () => ({
+                json: '',
+
+                async save() {
+                    try {
+                        const r = await fetch('/admin/savefaqtopic/', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: this.json
+                        });
+                        const data = await r.json();
+                        if (data.Error) { alert(data.Error); return; }
+                        location.reload();
+                    } catch (e) {
+                        alert('Error Saving');
+                        console.error(e);
+                    }
+                }
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Admin/Slackers.cshtml
+++ b/EGG9000.Site/Views/Admin/Slackers.cshtml
@@ -107,7 +107,7 @@
 
 	}
 
-	.bootstrap-dark .bg-warning {
+	[data-bs-theme="dark"] .bg-warning {
 		color: #333;
 	}
 </style>

--- a/EGG9000.Site/Views/Contract/Day1Coops.cshtml
+++ b/EGG9000.Site/Views/Contract/Day1Coops.cshtml
@@ -1,4 +1,4 @@
-﻿@using Discord.WebSocket
+@using Discord.WebSocket
 @model (List<PotentialCoopGroup> coopGroups, List<(String reason, UserByAccount account)> excluded)
 @inject DiscordSocketClient discordClient
 @{
@@ -59,7 +59,7 @@
         overflow: scroll !important;
     }
 </style>
-<div ng-controller="Page">
+<div x-data="day1CoopsPage()">
 
 <div>
     User Counts:
@@ -67,92 +67,108 @@
     @foreach (var grade in grades) {
         <span><img src="@PlayerGradeDetails.GetImage(grade.Key)" style="height: 1em;" /> @grade.Sum(x => x.PotentialCoops?.Sum(y => y.Users.Count) ?? 0) &nbsp;&nbsp;</span>
     }
-    
+
     @foreach(var group in Model.excluded.GroupBy(x => x.reason)) {
         <span>@group.Key: @group.Count() &nbsp;&nbsp;</span>
-    } <button ng-click="ViewExcluded()" class="btn btn-primary">View</button>
+    } <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#excludedModal">View</button>
 </div>
     @if (dbguild.DisableBG) {
         @: Group
     } else {
         @: Boarding Group
     }
-    <select ng-model="bg" ng-options="item as item.BoardingGroup.Name for item in boardingGroups track by item.BoardingGroup.Value"></select>
+    <select x-model="bgIndex" @@change="bg = boardingGroups[parseInt($event.target.value)]">
+        <template x-for="(item, idx) in boardingGroups" :key="item.BoardingGroup.Value">
+            <option :value="idx" x-text="item.BoardingGroup.Name"></option>
+        </template>
+    </select>
 
     <div class="row scrollable">
-        <div class="col-sm" ng-repeat="group in bg.Grades">
-            <h2>
-                <img ng-src="{{group.GradeImage}}" style="height: 1em;" />
-                @if (isAdmin) {
-                    <input ng-model="group.CoopCount" style="width: 60px;" />
-                    <button class="btn btn-primary" ng-click="ReloadGrade(group)">Update Count</button>
-                    <button class="btn btn-primary" ng-click="StartAll(group)" ng-disabled="group.Disable">Start All</button>
-                    <span>
-                        Assigned Users: {{Total(group)}}
-                    </span>
-                    <span>
-                        | Free Spaces: {{FreeSpaces(group)}}
-                    </span>
-                    @if(dbguild.DisableBG) {
-                        <span ng-repeat="item in getExcluded(this)">
-                            | {{item.Reason}}: {{item.Count}}
-                        </span>
-                        
-                    }
-                } else {
-                    @: ({{group.Coops.length}})
-                }
-            </h2>
-
-            <div class="card" ng-repeat="coop in group.Coops">
-                <h5 class="card-header">Coop ({{coop.Users.length}}/@contract.MaxCoopSize)</h5>
-                <table class="table table-striped">
-                    <tbody>
-                        <tr ng-repeat="user in coop.Users">
-                            <td>{{user.Name}} <span ng-if="user.MultipleAccounts">({{user.AccountName}})</span> <span ng-if="user.FromGroup > 0" style="display: inline-block;background-color: mediumvioletred">BG{{user.FromGroup}}</span> <span ng-if="user.Guild.length > 0">[{{user.Guild}}]</span> </td>
-                            <td>{{user.EBString}}</td>
-                        </tr>
-                    </tbody>
-                </table>
-                <div class="card-footer">
-                    Total EB {{coop.TotalEB}}
+        <template x-for="group in (bg ? bg.Grades : [])" :key="group.Grade">
+            <div class="col-sm">
+                <h2>
+                    <img :src="group.GradeImage" style="height: 1em;" />
                     @if (isAdmin) {
-                        <button ng-click="Start(coop, group.Coops, group.Grade)" ng-disabled="coop.Disable || group.Disable">Start</button>
+                        <input x-model.number="group.CoopCount" style="width: 60px;" />
+                        <button class="btn btn-primary" @@click="reloadGrade(group)">Update Count</button>
+                        <button class="btn btn-primary" @@click="startAll(group)" :disabled="group.Disable">Start All</button>
+                        <span>Assigned Users: <span x-text="total(group)"></span></span>
+                        <span>| Free Spaces: <span x-text="freeSpaces(group)"></span></span>
+                        @if(dbguild.DisableBG) {
+                            <template x-for="item in getExcluded(group)" :key="item.Reason">
+                                <span>| <span x-text="item.Reason"></span>: <span x-text="item.Count"></span></span>
+                            </template>
+                        }
+                    } else {
+                        <span>(<span x-text="group.Coops.length"></span>)</span>
                     }
-                </div>
+                </h2>
+
+                <template x-for="(coop, coopIdx) in group.Coops" :key="coopIdx">
+                    <div class="card">
+                        <h5 class="card-header">Coop (<span x-text="coop.Users.length"></span>/@contract.MaxCoopSize)</h5>
+                        <table class="table table-striped">
+                            <tbody>
+                                <template x-for="user in coop.Users" :key="user.EggIncId || user.Name">
+                                    <tr>
+                                        <td>
+                                            <span x-text="user.Name"></span>
+                                            <span x-show="user.MultipleAccounts"> (<span x-text="user.AccountName"></span>)</span>
+                                            <span x-show="user.FromGroup > 0" style="display:inline-block;background-color:mediumvioletred">BG<span x-text="user.FromGroup"></span></span>
+                                            <span x-show="user.Guild && user.Guild.length > 0">[<span x-text="user.Guild"></span>]</span>
+                                        </td>
+                                        <td x-text="user.EBString"></td>
+                                    </tr>
+                                </template>
+                            </tbody>
+                        </table>
+                        <div class="card-footer">
+                            Total EB <span x-text="coop.TotalEB"></span>
+                            @if (isAdmin) {
+                                <button @@click="start(coop, group.Coops, group)" :disabled="coop.Disable || group.Disable">Start</button>
+                            }
+                        </div>
+                    </div>
+                </template>
             </div>
-        </div>
+        </template>
     </div>
 </div>
 
-
-<script type="text/ng-template" id="Excluded">
-    <div class="modal-header">Excluded</div>
-    <table class="modal-body table table-sm table-striped">
-        <thead>
-            <tr>
-                <th>Discord Name</th>
-                <th>Reason</th>
-                @if(dbguild.DisableBG) {
-                    <th>Group</th>
-                }
-            </tr>
-        </thead>
-        <tbody>
-            @foreach(var group in Model.excluded.GroupBy(x => x.reason)) {
-                @foreach(var user in group.OrderBy(x => x.account.RoleId).ThenBy(x => x.account.User.DiscordUsername)) {
+<div class="modal fade" id="excludedModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Excluded</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <table class="modal-body table table-sm table-striped">
+                <thead>
                     <tr>
-                        <td>@user.account.User.DiscordUsername</td>
-                        <td>@user.reason</td>
+                        <th>Discord Name</th>
+                        <th>Reason</th>
                         @if(dbguild.DisableBG) {
-                            <td>@guild.GetRole(user.account.RoleId)</td>
+                            <th>Group</th>
                         }
                     </tr>
-                }
-            }
-        </tbody>
-    </table>
-</script>
+                </thead>
+                <tbody>
+                    @foreach(var group in Model.excluded.GroupBy(x => x.reason)) {
+                        @foreach(var user in group.OrderBy(x => x.account.RoleId).ThenBy(x => x.account.User.DiscordUsername)) {
+                            <tr>
+                                <td>@user.account.User.DiscordUsername</td>
+                                <td>@user.reason</td>
+                                @if(dbguild.DisableBG) {
+                                    <td>@guild.GetRole(user.account.RoleId)</td>
+                                }
+                            </tr>
+                        }
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
 
 @{
     var excluded = Model.excluded.GroupBy(x => new { x.reason, x.account.RoleId, Grade =  x.account.Account.GetGrade() }).Select(x => new { Grade = x.Key.Grade, Reason = x.Key.reason, Count = x.Count(), RoleId = x.Key.RoleId });
@@ -160,90 +176,77 @@
 
 @section Scripts {
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('Page', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-                $scope.boardingGroups = @Html.Raw(JsonConvert.SerializeObject(boardingGroups));
-                $scope.bg = $scope.boardingGroups[0];
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('day1CoopsPage', () => ({
+                boardingGroups: [],
+                bgIndex: 0,
+                bg: null,
+                excluded: [],
 
-                $scope.excluded = @Html.Raw(JsonConvert.SerializeObject(excluded));
+                init() {
+                    const _bgRaw = @Html.Raw(JsonConvert.SerializeObject(boardingGroups));
+                    this.boardingGroups = _bgRaw;
+                    this.bg = this.boardingGroups[0] || null;
 
-                $scope.getExcluded = function(scope) {
-                    var item = _.filter($scope.excluded, function (value, key) {
-                        return value.Grade == scope.group.GradeNum && value.RoleId == $scope.bg.BoardingGroup.RoleId;
-                    });
-                    return item;
-                }
-                console.log($scope.excluded);
+                    const _exRaw = @Html.Raw(JsonConvert.SerializeObject(excluded));
+                    this.excluded = _exRaw;
+                },
 
-                $scope.FreeSpaces = function (grade) {
-                    var freeSpaces = 0;
-                    angular.forEach(grade.Coops, (coop) => {
-                        console.log(coop);
-                        console.log(coop.Users.length);
-                        freeSpaces += @contract.MaxCoopSize - coop.Users.length;
-                    });
-                    return freeSpaces;
-                }
-                $scope.Total = function (grade) {
-                    var total = 0;
-                    angular.forEach(grade.Coops, (coop) => {
-                        total += coop.Users.length;
-                    });
-                    return total;
-                }
+                freeSpaces(grade) {
+                    return grade.Coops.reduce((sum, coop) => sum + (@contract.MaxCoopSize - coop.Users.length), 0);
+                },
 
-                $scope.ReloadGrade = function (grade) {
-                    $http.post("/contract/reloadgrade?GuildId=@ViewBag.GuildId&ContractID=@ViewBag.Contract.ID&Grade=" + grade.Grade + "&bg=" + $scope.bg.BoardingGroup.Value + "&count=" + grade.CoopCount).then(function Success(response) {
-                        console.log(grade.Coops);
-                        console.log(response.data);
-                        grade.Coops = response.data;
-                    }, function Error(response) {
-                        alert("Error");
-                        console.log(response);
-                    });
-                };
+                total(grade) {
+                    return grade.Coops.reduce((sum, coop) => sum + coop.Users.length, 0);
+                },
 
-                $scope.StartAll = function (grade) {
-                    grade.Disable = true;
-                    $http.post("/contract/startcoops?GuildId=@ViewBag.GuildId&ContractID=@ViewBag.Contract.ID&Grade=" + grade.Grade + "&bg=" + $scope.bg.BoardingGroup.Value + "&count=" + grade.CoopCount, grade.Coops).then(function Success(response) {
-                        console.log(grade.Coops);
-                        console.log(response.data);
-                        grade.Coops = response.data;
-                        grade.Disable = false;
-                    }, function Error(response) {
-                        alert("Error");
-                        console.log(response);
-                    });
-                };
+                getExcluded(grade) {
+                    return this.excluded.filter(e => e.Grade === grade.GradeNum && e.RoleId == (this.bg?.BoardingGroup?.RoleId ?? 0));
+                },
 
-                $scope.Start = function (coop, coops, grade) {
-                    if (confirm("Are you sure you want to start this co-op?")) {
-                        coop.Disable = true;
-
-                        var newGrade = {
-                            Grade: grade.Grade,
-                            Coops: [coop]
-                        };
-
-                        $http.post("/contract/startcoops?GuildId=@ViewBag.GuildId&ContractID=@ViewBag.Contract.ID&Grade=" + grade.Grade + "&bg=" + $scope.bg.BoardingGroup.Value + "&count=" + grade.CoopCount, [coop]).then(function Success(response) {
-                            console.log(grade.Coops);
-                            console.log(response.data);
-                            grade.Coops = response.data;
-                            grade.Disable = false;
-                        }, function Error(response) {
-                            alert("Error");
-                            console.log(response);
-                        });
+                async reloadGrade(grade) {
+                    try {
+                        const r = await fetch(`/contract/reloadgrade?GuildId=@ViewBag.GuildId&ContractID=@ViewBag.Contract.ID&Grade=${grade.Grade}&bg=${this.bg.BoardingGroup.Value}&count=${grade.CoopCount}`, { method: 'POST' });
+                        grade.Coops = await r.json();
+                    } catch (e) {
+                        alert('Error');
+                        console.error(e);
                     }
-                };
+                },
 
-                $scope.ViewExcluded = function() {
-                    console.log(1);
-                    $uibModal.open({
-                        templateUrl: 'Excluded',
-                        animation: false,
-                    });
-                };
-            }]);
+                async startAll(grade) {
+                    grade.Disable = true;
+                    try {
+                        const r = await fetch(`/contract/startcoops?GuildId=@ViewBag.GuildId&ContractID=@ViewBag.Contract.ID&Grade=${grade.Grade}&bg=${this.bg.BoardingGroup.Value}&count=${grade.CoopCount}`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(grade.Coops)
+                        });
+                        grade.Coops = await r.json();
+                    } catch (e) {
+                        alert('Error');
+                        console.error(e);
+                    }
+                    grade.Disable = false;
+                },
+
+                async start(coop, coops, grade) {
+                    if (!confirm('Are you sure you want to start this co-op?')) return;
+                    coop.Disable = true;
+                    try {
+                        const r = await fetch(`/contract/startcoops?GuildId=@ViewBag.GuildId&ContractID=@ViewBag.Contract.ID&Grade=${grade.Grade}&bg=${this.bg.BoardingGroup.Value}&count=${grade.CoopCount}`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify([coop])
+                        });
+                        grade.Coops = await r.json();
+                    } catch (e) {
+                        alert('Error');
+                        console.error(e);
+                    }
+                    grade.Disable = false;
+                }
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -554,11 +554,17 @@
                     if (!this.IsAdmin) return;
                     document.querySelectorAll('.sortablers').forEach(el => {
                         if (el._sortable) el._sortable.destroy();
+                        // Only active-coop tbodies carry data-coop-id and accept drops; potential
+                        // coops are drag sources only (put:false), so nothing lands in a non-target.
+                        const isDropTarget = el.dataset.coopId != null;
                         el._sortable = Sortable.create(el, {
-                            group: 'coops',
+                            group: { name: 'coops', pull: true, put: isDropTarget },
+                            sort: false,
                             animation: 150,
                             filter: '.notsortable',
                             onAdd: (evt) => {
+                                // Pull the node SortableJS inserted regardless of outcome; Alpine re-renders.
+                                evt.item.parentNode && evt.item.parentNode.removeChild(evt.item);
                                 const eggIncId = evt.item.dataset.eggIncId;
                                 const toCoopId = evt.to.dataset.coopId;
                                 const toCoop = this.ActiveCoops.find(c => String(c.CoopId) === String(toCoopId));
@@ -570,8 +576,6 @@
                                     if (user) break;
                                 }
                                 if (!user) return;
-                                // Remove the DOM node SortableJS inserted (Alpine will re-render)
-                                evt.item.parentNode && evt.item.parentNode.removeChild(evt.item);
                                 this.dropCallback(user, toCoop);
                             }
                         });

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -110,7 +110,7 @@
         border-color: #00ff90;
     }
 
-    .bootstrap-dark #CurrentCoop {
+    [data-bs-theme="dark"] #CurrentCoop {
         border-color: #4c664b !important;
     }
 
@@ -126,7 +126,7 @@
         background-color: #a2ffa1;
     }
 
-    .bootstrap-dark .CurrentCoop .card-header {
+    [data-bs-theme="dark"] .CurrentCoop .card-header {
         background-color: #2c462b;
     }
 
@@ -154,7 +154,7 @@
         min-height: 42px;
     }
 
-    .bootstrap-dark .dndPlaceHolder {
+    [data-bs-theme="dark"] .dndPlaceHolder {
         background-color: #333 !important;
     }
 
@@ -183,7 +183,7 @@
     }
     
 
-    .bootstrap-dark .pb-3, .bootstrap-dark .py-3 {
+    [data-bs-theme="dark"] .pb-3, [data-bs-theme="dark"] .py-3 {
     padding-bottom: 0 !important;
 }
 </style>
@@ -195,7 +195,7 @@
 
 
 
-<div ng-controller="Page">
+<div x-data="detailsPage()">
     <div style="float: left;">
         <h3><img src="@PlayerGradeDetails.GetImage(Model.League)" style="height: 1em;" /> @Model.GuildContract.Contract.Name</h3>
         <select id="League">
@@ -235,76 +235,77 @@
         <table>
             <tr>
                 <td>Spots in active co-ops</td>
-                <td>{{SpotsActive()}}</td>
+                <td x-text="spotsActive()"></td>
             </tr>
             <tr>
                 <td>Spots in active co-ops >24h</td>
-                <td>{{SpotsActive24()}}</td>
+                <td x-text="spotsActive24()"></td>
             </tr>
         </table>
     </div>
     }
     <div style="clear: both;"></div>
     <div class="row scrollable">
-        <div class="col-sm" ng-if="ActiveCoops.length > 0">
+        <div class="col-sm" x-show="ActiveCoops.length > 0">
             <h2>Active Coops
             @if(isStaff) {
-            <span  class="btn btn-sm btn-primary" ng-click="ToggleAll()">Toggle All</span>
+            <span class="btn btn-sm btn-primary" @@click="toggleAll()">Toggle All</span>
             }
             </h2>
             @if(isStaff) {
-            <p ng-if>
+            <p>
                 Note: The co-ops are sorted such that the top ones listed have spots available with the soonest ending on top.
             </p>
             }
-            <div class="card" ng-repeat="coop in ActiveCoops" ng-class="{ CurrentCoop: coop.CurrentCoop}">
-                <div style="position: relative; top: -20px;" id="{{coop.Name}}" ng-if="coop.CurrentCoop"></div>
-                <h5 class="card-header" ng-click="coop.Hide = !coop.Hide">
-                    <a ng-click="$event.stopPropagation();" ng-if="IsStaff || coop.CurrentCoop" ng-href="/coop/{{coop.ContractID}}/{{coop.Name}}">{{coop.Name}}</a>
-
-                    <a ng-click="$event.stopPropagation();" ng-if="(IsStaff || coop.CurrentCoop) && !coop.DeletedChannel" ng-href="discord://discordapp.com/channels/{{coop.OverflowGuildId}}/{{coop.DiscordChannelId}}/"><img src="/images/discordicon.png" style="max-height: 1em;" /></a>
-
-                    <span style="font-size: 0;"> - {{coop.MaxSize - coop.Users.length}} spot{{coop.MaxSize - coop.Users.length > 1 ? 's' : ''}}</span>
-
-                    <div ng-if="!IsStaff">Co-op</div>
-                    <span style="user-select: none;">{{coop.Status}}</span>
-                    <abbr ng-if="IsStaff" style="user-select: none;">
-                        {{coop.Users.length}}/{{coop.MaxSize}}&nbsp;
-                    </abbr>
-                </h5>
-                <div class="card-body" ng-show="!coop.Hide">
-                    <table class="table table-striped">
-                        <tbody class="sortablers" ng-model="coop.Users" dnd-list="coop.Users" dnd-drop="dropCallback(item, coop)">
-                            <tr ng-repeat="user in coop.Users" ng-class="{ notsortable: user.Locked }">
-                                <td>{{user.Name}}
-                                <span ng-if="user.Guild.length > 0">[{{user.Guild}}]</span>
-
-                                </td>
-                                <td align="right">{{user.NumChickens}}</td>
-                                <td align="right">{{user.Rate}}</td>
-                                <td align="right">{{user.Projected}}</td>
-                                <td>
-                                    {{user.Status}}
-                                    @if(isAdmin) {
-                                    <button ng-if="user.UserId" ng-click="RemoveXref(user, coop)">X</button>
-                                    }
-                                </td>
-                            </tr>
-                            <tr class="dndPlaceholder"><td colspan="99"></td></tr>
-                            <tr ng-if="coop.Users.length == 0"><td colspan="99"><i>No Users</i></td></tr>
-                        </tbody>
-                        <tfoot>
-                            <tr>
-                                <td>{{coop.Users.length}}/{{coop.MaxSize}}</td>
-                                <td></td>
-                                <td align="right">{{coop.Rate}}</td>
-                                <td align="right">{{coop.Percent}}</td>
-                                <td></td>
-                            </tr>
-                        </tfoot>
-                    </table>
+            <template x-for="coop in ActiveCoops" :key="coop.Name">
+                <div class="card" :class="{ CurrentCoop: coop.CurrentCoop }">
+                    <div x-show="coop.CurrentCoop" style="position: relative; top: -20px;" :id="coop.Name"></div>
+                    <h5 class="card-header" @@click="coop.Hide = !coop.Hide" style="cursor:pointer;">
+                        <a @@click.stop="" x-show="IsStaff || coop.CurrentCoop" :href="'/coop/' + coop.ContractID + '/' + coop.Name" x-text="coop.Name"></a>
+                        <a @@click.stop="" x-show="(IsStaff || coop.CurrentCoop) && !coop.DeletedChannel" :href="'discord://discordapp.com/channels/' + coop.OverflowGuildId + '/' + coop.DiscordChannelId + '/'"><img src="/images/discordicon.png" style="max-height: 1em;" /></a>
+                        <span style="font-size: 0;"> - <span x-text="coop.MaxSize - coop.Users.length"></span> <span x-text="coop.MaxSize - coop.Users.length > 1 ? 'spots' : 'spot'"></span></span>
+                        <div x-show="!IsStaff">Co-op</div>
+                        <span style="user-select: none;" x-text="coop.Status"></span>
+                        <abbr x-show="IsStaff" style="user-select: none;">
+                            <span x-text="coop.Users.length"></span>/<span x-text="coop.MaxSize"></span>&nbsp;
+                        </abbr>
+                    </h5>
+                    <div class="card-body" x-show="!coop.Hide">
+                        <table class="table table-striped">
+                            <tbody class="sortablers" :data-coop-id="coop.CoopId">
+                                <template x-for="user in coop.Users" :key="user.EggIncId || user.Name">
+                                    <tr :class="{ notsortable: user.Locked }" :data-egg-inc-id="user.EggIncId">
+                                        <td>
+                                            <span x-text="user.Name"></span>
+                                            <span x-show="user.Guild && user.Guild.length > 0">[<span x-text="user.Guild"></span>]</span>
+                                        </td>
+                                        <td align="right" x-text="user.NumChickens"></td>
+                                        <td align="right" x-text="user.Rate"></td>
+                                        <td align="right" x-text="user.Projected"></td>
+                                        <td>
+                                            <span x-text="user.Status"></span>
+                                            @if(isAdmin) {
+                                            <button x-show="user.UserId" @@click.stop="removeXref(user, coop)">X</button>
+                                            }
+                                        </td>
+                                    </tr>
+                                </template>
+                                <tr class="dndPlaceholder"><td colspan="99"></td></tr>
+                                <tr x-show="coop.Users.length === 0"><td colspan="99"><i>No Users</i></td></tr>
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <td><span x-text="coop.Users.length"></span>/<span x-text="coop.MaxSize"></span></td>
+                                    <td></td>
+                                    <td align="right" x-text="coop.Rate"></td>
+                                    <td align="right" x-text="coop.Percent"></td>
+                                    <td></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
                 </div>
-            </div>
+            </template>
         </div>
 
 
@@ -471,207 +472,174 @@
     //}
 }
 @section Scripts {
-    <script src="~/lib/angular-drag-and-drop-lists.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <script>
-        //angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages', 'ui.sortable'])
-
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages', 'dndLists'])
-            .config( [
-                '$compileProvider',
-                function( $compileProvider )
-                {   
-                    $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|discord):/);
-                    //$compileProvider.urlSanitizationWhitelist(/^\s*(https?|discord):/)
-                    // Angular before v1.2 uses $compileProvider.urlSanitizationWhitelist(...)
-                }
-            ])
-            .controller('Page', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('detailsPage', () => ({
                 // IsAdmin gates write actions; IsStaff gates read-only display (names, links, counts).
-                $scope.IsAdmin = @JsonConvert.SerializeObject(isAdmin);
-                $scope.IsStaff = @JsonConvert.SerializeObject(isStaff);
+                IsAdmin: @JsonConvert.SerializeObject(isAdmin),
+                IsStaff: @JsonConvert.SerializeObject(isStaff),
+                ActiveCoops: [],
+                EmptyCoops: [],
+                ExpiredFarms: [],
+                PotentialCoops: [],
+                ShowPotential: true,
+                ShowAll: true,
+                SortAll: 'EBValue',
+                SortSolo: 'Name',
+                CurrentCoopCount: @count,
+                UsersByEB: [],
 
-                $scope.ActiveCoops = @Html.Raw(JsonConvert.SerializeObject(activeCoops));
-                $scope.EmptyCoops = [];
-                $scope.ExpiredFarms = @Html.Raw(JsonConvert.SerializeObject(expiredFarms));
-                $scope.PotentialCoops = @Html.Raw(JsonConvert.SerializeObject(potentialCoops));
-                $scope.ShowPotential = true;
-                $scope.ShowAll = true;
-                $scope.SortAll = 'EBValue';
-                $scope.SortSolo = 'Name';
+                init() {
+                    const _activeRaw = @Html.Raw(JsonConvert.SerializeObject(activeCoops));
+                    this.ActiveCoops = _activeRaw;
 
-                $scope.CurrentCoopCount = @count;
+                    const _expiredRaw = @Html.Raw(JsonConvert.SerializeObject(expiredFarms));
+                    this.ExpiredFarms = _expiredRaw;
 
-                $interval(function () {
-                    var top = $(".scrollable").position().top;
-                    var height = $(window).height();
-                    $(".scrollable").height(height - top - 1);
-                }, 1000);
+                    const _potentialRaw = @Html.Raw(JsonConvert.SerializeObject(potentialCoops));
+                    this.PotentialCoops = _potentialRaw;
 
-                $scope.PercentSum = function (users) {
-                    if (users.length == 0)
-                        return "";
-                    var percent = 0;
-                    angular.forEach(users, function (u) { percent += u.ProjectedPercent; });
-                    return percent;
-                };
+                    this.UsersByEB = this.getUsersByEB();
 
-                $scope.MinimumTime = function (users) {
-                    if (users.length == 0)
-                        return "";
-                    var min = _.minBy(users, function (o) { return o.TimeLeft; });
-                    return min.Status;
-                };
+                    setInterval(() => {
+                        const el = document.querySelector('.scrollable');
+                        if (el) {
+                            const top = el.getBoundingClientRect().top + window.scrollY;
+                            el.style.height = (window.innerHeight - el.getBoundingClientRect().top - 1) + 'px';
+                        }
+                    }, 1000);
 
-                $scope.dropCallback = function (item, coop) {
-                    if (confirm("Do you want to move " + item.Name + " to " + coop.Name)) {
-                        $http.post("/contract/movetocoop?CoopId=" + coop.CoopId + "&UserId=" + item.DatabaseId + "&EggIncId=" + item.EggIncId, {}).then(function Success(response) {
-                            if (response.data.error) {
-                                alert(response.data.error);
-                            } else {
-                                if (coop.Users.length == coop.MaxSize) {
-                                    coop.Hide = true;
+                    this.$nextTick(() => this.initSortable());
+                },
+
+                initSortable() {
+                    document.querySelectorAll('.sortablers').forEach(el => {
+                        if (el._sortable) el._sortable.destroy();
+                        el._sortable = Sortable.create(el, {
+                            group: 'coops',
+                            animation: 150,
+                            filter: '.notsortable',
+                            onAdd: (evt) => {
+                                const eggIncId = evt.item.dataset.eggIncId;
+                                const toCoopId = evt.to.dataset.coopId;
+                                const toCoop = this.ActiveCoops.find(c => String(c.CoopId) === String(toCoopId));
+                                if (!toCoop) return;
+                                // Find user across all potential coops
+                                let user = null;
+                                for (const coop of this.PotentialCoops) {
+                                    user = coop.Users.find(u => u.EggIncId === eggIncId);
+                                    if (user) break;
                                 }
-                                console.log(response);
-                                RemoveUser(item);
-                                //alert(response.data.userName + " moved to " + response.data.coopName);
-                            }
-                        }, function Error(response) {
-                            alert("Error");
-                            console.log(response);
-                        });
-                        return item;
-                    } else {
-                        return false;
-                    }
-                };
-
-                $scope.Start = function (coop, coopList, potential) {
-                    if (confirm("Are you sure you want to start this co-op?")) {
-                        var prefarms = [];
-                        angular.forEach(coop.Users, function (user) {
-                            prefarms.push({ EggIncId: user.EggIncId, DatabaseId: user.DatabaseId, Name: user.Name })
-                        });
-                        $http.post("/contract/startcoop?GuildId=@Model.GuildContract.GuildID&ContractID=@Model.GuildContract.ContractID&League=@Model.GuildContract.League", prefarms).then(function Success(response) {
-                            if (response.data.error) {
-                                alert(response.data.message);
-                                return;
-                            }
-                            console.log(response);
-                            //alert("Co-op " + response.data + " Created");
-                            $scope.ActiveCoops.unshift(coop);
-                            coop.Name = response.data.coopName;
-                            coop.Stats = "Just Created";
-                            //$.each(coop.Users, function () { this.Locked = true; });
-                            $.each(coopList, function (i) {
-                                console.log(coopList[i].Count, coop.Count);
-                                if (coopList[i].Count == coop.Count) {
-                                    coopList.splice(i, 1);
-                                    return;
-                                }
-                            });
-
-                            $.each(coop.Users, function (index, User) {
-                                RemoveUser(User);
-                            });
-
-                        }, function Error(response) {
-                            alert("Error");
-                            console.log(response);
-                        });
-                    }
-                };
-
-                $scope.RemoveXref = function (user, coop) {
-                    if (confirm("Are you sure you want to remove " + user.Name + " from the co-op?")) {
-                        $http.post("/contract/removexref", { UserId: user.UserId, EggIncId: user.EggIncId, CoopId: coop.CoopId }).then(function Success(response) {
-                            if (response.data.error) {
-                                alert(response.data.message);
-                                return;
-                            }
-                            var index = coop.Users.indexOf(user);
-                            coop.Users.splice(index, 1);
-                        }, function Error(response) {
-                            alert("Error");
-                            console.log(response);
-                        });
-                    }
-                };
-
-                function RemoveUser(user) {
-                    console.log(user);
-                    _.forEach($scope.PotentialCoops, function (coop) {
-                        _.forEach(coop.Users, function (coopUser, index) {
-                            if (!coopUser) {
-                                console.log(coopUser, index, coop);
-                                return;
-                            }
-                            if (coopUser.EggIncId == user.EggIncId) {
-                                coop.Users.splice(index, 1);
-                                console.log("Removed " + user.Name);
+                                if (!user) return;
+                                // Remove the DOM node SortableJS inserted (Alpine will re-render)
+                                evt.item.parentNode && evt.item.parentNode.removeChild(evt.item);
+                                this.dropCallback(user, toCoop);
                             }
                         });
                     });
+                },
 
-                    //$.each($scope.PotentialCoops, function (i) {
-                    //    $.each($scope.PotentialCoops[i].Users, function (coopUserIndex, coopUser) {
-                    //        if (user.EggIncId == coopUser.EggIncId) {
-                    //            $scope.PotentialCoops[i].Users.splice(coopUserIndex, 1);
-                    //            console.log("Removed " + user.Name);
-                    //        }
-                    //    });
-                    //});
-                    $scope.UsersByEB = _.sortBy(GetUsersByEB(), [$scope.SortAll]);
-                //    $.each($scope.UsersByEB, function (coopUserIndex, coopUser) {
-                //        if (!coopUser) {
-                //            console.log(coopUser)
-                //            return;
-                //        }
-                //        if (user.EggIncId == coopUser.EggIncId) {
-                //            $scope.UsersByEB.splice(coopUserIndex, 1);
-                //            console.log("Removed " + user.Name);
-                //        }
-                //    });
-                }
+                percentSum(users) {
+                    if (!users.length) return '';
+                    return users.reduce((s, u) => s + u.ProjectedPercent, 0);
+                },
 
-                $scope.UsersByEB = GetUsersByEB();
+                minimumTime(users) {
+                    if (!users.length) return '';
+                    return _.minBy(users, u => u.TimeLeft).Status;
+                },
 
-                function GetUsersByEB() {
-                    var users = [];
-                    _.forEach($scope.PotentialCoops, function (value, key) {
-                        _.forEach(value.Users, function (user, key) {
-                            users.push(user);
-                        });
-                    });
+                getUsersByEB() {
+                    const users = [];
+                    this.PotentialCoops.forEach(coop => coop.Users.forEach(u => users.push(u)));
                     return users;
-                }
+                },
 
-                $scope.$watch("SortAll", function (newValue) {
-                    $scope.UsersByEB = _.sortBy($scope.UsersByEB, [newValue]);
-                });
+                spotsActive() {
+                    return _.sumBy(this.ActiveCoops, o => o.Status === 'Finished' ? 0 : Math.max(0, o.MaxSize - o.Users.length));
+                },
 
+                spotsActive24() {
+                    return _.sumBy(this.ActiveCoops, o => (o.Status === 'Finished' || o.HoursToFinish < 24) ? 0 : Math.max(0, o.MaxSize - o.Users.length));
+                },
 
-                $scope.SpotsActive = function () {
-                    return _.sumBy($scope.ActiveCoops, function (o) { return o.Status == "Finished" ? 0 : Math.max(0, o.MaxSize - o.Users.length); });
-                };
+                toggleAll() {
+                    const allHidden = this.ActiveCoops.every(c => c.Hide);
+                    this.ActiveCoops.forEach(c => c.Hide = !allHidden);
+                },
 
-                $scope.SpotsActive24 = function () {
-                    return _.sumBy($scope.ActiveCoops, function (o) { return o.Status == "Finished" || o.HoursToFinish < 24 ? 0 :Math.max(0, o.MaxSize - o.Users.length); });
-                };
+                async dropCallback(item, toCoop) {
+                    if (!confirm('Do you want to move ' + item.Name + ' to ' + toCoop.Name)) return;
+                    try {
+                        const r = await fetch('/contract/movetocoop?CoopId=' + toCoop.CoopId + '&UserId=' + item.DatabaseId + '&EggIncId=' + item.EggIncId, { method: 'POST' });
+                        const data = await r.json();
+                        if (data.error) {
+                            alert(data.error);
+                        } else {
+                            if (toCoop.Users.length >= toCoop.MaxSize) toCoop.Hide = true;
+                            this.removeUser(item);
+                        }
+                    } catch (e) {
+                        alert('Error');
+                        console.error(e);
+                    }
+                },
 
-                $scope.ToggleAll = function () {
-                    _.forEach($scope.ActiveCoops, function (coop) {
-                        coop.Hide = !coop.Hide;
+                async start(coop, coopList) {
+                    if (!confirm('Are you sure you want to start this co-op?')) return;
+                    const prefarms = coop.Users.map(u => ({ EggIncId: u.EggIncId, DatabaseId: u.DatabaseId, Name: u.Name }));
+                    try {
+                        const r = await fetch('/contract/startcoop?GuildId=@Model.GuildContract.GuildID&ContractID=@Model.GuildContract.ContractID&League=@Model.GuildContract.League', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(prefarms)
+                        });
+                        const data = await r.json();
+                        if (data.error) { alert(data.message); return; }
+                        this.ActiveCoops.unshift(coop);
+                        coop.Name = data.coopName;
+                        coop.Status = 'Just Created';
+                        const idx = coopList.findIndex(c => c.Count === coop.Count);
+                        if (idx > -1) coopList.splice(idx, 1);
+                        coop.Users.forEach(u => this.removeUser(u));
+                        this.$nextTick(() => this.initSortable());
+                    } catch (e) {
+                        alert('Error');
+                        console.error(e);
+                    }
+                },
+
+                removeUser(user) {
+                    this.PotentialCoops.forEach(coop => {
+                        const idx = coop.Users.findIndex(u => u && u.EggIncId === user.EggIncId);
+                        if (idx > -1) coop.Users.splice(idx, 1);
                     });
-                };
-            }]);
-        angular.module('egg9000').filter('percentage', ['$filter', function ($filter) {
-            return function (input, decimals) {
-                return $filter('number')(input * 100, decimals) + '%';
-            };
-        }]);
+                    this.UsersByEB = _.sortBy(this.getUsersByEB(), [this.SortAll]);
+                },
 
-        $("#League").change(function(val) {
-            document.location = '/Contract/Details?GuildId=@(guild.Id)&ContractId=@(Model.GuildContract.ContractID)&League=' + $(val.target).val();
+                async removeXref(user, coop) {
+                    if (!confirm('Are you sure you want to remove ' + user.Name + ' from the co-op?')) return;
+                    try {
+                        const r = await fetch('/contract/removexref', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ UserId: user.UserId, EggIncId: user.EggIncId, CoopId: coop.CoopId })
+                        });
+                        const data = await r.json();
+                        if (data.error) { alert(data.message); return; }
+                        const idx = coop.Users.indexOf(user);
+                        if (idx > -1) coop.Users.splice(idx, 1);
+                    } catch (e) {
+                        alert('Error');
+                        console.error(e);
+                    }
+                }
+            }));
+        });
+
+        document.getElementById('League').addEventListener('change', function(e) {
+            document.location = '/Contract/Details?GuildId=@(guild.Id)&ContractId=@(Model.GuildContract.ContractID)&League=' + e.target.value;
         });
     </script>
 }

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -310,6 +310,43 @@
 
 
 
+        @if(isAdmin) {
+        <div class="col-sm" x-show="ShowPotential">
+            <h2>@(isSolo ? "Solo" : "Potential Co-ops")</h2>
+            <template x-for="(coop, coopIndex) in PotentialCoops" :key="coopIndex">
+                <div class="card" :class="{ CurrentCoop: coop.CurrentCoop }">
+                    <h5 class="card-header">
+                        <div x-show="!@(isSolo.ToString().ToLower())">Co-op <span x-text="coop.Count"></span></div>
+                    </h5>
+                    <div class="card-body">
+                        <table class="table table-striped">
+                            <tbody class="sortablers">
+                                <template x-for="(user, userIndex) in coop.Users" :key="userIndex">
+                                    <tr :class="{ notsortable: user.Locked }" :data-egg-inc-id="user.EggIncId">
+                                        <td x-text="user.Name"></td>
+                                        <td align="right" x-text="user.NumChickens"></td>
+                                        <td align="right" x-text="user.Rate"></td>
+                                        <td align="right" x-text="user.EB"></td>
+                                        <td x-text="user.Status"></td>
+                                        <td x-text="user.Sleep"></td>
+                                    </tr>
+                                </template>
+                                <tr class="dndPlaceholder"><td colspan="99"></td></tr>
+                            </tbody>
+                            <tfoot>
+                                <tr>
+                                    <td><span x-text="coop.Users.length"></span>/<span x-text="coop.MaxSize"></span></td>
+                                    <td></td>
+                                    <td align="right" x-text="coop.Rate"></td>
+                                    <td colspan="3"></td>
+                                </tr>
+                            </tfoot>
+                        </table>
+                    </div>
+                </div>
+            </template>
+        </div>
+        }
         @{
         //                                                            <div class="col-sm">
         //                                                                @if(!isSolo) {
@@ -514,6 +551,7 @@
                 },
 
                 initSortable() {
+                    if (!this.IsAdmin) return;
                     document.querySelectorAll('.sortablers').forEach(el => {
                         if (el._sortable) el._sortable.destroy();
                         el._sortable = Sortable.create(el, {

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -257,7 +257,7 @@
                 Note: The co-ops are sorted such that the top ones listed have spots available with the soonest ending on top.
             </p>
             }
-            <template x-for="coop in ActiveCoops" :key="coop.Name">
+            <template x-for="(coop, coopIndex) in ActiveCoops" :key="coopIndex">
                 <div class="card" :class="{ CurrentCoop: coop.CurrentCoop }">
                     <div x-show="coop.CurrentCoop" style="position: relative; top: -20px;" :id="coop.Name"></div>
                     <h5 class="card-header" @@click="coop.Hide = !coop.Hide" style="cursor:pointer;">
@@ -273,7 +273,7 @@
                     <div class="card-body" x-show="!coop.Hide">
                         <table class="table table-striped">
                             <tbody class="sortablers" :data-coop-id="coop.CoopId">
-                                <template x-for="user in coop.Users" :key="user.EggIncId || user.Name">
+                                <template x-for="(user, userIndex) in coop.Users" :key="userIndex">
                                     <tr :class="{ notsortable: user.Locked }" :data-egg-inc-id="user.EggIncId">
                                         <td>
                                             <span x-text="user.Name"></span>

--- a/EGG9000.Site/Views/Donation/Index.cshtml
+++ b/EGG9000.Site/Views/Donation/Index.cshtml
@@ -3,7 +3,7 @@
     ViewData["Title"] = "Donate";
 }
 
-<div ng-controller="donation">
+<div>
     <h2>Donate</h2>
     <h4>Donations temporarily disabled, please check with staff if you want to do something.</h4>
 </div>

--- a/EGG9000.Site/Views/Home/Boosts.cshtml
+++ b/EGG9000.Site/Views/Home/Boosts.cshtml
@@ -1,15 +1,15 @@
-﻿@{
+@{
     ViewData["Title"] = "Home Page";
 }
 
-<div ng-controller="Page">
-    <div class="form-inline">
+<div x-data="boostsPage()">
+    <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
         <label>Max Tokens</label>
-        <input type="number" ng-model="maxTokens" class="form-control mb-2" />
+        <input type="number" x-model.number="maxTokens" class="form-control mb-2" @@input="startCalculate()" />
         <label>Earning Per Second</label>
-        <input type="number" ng-model="earningsPerSecond" class="form-control md-2" />
+        <input type="number" x-model.number="earningsPerSecond" class="form-control mb-2" @@input="startCalculate()" />
         <div class="form-check">
-            <input class="form-check-input" type="checkbox" value="" id="defaultCheck1" ng-model="hide8Hour">
+            <input class="form-check-input" type="checkbox" value="" id="defaultCheck1" x-model="hide8Hour" @@change="startCalculate()">
             <label class="form-check-label" for="defaultCheck1">
                 Hide 8h boosts
             </label>
@@ -31,140 +31,109 @@
             </tr>
         </thead>
         <tbody>
-            <tr ng-repeat="combo in combos track by $index">
-                <td ng-repeat="boost in combo.boosts track by $index">
-                    <div ng-if="boost.A">
-                        {{boost.A}}x for {{boost.T}}m E
-                    </div>
-                    <div ng-if="boost.B">
-                        {{boost.B}}x for {{boost.T}}m B
-                    </div>
-                </td>
-                <td>
-                    {{combo.cost}}
-                </td>
-                <td>
-                    {{combo.multiplier}}
-                </td>
-                <td>
-                    {{combo.pertoken}}
-                </td>
-                <td>
-                    {{combo.time}}
-                </td>
-                <td>
-                    {{combo.total | number}}
-                </td>
-            </tr>
+            <template x-for="(combo, $index) in combos" :key="$index">
+                <tr>
+                    <template x-for="(boost, $bi) in combo.boosts" :key="$bi">
+                        <td>
+                            <div x-show="boost.A" x-text="boost.A + 'x for ' + boost.T + 'm E'"></div>
+                            <div x-show="boost.B" x-text="boost.B + 'x for ' + boost.T + 'm B'"></div>
+                        </td>
+                    </template>
+                    <td x-text="combo.cost"></td>
+                    <td x-text="combo.multiplier"></td>
+                    <td x-text="combo.pertoken"></td>
+                    <td x-text="combo.time"></td>
+                    <td x-text="combo.total.toLocaleString()"></td>
+                </tr>
+            </template>
         </tbody>
     </table>
-    <div class="alert alert-info" role="alert" ng-if="calculating">
+    <div class="alert alert-info" role="alert" x-show="calculating">
         Calculating...
     </div>
 </div>
 
 
 @section Scripts {
-
-
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('Page', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('boostsPage', () => ({
+                maxTokens: 75,
+                earningsPerSecond: 1,
+                hide8Hour: false,
+                combos: [],
+                calculating: false,
 
-                var allBoosts = [
-                    { A: 2, T: 60, C: 1 },
-                    { A: 2, T: 60 * 8, C: 1 },
-                    { A: 10, T: 30, C: 2 },
-                    { A: 10, T: 120, C: 3 },
-                    { A: 50, T: 10, C: 3 }, { A: 50, T: 60, C: 5 },
-                    { B: 2, T: 30, C: 5 },
-                    { B: 10, T: 10, C: 10 },
-                    { B: 5, T: 60, C: 15 },
-                    { B: 50, T: 10, C: 50 },
-                    { C: 0, T: 0 }
-                ];
+                startCalculate() {
+                    this.calculating = true;
+                    this.combos = [];
+                    setTimeout(() => this.calculateAll(), 1);
+                },
 
+                calculateAll() {
+                    const allBoosts = [
+                        { A: 2, T: 60, C: 1 },
+                        { A: 2, T: 60 * 8, C: 1 },
+                        { A: 10, T: 30, C: 2 },
+                        { A: 10, T: 120, C: 3 },
+                        { A: 50, T: 10, C: 3 }, { A: 50, T: 60, C: 5 },
+                        { B: 2, T: 30, C: 5 },
+                        { B: 10, T: 10, C: 10 },
+                        { B: 5, T: 60, C: 15 },
+                        { B: 50, T: 10, C: 50 },
+                        { C: 0, T: 0 }
+                    ];
+                    const maxTime = 40099;
+                    const boosts = _.filter(allBoosts, item => !this.hide8Hour || item.T < 480);
 
-                var maxTime = 40099;
-
-                $scope.maxTokens = 75;
-                $scope.earningsPerSecond = 1;
-                $scope.hide8Hour = false;
-                //StartCalculate();
-
-                $scope.$watchGroup(['maxTokens','earningsPerSecond','hide8Hour'], StartCalculate)
-                //$scope.$watch('earningsPerSecond', StartCalculate)
-                //$scope.$watch('hide8Hour', StartCalculate)
-
-                function StartCalculate() {
-                    $scope.calculating = true;
-                    $scope.combos = [];
-                    $timeout(CalculateAll, 1);
-                }
-
-                function CalculateAll() {
-                    console.log("Calculating");
-
-                    var boosts = _.filter(allBoosts, function (item) {
-                        console.log(!$scope.hide8Hour || item.T < 480, !$scope.hide8Hour, item.T < 480, item.T);
-                        return !$scope.hide8Hour || item.T < 480
-                    });
-
-                    //var amount = $scope.earningsPerSecond * 60;
-                    for (var a1 = 0; a1 < boosts.length; a1++) {
-                        for (var a2 = a1; a2 < boosts.length; a2++) {
-                            for (var a3 = a2; a3 < boosts.length; a3++) {
-                                for (var a4 = a3; a4 < boosts.length; a4++) {
-                                    for (var a5 = a4; a5 < boosts.length; a5++) {
-                                        var combo = [boosts[a1], boosts[a2], boosts[a3], boosts[a4], boosts[a5]];
-                                        var cost = _.sumBy(combo, "C");
-                                        var aSum = _.sumBy(combo, "A");
-                                        var time = _.max(combo, "T").T;
-                                        if (cost < $scope.maxTokens && aSum > 0 && time < maxTime) {
-                                            var item = {
-                                                cost: cost,
-                                                boosts: combo,
-                                                time: time
-                                            };
-                                            CalculateM(item);
-                                            $scope.combos.push(item);
-                                        }
-                                    }
-                                }
-                            }
+                    const combos = [];
+                    for (let a1 = 0; a1 < boosts.length; a1++)
+                    for (let a2 = a1; a2 < boosts.length; a2++)
+                    for (let a3 = a2; a3 < boosts.length; a3++)
+                    for (let a4 = a3; a4 < boosts.length; a4++)
+                    for (let a5 = a4; a5 < boosts.length; a5++) {
+                        const combo = [boosts[a1], boosts[a2], boosts[a3], boosts[a4], boosts[a5]];
+                        const cost = _.sumBy(combo, 'C');
+                        const aSum = _.sumBy(combo, 'A');
+                        const time = _.maxBy(combo, 'T').T;
+                        if (cost <= this.maxTokens && aSum > 0 && time < maxTime) {
+                            const item = { cost, boosts: combo, time };
+                            this.calculateM(item);
+                            combos.push(item);
                         }
                     }
 
-                    $scope.combos = _.orderBy($scope.combos, ['total'], ['desc']);
-
-
-                    for (var i = 0; i < $scope.combos.length - 1; i++) {
-                        var c1 = $scope.combos[i];
-                        for (var j = i + 1; j < $scope.combos.length; j++) {
-                            var c2 = $scope.combos[j];
-                            if (c2.cost > c1.cost || (c2.cost == c1.cost && c2.total <= c1.total && c2.time >= c1.time)) {
+                    let sorted = _.orderBy(combos, ['total'], ['desc']);
+                    for (let i = 0; i < sorted.length - 1; i++) {
+                        const c1 = sorted[i];
+                        for (let j = i + 1; j < sorted.length; j++) {
+                            const c2 = sorted[j];
+                            if (c2.cost > c1.cost || (c2.cost === c1.cost && c2.total <= c1.total && c2.time >= c1.time)) {
                                 c2.delete = true;
                             }
-
                         }
                     }
+                    this.combos = _.filter(sorted, item => !item.delete);
+                    this.calculating = false;
+                },
 
-                    $scope.combos = _.filter($scope.combos, function (item) { return !item.delete; });
-                    $scope.calculating = false;
-                }
-
-                function CalculateM(combo) {
-                    var multiplier = 0;
-                    for (var m = 0; m < _.max(combo.boosts, "T").T; m++) {
-                        var earnings = _.filter(combo.boosts, function (item) { return item.A > 0 && item.T > m; });
-                        var boost = _.filter(combo.boosts, function (item) { return item.B > 0 && item.T > m; });
-                        multiplier += _.sumBy(earnings, "A") * Math.max(_.sumBy(boost, "B"), 1);
-                        //console.log(combo, earnings, Math.max(_.sumBy(boost, "B"), 1));
+                calculateM(combo) {
+                    const maxT = _.maxBy(combo.boosts, 'T').T;
+                    let multiplier = 0;
+                    for (let m = 0; m < maxT; m++) {
+                        const earnings = _.filter(combo.boosts, b => b.A > 0 && b.T > m);
+                        const boost = _.filter(combo.boosts, b => b.B > 0 && b.T > m);
+                        multiplier += _.sumBy(earnings, 'A') * Math.max(_.sumBy(boost, 'B'), 1);
                     }
                     combo.multiplier = multiplier;
                     combo.pertoken = Math.round(multiplier / combo.cost);
-                    combo.total = Math.round(multiplier * $scope.earningsPerSecond * 60);
+                    combo.total = Math.round(multiplier * this.earningsPerSecond * 60);
+                },
+
+                init() {
+                    this.startCalculate();
                 }
-            }]);
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Home/CSLeaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/CSLeaderboard.cshtml
@@ -43,7 +43,7 @@ else if (myAccounts.Count() > 1)
 		background-color: #adffaa !important;
 	}
 
-	.bootstrap-dark .Me td {
+	[data-bs-theme="dark"] .Me td {
 		background-color: #2c462b !important;
 	}
 

--- a/EGG9000.Site/Views/Home/Coop.cshtml
+++ b/EGG9000.Site/Views/Home/Coop.cshtml
@@ -276,7 +276,7 @@
 			height: 30px;
 		}
 
-		.bootstrap-dark .progress-bar span {
+		[data-bs-theme="dark"] .progress-bar span {
 			color: #1e1e1e;
 		}
 

--- a/EGG9000.Site/Views/Home/CraftingLevelLeaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/CraftingLevelLeaderboard.cshtml
@@ -42,7 +42,7 @@ else if (myAccounts.Count() > 1)
         background-color: #adffaa !important;
     }
 
-    .bootstrap-dark .Me td {
+    [data-bs-theme="dark"] .Me td {
         background-color: #2c462b !important;
     }
 

--- a/EGG9000.Site/Views/Home/EggDayLeaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/EggDayLeaderboard.cshtml
@@ -39,7 +39,7 @@
 		background-color: #adffaa !important;
 	}
 
-	.bootstrap-dark .Me td {
+	[data-bs-theme="dark"] .Me td {
 		background-color: #2c462b !important;
 	}
 

--- a/EGG9000.Site/Views/Home/FAQ.cshtml
+++ b/EGG9000.Site/Views/Home/FAQ.cshtml
@@ -1,13 +1,13 @@
-﻿@model EGG9000.Site.Controllers.HomeController.FAQViewModel;
+@model EGG9000.Site.Controllers.HomeController.FAQViewModel;
 @using System.Security.Claims;
 @{
     ViewData["Title"] = "FAQ Index";
 }
 
-<div ng-controller="Page">
+<div x-data="faqPage()">
     <div style="display: flex; align-items: center; justify-content: space-between;">
         <h2>@Model.GuildName FAQs</h2>
-        <input class="form-control" ng-model="guildSearchTerm" style="width: 500px" placeholder="Search (Name, Keywords, Explanation)" name="guildSearchTerm" />
+        <input class="form-control" x-model="guildSearchTerm" style="width: 500px" placeholder="Search (Name, Keywords, Explanation)" name="guildSearchTerm" />
     </div>
     <table class="table table-striped table-hover">
         <thead>
@@ -19,91 +19,61 @@
             </tr>
         </thead>
         <tbody>
-            <tr ng-if="filteredGuildItems.length == 0">
-                <td colspan="8" style="text-align: center; font-weight: bold;">No items to show.</td>
-            </tr>
-            <tr ng-else ng-repeat="faqItem in filteredGuildItems = (items | filter:guildFilter)" ng-click="ViewItem(faqItem, false)">
-                <td>{{faqItem.name}}</td>
-                <td>{{faqItem.Keywords.join(", ")}}</td>
-                <td colspan="2">{{minifyIfOver(faqItem.explanation)}}</td>
-                <td>{{faqItem.createdBy}}</td>
-            </tr>
+            <template x-if="filteredItems().length === 0">
+                <tr>
+                    <td colspan="8" style="text-align: center; font-weight: bold;">No items to show.</td>
+                </tr>
+            </template>
+            <template x-for="faqItem in filteredItems()" :key="faqItem.name">
+                <tr @@click="viewItem(faqItem)" style="cursor:pointer;">
+                    <td x-text="faqItem.name"></td>
+                    <td x-text="faqItem.Keywords.join(', ')"></td>
+                    <td colspan="2" x-text="minifyIfOver(faqItem.explanation)"></td>
+                    <td x-text="faqItem.createdBy"></td>
+                </tr>
+            </template>
         </tbody>
     </table>
 
-    <script type="text/ng-template" id="View.html">
-        <style>
-            .modal-body {
-                max-height: calc(100vh - 180px);
-                overflow-y: auto;
-            }
-
-            .grid-container {
-                display: grid;
-                grid-template-columns: repeat(2, 1fr);
-                gap: 10px;
-                margin-top: 10px;
-            }
-
-            .grid-item {
-                display: flex;
-                flex-direction: column;
-            }
-
-            .grid-item label {
-                margin-bottom: 5px;
-            }
-        </style>
-
-        <div class="modal-header d-flex justify-content-between align-items-center">
-            <span ng-if="!newItem">FAQ Topic - {{ item.name }}</span>
-            <span ng-if="newItem">New FAQ Topic</span>
-            <button type="button" class="close" ng-click="Back()" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-
-        <div class="modal-body overflow-auto">
-            <div class="form-group">
-                <label>
-                    Name<br />
-                </label>
-                <input ng-disabled="true" autocomplete="off" aria-autocomplete="none" class="form-control" ng-model="item.name" />
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Keywords<br />
-                    <span style="font-size: 0.9rem; color: gray;">
-                        These are the keywords that can be searched to display this topic.
-                    </span>
-                </label><br>
-                <div ng-repeat="keyword in item.Keywords track by $index" style="display: flex; align-items: center; margin-bottom: 5px;">
-                    <input ng-disabled="true" autocomplete="off" aria-autocomplete="none" type="text" class="form-control" ng-model="item.Keywords[$index]" ng-blur="formatKeyword($index)" style="margin-right: 10px;" />
+    <div class="modal fade" id="faqViewModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header d-flex justify-content-between align-items-center">
+                    <span x-text="selectedItem ? 'FAQ Topic - ' + selectedItem.name : ''"></span>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body overflow-auto" style="max-height: calc(100vh - 180px);">
+                    <template x-if="selectedItem">
+                        <div>
+                            <div class="form-group mb-3">
+                                <label>Name</label>
+                                <input disabled autocomplete="off" class="form-control" :value="selectedItem.name" />
+                            </div>
+                            <div class="form-group mb-3">
+                                <label>Keywords</label>
+                                <template x-for="(keyword, idx) in selectedItem.Keywords" :key="idx">
+                                    <div style="display: flex; align-items: center; margin-bottom: 5px;">
+                                        <input disabled type="text" class="form-control" :value="keyword" style="margin-right: 10px;" />
+                                    </div>
+                                </template>
+                            </div>
+                            <div class="form-group mb-3">
+                                <label>Explanation</label>
+                                <textarea rows="8" disabled autocomplete="off" spellcheck="false" class="form-control" x-text="selectedItem.explanation"></textarea>
+                            </div>
+                            <div class="form-group mb-3">
+                                <label>Created by</label>
+                                <input disabled class="form-control" :value="selectedItem.createdBy" />
+                            </div>
+                        </div>
+                    </template>
+                </div>
+                <div class="modal-footer" style="justify-content: flex-start;">
+                    <button class="btn btn-warning" data-bs-dismiss="modal">Back</button>
                 </div>
             </div>
-
-            <div class="form-group">
-                <label>
-                    Explanation<br />
-                </label>
-                <textarea rows="8" ng-disabled="true" autocomplete="off" aria-autocomplete="none" spellcheck="false" class="form-control" ng-model="item.explanation"></textarea>
-            </div>
-
-            <div class="form-group">
-                <label>
-                    Created by<br />
-                </label>
-                <input disabled class="form-control" ng-model="item.createdBy" />
-            </div>
         </div>
-
-        <div class="modal-footer ng-scope" style="display: flex; justify-content: space-between; align-items: center;">
-            <div style="display: flex; gap: 10px;">
-                <button class="btn btn-warning" ng-click="Back()">Back</button>
-            </div>
-        </div>
-    </script>
+    </div>
 </div>
 
 @section Scripts {
@@ -118,52 +88,42 @@
     </style>
 
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('Page', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-                // Setup items from Model
-                $scope.items = @Html.Raw(Json.Serialize(Model.FAQTopics));
+        const _faqRawItems = @Html.Raw(Json.Serialize(Model.FAQTopics));
 
-                angular.forEach($scope.items, function (item) {
-                    item.Keywords = JSON.parse(item._keywords || '[]');
-                });
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('faqPage', () => ({
+                items: _faqRawItems.map(item => ({
+                    ...item,
+                    Keywords: JSON.parse(item._keywords || '[]')
+                })),
+                guildSearchTerm: '',
+                selectedItem: null,
+                _modal: null,
 
-                $scope.minifyIfOver = function (str) {
+                init() {
+                    this._modal = new bootstrap.Modal(document.getElementById('faqViewModal'));
+                },
+
+                filteredItems() {
+                    if (!this.guildSearchTerm) return this.items;
+                    const term = this.guildSearchTerm.toLowerCase();
+                    return this.items.filter(item =>
+                        item.name.toLowerCase().includes(term) ||
+                        item.Keywords.join(', ').toLowerCase().includes(term) ||
+                        item.explanation.toLowerCase().includes(term)
+                    );
+                },
+
+                minifyIfOver(str) {
                     if (!str) return '';
-                    if (str.length > 200) {
-                        return str.substr(0, 200) + ' [...]';
-                    } else return str;
-                };
+                    return str.length > 200 ? str.substr(0, 200) + ' [...]' : str;
+                },
 
-                // Filter function for guild items
-                $scope.guildFilter = function (faqItem) {
-                    if (!$scope.guildSearchTerm) {
-                        return true;
-                    }
-                    var searchTerm = $scope.guildSearchTerm.toLowerCase();
-                    return faqItem.name.toLowerCase().includes(searchTerm) ||
-                        faqItem.Keywords.join(", ").toLowerCase().includes(searchTerm) ||
-                        faqItem.explanation.toLowerCase().includes(searchTerm);
-                };
-
-                // Modal setup
-                $scope.ViewItem = function ViewItem(item, subscribeModal) {
-                    $uibModal.open({
-                        templateUrl: 'View.html',
-                        size: 'lg',
-                        backdrop: 'static',
-                        animation: false,
-                        controller: function ($scope, $uibModalInstance) {
-                            // Item declarations and setup
-                            if (item != null) {
-                                $scope.item = item;
-                            }
-
-                            $scope.Back = function Cancel() {
-                                $uibModalInstance.close();
-                            };
-                        }
-                    });
-                };
-            }]);
+                viewItem(item) {
+                    this.selectedItem = item;
+                    this._modal.show();
+                }
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Home/Leaderboard.cshtml
+++ b/EGG9000.Site/Views/Home/Leaderboard.cshtml
@@ -45,7 +45,7 @@
 		background-color: #adffaa !important;
 	}
 
-	.bootstrap-dark .Me td {
+	[data-bs-theme="dark"] .Me td {
 		background-color: #2c462b !important;
 	}
 

--- a/EGG9000.Site/Views/MyFarms/-Colleggtibles.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-Colleggtibles.cshtml
@@ -6,15 +6,26 @@
 }
 
 <style>
-    .bootstrap-dark .colleggtibles-table .table-success,
-    .bootstrap-dark .colleggtibles-table .table-success > td,
-    .bootstrap-dark .colleggtibles-table .table-success > th {
-        background-color: rgba(40, 167, 69, 0.25);
-        color: inherit;
+    /* Fix dark-mode table-striped: Bootstrap's stripe CSS variables can resolve to a
+       light fallback when --bs-table-bg is unset. Explicitly anchor all table vars
+       so alternating rows stay dark-on-dark instead of white-on-dark. */
+    [data-bs-theme="dark"] .colleggtibles-table {
+        --bs-table-bg: transparent;
+        --bs-table-color: var(--bs-body-color);
+        --bs-table-border-color: rgba(255, 255, 255, 0.1);
+        --bs-table-striped-bg: rgba(255, 255, 255, 0.06);
+        --bs-table-striped-color: var(--bs-body-color);
     }
-    .bootstrap-dark .colleggtibles-table .table-secondary,
-    .bootstrap-dark .colleggtibles-table .table-secondary > td,
-    .bootstrap-dark .colleggtibles-table .table-secondary > th {
+    [data-bs-theme="dark"] .colleggtibles-table .table-success {
+        /* Bootstrap's table-striped paints over background-color via box-shadow.
+           Override box-shadow too so striped odd rows stay dark-green, not light. */
+        background-color: rgba(40, 167, 69, 0.25);
+        box-shadow: inset 0 0 0 9999px rgba(40, 167, 69, 0.25);
+        color: var(--bs-body-color);
+    }
+    [data-bs-theme="dark"] .colleggtibles-table .table-secondary,
+    [data-bs-theme="dark"] .colleggtibles-table .table-secondary > td,
+    [data-bs-theme="dark"] .colleggtibles-table .table-secondary > th {
         background-color: rgba(108, 117, 125, 0.2);
         color: inherit;
         border-top-color: rgba(255, 255, 255, 0.08);
@@ -45,7 +56,7 @@
                             }
                             <strong>@row.Name</strong>
                             @if (row.Missing) {
-                                <span class="badge badge-secondary" style="margin-left:4px;">Missing</span>
+                                <span class="badge text-bg-secondary" style="margin-left:4px;">Missing</span>
                             }
                             @if (!string.IsNullOrEmpty(row.FarmReachedText)) {
                                 <small class="text-muted" style="margin-left:4px;">reached @row.FarmReachedText</small>
@@ -53,7 +64,7 @@
                         </td>
                         <td style="white-space:nowrap">@row.Dimension</td>
                         <td class="text-center">
-                            <span class="badge @(row.Missing ? "badge-secondary" : row.Level == 4 ? "badge-success" : "badge-warning")">
+                            <span class="badge @(row.Missing ? "text-bg-secondary" : row.Level == 4 ? "text-bg-success" : "text-bg-warning")">
                                 @row.Level/4
                             </span>
                         </td>

--- a/EGG9000.Site/Views/MyFarms/-ContractHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ContractHistory.cshtml
@@ -21,11 +21,11 @@
 }
 
 <style>
-	.bootstrap .tooltip-text {
+	.tooltip-text {
 		color: black;
 	}
 
-	.bootstrap-dark .tooltip-text {
+	[data-bs-theme="dark"] .tooltip-text {
 		color: #ccc;
 	}
 
@@ -50,7 +50,7 @@
 			vertical-align: middle; /* Align the image vertically with the text */
 		}
 
-	.bootstrap-dark .tooltip-custom img {
+	[data-bs-theme="dark"] .tooltip-custom img {
 		filter: invert(1) !important;
 	}
 
@@ -62,22 +62,15 @@
 		white-space: nowrap;
 		text-align: center; /* Center the text within the tooltip */
 		position: absolute;
-	}
-
-	.bootstrap-dark .tooltiptext-custom {
-		background-color: rgba(33, 37, 41, 0.95);
-	}
-
-	.bootstrap .tooltiptext-custom {
 		background-color: rgba(235, 239, 242, 0.95);
 	}
 
-	.bootstrap-dark .speech-bubble {
+	[data-bs-theme="dark"] .tooltiptext-custom {
 		background-color: rgba(33, 37, 41, 0.95);
 	}
 
-	.bootstrap .speech-bubble {
-		background-color: rgba(235, 239, 242, 0.95);
+	[data-bs-theme="dark"] .speech-bubble {
+		background-color: rgba(33, 37, 41, 0.95);
 	}
 
 	.speech-bubble {
@@ -85,6 +78,7 @@
 		padding: 10px;
 		margin: 10px auto; /* Center the bubble horizontally */
 		border-radius: 5px; /* Rounded corners for the bubble */
+		background-color: rgba(235, 239, 242, 0.95);
 	}
 
 		/* Create the triangle */
@@ -112,17 +106,17 @@
 					<th>Contract</th>
 					<th>Coop</th>
 					<th>Started</th>
-					<th data-toggle="tooltip" title="# of Chickens" class="text-right">🐔</th>
-					<th data-toggle="tooltip" title="# of Eggs" class="text-right">🥚</th>
-					<th class="text-right">%</th>
+					<th data-bs-toggle="tooltip" title="# of Chickens" class="text-end">🐔</th>
+					<th data-bs-toggle="tooltip" title="# of Eggs" class="text-end">🥚</th>
+					<th class="text-end">%</th>
 					@if (isLesserAdmin) {
-						<th data-toggle="tooltip" title="Time Cheat" class="text-right">🕵</th>
-						<th data-toggle="tooltip" title="Cheat Time Debt" class="text-right">⏲️</th>
+						<th data-bs-toggle="tooltip" title="Time Cheat" class="text-end">🕵</th>
+						<th data-bs-toggle="tooltip" title="Cheat Time Debt" class="text-end">⏲️</th>
 						fullColSpan += 2;
 					}
-					<th data-toggle="tooltip" title="Tokens Received" class="text-right tight-emojis">🟡 📥</th>
-					<th data-toggle="tooltip" title="Tokens Spent" class="text-right tight-emojis">🟡 💲</th>
-					<th data-toggle="tooltip" title="Tokens Given" class="text-right tight-emojis">🟡 📤</th>
+					<th data-bs-toggle="tooltip" title="Tokens Received" class="text-end tight-emojis">🟡 📥</th>
+					<th data-bs-toggle="tooltip" title="Tokens Spent" class="text-end tight-emojis">🟡 💲</th>
+					<th data-bs-toggle="tooltip" title="Tokens Given" class="text-end tight-emojis">🟡 📤</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -154,9 +148,9 @@
 									}
 								</td>
 								<td>@farm.Started.ToString("yyyy-MM-dd")</td>
-								<td class="text-right">@farm.NumChickens.ToEggString()</td>
-								<td class="text-right">@farm.EggsPaidFor.ToEggString()</td>
-								<td class="text-right">
+								<td class="text-end">@farm.NumChickens.ToEggString()</td>
+								<td class="text-end">@farm.EggsPaidFor.ToEggString()</td>
+								<td class="text-end">
 									@if (lastUpdate != null)
 									{
 										var percent = lastUpdate.ContributionAmount / xref.Coop.LastStatusUpdate.TotalAmount;
@@ -165,12 +159,12 @@
 								</td>
 								@if (isLesserAdmin)
 								{
-									<td class="text-right">@farm.TimeCheatsDetected</td>
-									<td class="text-right">@TimeSpan.FromSeconds(farm.TimeCheatDebt).Humanize().ShortenTime()</td>
+									<td class="text-end">@farm.TimeCheatsDetected</td>
+									<td class="text-end">@TimeSpan.FromSeconds(farm.TimeCheatDebt).Humanize().ShortenTime()</td>
 								}
-								<td class="text-right">@farm.BoostTokensReceived</td>
-								<td class="text-right">@farm.BoostTokensSpent</td>
-								<td class="text-right">@farm.BoostTokensGiven</td>
+								<td class="text-end">@farm.BoostTokensReceived</td>
+								<td class="text-end">@farm.BoostTokensSpent</td>
+								<td class="text-end">@farm.BoostTokensGiven</td>
 							</tr>
 						}
 					}
@@ -191,12 +185,12 @@
 					<th>Coop</th>
 					<th>Started</th>
 					<th>🏁</th>
-					<th class="text-right">Score</th>
-					<th class="text-right">Running Score</th>
-					<th data-toggle="tooltip" title="# of Eggs" class="text-right">🥚</th>
-					<th class="text-right">%</th>
-					<th data-toggle="tooltip" title="Suspected Time Cheat" class="text-right">🕵</th>
-					<th data-toggle="tooltip" title="Tokens Spent" class="text-right tight-emojis">🟡💲</th>
+					<th class="text-end">Score</th>
+					<th class="text-end">Running Score</th>
+					<th data-bs-toggle="tooltip" title="# of Eggs" class="text-end">🥚</th>
+					<th class="text-end">%</th>
+					<th data-bs-toggle="tooltip" title="Suspected Time Cheat" class="text-end">🕵</th>
+					<th data-bs-toggle="tooltip" title="Tokens Spent" class="text-end tight-emojis">🟡💲</th>
 				</tr>
 			</thead>
 			<tbody id="@("ArchivedFarmsTBody" + Model.index)">
@@ -234,7 +228,7 @@
 								<td>@farm.Started.ToString("yyyy-MM-dd")</td>
 								<td>@(farm.Completed ? "✔️" : "")</td>
 								@if (pastXrefWithScore != null) {
-									<td class="text-right font-italic">
+									<td class="text-end font-italic">
 										@pastXrefWithScore?.Score?.ToString("G2")
 										<span class="tooltip-custom">
 											<img src="/images/help_icon.png"/>
@@ -246,18 +240,18 @@
 											</span>
 										</span>
 									</td>
-									<td class="text-right font-italic">--</td>
+									<td class="text-end font-italic">--</td>
 								} else {
-									<td class="text-right"></td>
-									<td class="text-right"></td>
+									<td class="text-end"></td>
+									<td class="text-end"></td>
 								}
 
 								@if (userFarmDetails != null && xref != null) {
 									var percent = userFarmDetails.EggsShipped / (xref.Coop.LastStatusUpdate?.TotalAmount ?? 0);
-									<td class="text-right">@userFarmDetails.EggsShipped.ToEggString()</td>
-									<td class="text-right">@percent.ToString("P0").Replace(" ", "")</td>
-									<td class="text-right">@(userFarmDetails.CoopStatus?.TimeCheatDetected ?? false ? "Yes" : "No")</td>
-									<td class="text-right">@userFarmDetails.CoopStatus?.BoostTokensSpent</td>
+									<td class="text-end">@userFarmDetails.EggsShipped.ToEggString()</td>
+									<td class="text-end">@percent.ToString("P0").Replace(" ", "")</td>
+									<td class="text-end">@(userFarmDetails.CoopStatus?.TimeCheatDetected ?? false ? "Yes" : "No")</td>
+									<td class="text-end">@userFarmDetails.CoopStatus?.BoostTokensSpent</td>
 								} else {
 									<td colspan="99"></td>
 								}
@@ -292,10 +286,10 @@
 								<td>@(farm.Completed ? "✔️" : "")</td>
 
 								@if (xrefWithScore != null) {
-									<td class="text-right">@xrefWithScore?.Score?.ToString("G2")</td>
-									<td class="text-right">@xrefWithScore?.RunningScore?.ToString("G2")</td>
+									<td class="text-end">@xrefWithScore?.Score?.ToString("G2")</td>
+									<td class="text-end">@xrefWithScore?.RunningScore?.ToString("G2")</td>
 								} else if (pastXrefWithScore != null) {
-									<td class="text-right font-italic">
+									<td class="text-end font-italic">
 										@pastXrefWithScore?.Score?.ToString("G2")
 										<span class="tooltip-custom">
 											<img src="/images/help_icon.png" />
@@ -309,18 +303,18 @@
 											</span>
 										</span>
 									</td>
-									<td class="text-right font-italic">--</td>
+									<td class="text-end font-italic">--</td>
 								} else {
-									<td class="text-right"></td>
-									<td class="text-right"></td>
+									<td class="text-end"></td>
+									<td class="text-end"></td>
 								}
 
 								@if (userFarmDetails?.CoopStatus != null) {
 									var percent = userFarmDetails.EggsShipped / xref.Coop.LastStatusUpdate.TotalAmount;
-									<td class="text-right">@userFarmDetails.EggsShipped.ToEggString()</td>
-									<td class="text-right">@percent.ToString("P0").Replace(" ", "")</td>
-									<td class="text-right">@(userFarmDetails.CoopStatus.TimeCheatDetected ? "Yes" : "No")</td>
-									<td class="text-right">@userFarmDetails.CoopStatus.BoostTokensSpent</td>
+									<td class="text-end">@userFarmDetails.EggsShipped.ToEggString()</td>
+									<td class="text-end">@percent.ToString("P0").Replace(" ", "")</td>
+									<td class="text-end">@(userFarmDetails.CoopStatus.TimeCheatDetected ? "Yes" : "No")</td>
+									<td class="text-end">@userFarmDetails.CoopStatus.BoostTokensSpent</td>
 								} else {
 									<td colspan="99"></td>
 								}

--- a/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
@@ -49,11 +49,11 @@
                 <h4 class="card-header d-flex justify-content-between align-items-center">
                     <span>Progress Graph</span>
                     <div>
-                        <button class="btn btn-sm btn-primary mr-1"           id="ebStatsBtn-eb-full-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('eb')">EB</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-se-full-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('se')">SE</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-pe-full-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('pe')">PE</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-eot-full-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('eot')">EoT</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-mer-full-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('mer')">MER</button>
+                        <button class="btn btn-sm btn-primary me-1"           id="ebStatsBtn-eb-full-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('eb')">EB</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-se-full-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('se')">SE</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-pe-full-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('pe')">PE</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-eot-full-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('eot')">EoT</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-mer-full-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('mer')">MER</button>
                         <button class="btn btn-sm btn-outline-primary"        id="ebStatsCollapse-@(ebStatsSuffix)"     onclick="ebStatsCollapse_@(ebStatsSuffix)()">&#x26F6; Collapse</button>
                     </div>
                 </h4>
@@ -170,11 +170,11 @@
                 <h4 class="card-header d-flex justify-content-between align-items-center flex-nowrap">
                     <span style="white-space: nowrap; margin-right: 8px;">Progress Graph</span>
                     <div style="white-space: nowrap; flex-shrink: 0;">
-                        <button class="btn btn-sm btn-primary mr-1"           id="ebStatsBtn-eb-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('eb')">EB</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-se-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('se')">SE</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-pe-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('pe')">PE</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-eot-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('eot')">EoT</button>
-                        <button class="btn btn-sm btn-outline-secondary mr-1" id="ebStatsBtn-mer-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('mer')">MER</button>
+                        <button class="btn btn-sm btn-primary me-1"           id="ebStatsBtn-eb-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('eb')">EB</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-se-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('se')">SE</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-pe-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('pe')">PE</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-eot-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('eot')">EoT</button>
+                        <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-mer-@(ebStatsSuffix)" onclick="ebStatsToggle_@(ebStatsSuffix)('mer')">MER</button>
                         <button class="btn btn-sm btn-outline-primary"        id="ebStatsExpand-@(ebStatsSuffix)"  onclick="ebStatsExpand_@(ebStatsSuffix)()">&#x26F6; Expand</button>
                     </div>
                 </h4>

--- a/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
@@ -167,9 +167,9 @@
         <div class="col-sm">
             <!-- CHART CARD (narrow, default visible) -->
             <div class="card" style="margin-top:15px;" id="ebStatsNarrowCard-@(ebStatsSuffix)">
-                <h4 class="card-header d-flex justify-content-between align-items-center flex-nowrap">
+                <h4 class="card-header d-flex justify-content-between align-items-center flex-wrap gap-1">
                     <span style="white-space: nowrap; margin-right: 8px;">Progress Graph</span>
-                    <div style="white-space: nowrap; flex-shrink: 0;">
+                    <div class="d-flex flex-wrap gap-1">
                         <button class="btn btn-sm btn-primary me-1"           id="ebStatsBtn-eb-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('eb')">EB</button>
                         <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-se-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('se')">SE</button>
                         <button class="btn btn-sm btn-outline-secondary me-1" id="ebStatsBtn-pe-@(ebStatsSuffix)"  onclick="ebStatsToggle_@(ebStatsSuffix)('pe')">PE</button>

--- a/EGG9000.Site/Views/MyFarms/-EarningsBoostCalculator.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EarningsBoostCalculator.cshtml
@@ -1,4 +1,4 @@
-﻿@model EGG9000.Site.Controllers.MyFarmsController.EarningsBoostCalculatorModel
+@model EGG9000.Site.Controllers.MyFarmsController.EarningsBoostCalculatorModel
 @{
     ViewData["Title"] = "Home Page";
 
@@ -8,40 +8,44 @@
         max-height: 20px;
     }
 </style>
-<div ng-controller="EarningsBoostCalcModel@(Model.Backup.EggIncId)">
-    <div class="form-inline" style="padding-top:10px">
+<div x-data="earningsBoostCalc()">
+    <div class="d-flex align-items-center gap-2" style="padding-top:10px">
         <div class="form-group">
             <label style="margin-right:5px;">Farm</label>
-            <select class="form-control" ng-model="selectedFarm" ng-options="farm.name for farm in farms"></select>
+            <select class="form-control" x-model="selectedFarmIndex" @@change="selectedFarm = farms[parseInt($event.target.value)]; startCalculate()">
+                <template x-for="(farm, idx) in farms" :key="idx">
+                    <option :value="idx" x-text="farm.name"></option>
+                </template>
+            </select>
         </div>
         &nbsp;&nbsp;
         <div class="form-group">
             <label style="margin-right:5px;">Max Tokens</label>
-            <input type="number" ng-model="maxTokens" class="form-control" style="width: 70px" />
+            <input type="number" x-model.number="maxTokens" @@input="startCalculate()" class="form-control" style="width: 70px" />
         </div>
         &nbsp;&nbsp;
         <div class="form-check form-check-inline">
-            <input class="form-check-input" type="checkbox" value="" id="defaultCheck1" ng-model="hide8Hour">
+            <input class="form-check-input" type="checkbox" value="" id="defaultCheck1" x-model="hide8Hour" @@change="startCalculate()">
             <label class="form-check-label" for="defaultCheck1">
                 Hide 8h boosts
             </label>
         </div>
         <div class="form-check form-check-inline">
-            <input class="form-check-input" type="checkbox" value="" id="defaultCheckBoost" ng-model="twoBoost">
+            <input class="form-check-input" type="checkbox" value="" id="defaultCheckBoost" x-model="twoBoost" @@change="startCalculate()">
             <label class="form-check-label" for="defaultCheckBoost">
                 2 Boosts
             </label>
         </div>
         <div class="form-check form-check-inline">
-            <input class="form-check-input" type="checkbox" value="" id="defaultCheck2" ng-model="includeRunning">
+            <input class="form-check-input" type="checkbox" value="" id="defaultCheck2" x-model="includeRunning" @@change="startCalculate()">
             <label class="form-check-label" for="defaultCheck2">
                 Include Running Bonus
             </label>
         </div>
         <br />
         <div style="margin-top: 10px; margin-bottom: 10px;">
-            <span style="display:inline-block">Earning: <b>{{ToEggString(selectedFarm.income)}}/s</b></span><br />
-            <span style="display:inline-block">With Running <b>{{ToEggString(selectedFarm.incomeRunning)}}/s</b> <i>(This includes 2x from video<span ng-if="BoostValue > 1"> and {{BoostValue}}x from current event</span>)</i></span>
+            <span style="display:inline-block">Earning: <b x-text="toEggString(selectedFarm.income) + '/s'"></b></span><br />
+            <span style="display:inline-block">With Running <b x-text="toEggString(selectedFarm.incomeRunning) + '/s'"></b> <i>(This includes 2x from video<span x-show="boostValue > 1"> and <span x-text="boostValue"></span>x from current event</span>)</i></span>
         </div>
     </div>
     <table class="table table-striped">
@@ -49,9 +53,9 @@
             <tr>
                 <th>Boost 1</th>
                 <th>Boost 2</th>
-                <th ng-if="!twoBoost">Boost 3</th>
-                <th ng-if="!twoBoost">Boost 4</th>
-                <th ng-if="!twoBoost">Boost 5</th>
+                <th x-show="!twoBoost">Boost 3</th>
+                <th x-show="!twoBoost">Boost 4</th>
+                <th x-show="!twoBoost">Boost 5</th>
                 <th>Cost</th>
                 @*<th>Multiplier</th>
                     <th>Per Token</th>*@
@@ -61,225 +65,180 @@
             </tr>
         </thead>
         <tbody>
-            <tr ng-repeat="combo in combos track by $index">
-                <td ng-repeat="boost in combo.boosts track by $index">
-                    <div ng-if="boost.A">
-                        <img ng-src="{{boost.img}}" class="thumb" /> {{boost.A}}x {{boost.T}}m
-                    </div>
-                    <div ng-if="boost.B">
-                        <img ng-src="{{boost.img}}" class="thumb" /> {{boost.B}}x {{boost.T}}m
-                    </div>
-                </td>
-                <td>
-                    <img src="https://vignette.wikia.nocookie.net/egg-inc/images/e/ee/B_token.png/revision/latest/scale-to-width-down/16?cb=20191210172515" /> {{combo.cost}}
-                </td>
-                @*<td>
-                        {{combo.multiplier}}
+            <template x-for="(combo, $ci) in combos" :key="$ci">
+                <tr>
+                    <template x-for="(boost, $bi) in combo.boosts" :key="$bi">
+                        <td>
+                            <div x-show="boost.A">
+                                <img :src="boost.img" class="thumb" /> <span x-text="boost.A + 'x ' + boost.T + 'm'"></span>
+                            </div>
+                            <div x-show="boost.B">
+                                <img :src="boost.img" class="thumb" /> <span x-text="boost.B + 'x ' + boost.T + 'm'"></span>
+                            </div>
+                        </td>
+                    </template>
+                    <td>
+                        <img src="https://vignette.wikia.nocookie.net/egg-inc/images/e/ee/B_token.png/revision/latest/scale-to-width-down/16?cb=20191210172515" /> <span x-text="combo.cost"></span>
+                    </td>
+                    @*<td>
+                            <span x-text="combo.multiplier"></span>
+                        </td>
+                        <td>
+                            <span x-text="combo.pertoken"></span>
+                        </td>*@
+                    <td>
+                        🕑<span x-text="combo.time"></span>m
                     </td>
                     <td>
-                        {{combo.pertoken}}
-                    </td>*@
-                <td>
-                    🕑{{combo.time}}m
-                </td>
-                <td>
-                    <img src="https://vignette.wikia.nocookie.net/egg-inc/images/5/59/Money.png/revision/latest/scale-to-width-down/16?cb=20160818160253" />{{ToEggString(combo.total)}}
-                </td>
-                <td>
-                    {{ToEggString(combo.total / combo.cost)}} <img src="https://vignette.wikia.nocookie.net/egg-inc/images/5/59/Money.png/revision/latest/scale-to-width-down/16?cb=20160818160253" />/<img src="https://vignette.wikia.nocookie.net/egg-inc/images/e/ee/B_token.png/revision/latest/scale-to-width-down/16?cb=20191210172515" />
-                </td>
-            </tr>
+                        <img src="https://vignette.wikia.nocookie.net/egg-inc/images/5/59/Money.png/revision/latest/scale-to-width-down/16?cb=20160818160253" /><span x-text="toEggString(combo.total)"></span>
+                    </td>
+                    <td>
+                        <span x-text="toEggString(combo.total / combo.cost)"></span> <img src="https://vignette.wikia.nocookie.net/egg-inc/images/5/59/Money.png/revision/latest/scale-to-width-down/16?cb=20160818160253" />/<img src="https://vignette.wikia.nocookie.net/egg-inc/images/e/ee/B_token.png/revision/latest/scale-to-width-down/16?cb=20191210172515" />
+                    </td>
+                </tr>
+            </template>
         </tbody>
     </table>
-    <div class="alert alert-info" role="alert" ng-if="calculating">
+    <div class="alert alert-info" role="alert" x-show="calculating">
         Calculating...
     </div>
 </div>
 
 
 <script type="text/javascript">
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('earningsBoostCalc', () => ({
+            boostValue: @(Model.Event?.Multiplier ?? 1),
+            farms: [],
+            selectedFarm: null,
+            selectedFarmIndex: 0,
+            maxTokens: 75,
+            hide8Hour: true,
+            includeRunning: true,
+            twoBoost: false,
+            combos: [],
+            calculating: false,
 
-    function scriptToExecute() {
-        window.egg9000module = window.egg9000module || angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages']);
+            init() {
+                const _farmsRaw = @Html.Raw(
+                    Json.Serialize(
+                        Model.Backup.Farms.Where(x => x.FarmType != Ei.FarmType.Empty).Select(x => {
+                        var farm = x.WithStats(Model.Backup, null, Model.CustomEggs);
+                            var name = x.FarmType == Ei.FarmType.Home ? "Home" : $"{x.ContractId} ({x.CoopId})";
+                            return new {
+                                Name = name,
+                                Income = farm.Income * (Model.Event?.Multiplier ?? 1),
+                                IncomeRunning = farm.MaxRunningBonus * farm.Income * (Model.Event?.Multiplier ?? 1)
+                            };
+                        })
+                    )
+                );
+                this.farms = _farmsRaw;
+                this.selectedFarm = this.farms[0] || { name: '', income: 0, incomeRunning: 0 };
+                this.startCalculate();
+            },
 
-        window.egg9000module.controller('EarningsBoostCalcModel@(Model.Backup.EggIncId)', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-            $scope.BoostValue = @(Model.Event?.Multiplier ?? 1);
-            $scope.farms = @Html.Raw(
-                Json.Serialize(
-                    Model.Backup.Farms.Where(x => x.FarmType != Ei.FarmType.Empty).Select(x => {
-                    var farm = x.WithStats(Model.Backup, null, Model.CustomEggs);
-                        var name = x.FarmType == Ei.FarmType.Home ? "Home" : $"{x.ContractId} ({x.CoopId})";
-                        return new {
-                            Name = name,
-                            Income = farm.Income * (Model.Event?.Multiplier ?? 1),
-                            IncomeRunning = farm.MaxRunningBonus * farm.Income * (Model.Event?.Multiplier ?? 1)
-                        };
-                    }
-                ))
-            );
-            $scope.selectedFarm = $scope.farms[0];
-            var allBoosts = [
-                { A: 2, T: 60, C: 1, img: '/images/boosts/Jimbos_Excellent_Bird_Feed.png' },
-                { A: 2, T: 60 * 8, C: 1, img: '/images/boosts/Jimbos_Excellent_Bird_Feed_big.png' },
-                { A: 10, T: 30, C: 2, img: '/images/boosts/Jimbos_Premium_Bird_Feed.png' },
-                { A: 10, T: 120, C: 3, img: '/images/boosts/Jimbos_Premium_Bird_Feed_big.png' },
-                { A: 50, T: 10, C: 3, img: '/images/boosts/Jimbos_Best_Bird_Feed.png' },
-                { A: 50, T: 60, C: 5, img: '/images/boosts/Jimbos_Best_Bird_Feed_big.png' },
-                { B: 2, T: 30, C: 5, img: '/images/boosts/Boost_Beacon.png' },
-                { B: 10, T: 10, C: 8, img: '/images/boosts/Epic_Boost_Beacon.png' },
-                { B: 5, T: 60, C: 10, img: '/images/boosts/Large_Boost_Beacon.png' },
-                { B: 50, T: 10, C: 15, img: '/images/boosts/Legendary_Boost_Beacon.png' },
-                { C: 0, T: 0 }
-            ];
+            startCalculate() {
+                this.calculating = true;
+                this.combos = [];
+                setTimeout(() => this.calculateAll(), 1);
+            },
 
+            calculateAll() {
+                const allBoosts = [
+                    { A: 2, T: 60, C: 1, img: '/images/boosts/Jimbos_Excellent_Bird_Feed.png' },
+                    { A: 2, T: 60 * 8, C: 1, img: '/images/boosts/Jimbos_Excellent_Bird_Feed_big.png' },
+                    { A: 10, T: 30, C: 2, img: '/images/boosts/Jimbos_Premium_Bird_Feed.png' },
+                    { A: 10, T: 120, C: 3, img: '/images/boosts/Jimbos_Premium_Bird_Feed_big.png' },
+                    { A: 50, T: 10, C: 3, img: '/images/boosts/Jimbos_Best_Bird_Feed.png' },
+                    { A: 50, T: 60, C: 5, img: '/images/boosts/Jimbos_Best_Bird_Feed_big.png' },
+                    { B: 2, T: 30, C: 5, img: '/images/boosts/Boost_Beacon.png' },
+                    { B: 10, T: 10, C: 8, img: '/images/boosts/Epic_Boost_Beacon.png' },
+                    { B: 5, T: 60, C: 10, img: '/images/boosts/Large_Boost_Beacon.png' },
+                    { B: 50, T: 10, C: 15, img: '/images/boosts/Legendary_Boost_Beacon.png' },
+                    { C: 0, T: 0 }
+                ];
+                const maxTime = 40099;
+                const boosts = _.filter(allBoosts, item => !this.hide8Hour || item.T < 480);
+                const combos = [];
 
-            var maxTime = 40099;
-
-            $scope.maxTokens = 75;
-            $scope.hide8Hour = true;
-            $scope.includeRunning = true;
-            $scope.twoBoost = false;
-
-
-            $scope.$watchGroup(['maxTokens', 'hide8Hour', 'selectedFarm', 'includeRunning', 'twoBoost'], StartCalculate)
-
-            function StartCalculate() {
-                $scope.calculating = true;
-                $scope.combos = [];
-                $timeout(CalculateAll, 1);
-            }
-
-            function CalculateAll() {
-                var boosts = _.filter(allBoosts, function (item) {
-                    return !$scope.hide8Hour || item.T < 480
-                });
-
-
-                if ($scope.twoBoost) {
-                    for (var a1 = 0; a1 < boosts.length; a1++) {
-                        for (var a2 = a1; a2 < boosts.length; a2++) {
-                            var combo = [boosts[a1], boosts[a2]];
-                            var cost = _.sumBy(combo, "C");
-                            var aSum = _.sumBy(combo, "A");
-                            var time = _.max(combo, "T").T;
-                            if (cost <= $scope.maxTokens && aSum > 0 && time < maxTime) {
-                                var item = {
-                                    cost: cost,
-                                    boosts: combo,
-                                    time: time
-                                };
-                                CalculateM(item);
-                                $scope.combos.push(item);
+                if (this.twoBoost) {
+                    for (let a1 = 0; a1 < boosts.length; a1++) {
+                        for (let a2 = a1; a2 < boosts.length; a2++) {
+                            const combo = [boosts[a1], boosts[a2]];
+                            const cost = _.sumBy(combo, 'C');
+                            const aSum = _.sumBy(combo, 'A');
+                            const time = _.maxBy(combo, 'T').T;
+                            if (cost <= this.maxTokens && aSum > 0 && time < maxTime) {
+                                const item = { cost, boosts: combo, time };
+                                this.calculateM(item);
+                                combos.push(item);
                             }
                         }
                     }
                 } else {
-                    for (var a1 = 0; a1 < boosts.length; a1++) {
-                        for (var a2 = a1; a2 < boosts.length; a2++) {
-                            for (var a3 = a2; a3 < boosts.length; a3++) {
-                                for (var a4 = a3; a4 < boosts.length; a4++) {
-                                    for (var a5 = a4; a5 < boosts.length; a5++) {
-                                        var combo = [boosts[a1], boosts[a2], boosts[a3], boosts[a4], boosts[a5]];
-                                        var cost = _.sumBy(combo, "C");
-                                        var aSum = _.sumBy(combo, "A");
-                                        var time = _.max(combo, "T").T;
-                                        if (cost <= $scope.maxTokens && aSum > 0 && time < maxTime) {
-                                            var item = {
-                                                cost: cost,
-                                                boosts: combo,
-                                                time: time
-                                            };
-                                            CalculateM(item);
-                                            $scope.combos.push(item);
-                                        }
-                                    }
-                                }
-                            }
+                    for (let a1 = 0; a1 < boosts.length; a1++)
+                    for (let a2 = a1; a2 < boosts.length; a2++)
+                    for (let a3 = a2; a3 < boosts.length; a3++)
+                    for (let a4 = a3; a4 < boosts.length; a4++)
+                    for (let a5 = a4; a5 < boosts.length; a5++) {
+                        const combo = [boosts[a1], boosts[a2], boosts[a3], boosts[a4], boosts[a5]];
+                        const cost = _.sumBy(combo, 'C');
+                        const aSum = _.sumBy(combo, 'A');
+                        const time = _.maxBy(combo, 'T').T;
+                        if (cost <= this.maxTokens && aSum > 0 && time < maxTime) {
+                            const item = { cost, boosts: combo, time };
+                            this.calculateM(item);
+                            combos.push(item);
                         }
                     }
                 }
 
-                $scope.combos = _.orderBy($scope.combos, ['total'], ['desc']);
-
-
-                for (var i = 0; i < $scope.combos.length - 1; i++) {
-                    var c1 = $scope.combos[i];
-                    for (var j = i + 1; j < $scope.combos.length; j++) {
-                        var c2 = $scope.combos[j];
-                        if (c2.cost > c1.cost || (c2.cost == c1.cost && c2.total <= c1.total && c2.time >= c1.time)) {
+                let sorted = _.orderBy(combos, ['total'], ['desc']);
+                for (let i = 0; i < sorted.length - 1; i++) {
+                    const c1 = sorted[i];
+                    for (let j = i + 1; j < sorted.length; j++) {
+                        const c2 = sorted[j];
+                        if (c2.cost > c1.cost || (c2.cost === c1.cost && c2.total <= c1.total && c2.time >= c1.time)) {
                             c2.delete = true;
                         }
-
                     }
                 }
+                this.combos = _.filter(sorted, item => !item.delete);
+                this.calculating = false;
+            },
 
-                $scope.combos = _.filter($scope.combos, function (item) { return !item.delete; });
-                $scope.calculating = false;
-            }
-
-            function CalculateM(combo) {
-                var multiplier = 0;
-                for (var m = 0; m < _.max(combo.boosts, "T").T; m++) {
-                    var earnings = _.filter(combo.boosts, function (item) { return item.A > 0 && item.T > m; });
-                    var boost = _.filter(combo.boosts, function (item) { return item.B > 0 && item.T > m; });
-                    multiplier += _.sumBy(earnings, "A") * Math.max(_.sumBy(boost, "B"), 1);
+            calculateM(combo) {
+                let multiplier = 0;
+                const maxT = _.maxBy(combo.boosts, 'T').T;
+                for (let m = 0; m < maxT; m++) {
+                    const earnings = _.filter(combo.boosts, b => b.A > 0 && b.T > m);
+                    const boost = _.filter(combo.boosts, b => b.B > 0 && b.T > m);
+                    multiplier += _.sumBy(earnings, 'A') * Math.max(_.sumBy(boost, 'B'), 1);
                 }
                 combo.multiplier = multiplier;
                 combo.pertoken = Math.round(multiplier / combo.cost);
-                combo.total = multiplier * ($scope.includeRunning ? $scope.selectedFarm.incomeRunning : $scope.selectedFarm.income) * 60;
-            }
-            $scope.ToEggString = ToEggString;
+                combo.total = multiplier * (this.includeRunning ? this.selectedFarm.incomeRunning : this.selectedFarm.income) * 60;
+            },
 
-            function ToEggString(number) {
-                var SIPrefixs = {
-                    78: "QV",
-                    75: "qV",
-                    72: "tV",
-                    69: "dV",
-                    66: "uV",
-                    63: "V",
-                    60: "Nd",
-                    57: "Od",
-                    54: "Sd",
-                    51: "sd",
-                    48: "Qd",
-                    45: "qd",
-                    42: "td",
-                    39: "D",
-                    36: "u",
-                    33: "d",
-                    30: "n",
-                    27: "o",
-                    24: "S",
-                    21: "s",
-                    18: "Q",
-                    15: "q",
-                    12: "t",
-                    9: "b",
-                    6: "m",
-                    3: "k"
+            toEggString(number) {
+                const SIPrefixs = {
+                    78: "QV", 75: "qV", 72: "tV", 69: "dV", 66: "uV", 63: "V",
+                    60: "Nd", 57: "Od", 54: "Sd", 51: "sd", 48: "Qd", 45: "qd",
+                    42: "td", 39: "D", 36: "u", 33: "d", 30: "n", 27: "o",
+                    24: "S", 21: "s", 18: "Q", 15: "q", 12: "t", 9: "b", 6: "m", 3: "k"
                 };
-
-                for (var i = 78; i > 0; i = i - 3) {
-                    var ibig = i//BigInt(i);
-                    if (number >= 10 ** ibig) {
-                        var o = number / (10 ** ibig);
-                        if (o > 100) {
-                            o = o.toFixed(0);
-                        } else if (o > 10) {
-                            o = o.toFixed(1);
-                        } else {
-                            o = o.toFixed(2);
-                        }
+                for (let i = 78; i > 0; i -= 3) {
+                    if (number >= 10 ** i) {
+                        let o = number / (10 ** i);
+                        if (o > 100) o = o.toFixed(0);
+                        else if (o > 10) o = o.toFixed(1);
+                        else o = o.toFixed(2);
                         return o + SIPrefixs[i];
                     }
                 }
                 return number;
             }
-        }]);
-    }
-
-
-    window.ScriptsToExecute = window.ScriptsToExecute || [];
-    window.ScriptsToExecute.push(scriptToExecute);
+        }));
+    });
 </script>

--- a/EGG9000.Site/Views/MyFarms/-EpicResearch.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EpicResearch.cshtml
@@ -1,4 +1,4 @@
-﻿@using EGG9000.Common.JsonData
+@using EGG9000.Common.JsonData
 @using EGG9000.Common.JsonData.EIEpicResearch;
 @model (List<EpicResearchItem> epicResearchConfig, CustomBackup backup, EggIncAccount account);
 @{
@@ -16,10 +16,10 @@
 	var bankScalar = !Model.account.HasActiveSubscription() ? 1 : (Model.account.SubscriptionLevel == 0 ? 1.25 : 1.40);
 	var totalBankGE = (ulong)(Model.backup.TotalGEInPiggyBank * bankScalar);
 }
-<div class="card" style="margin-top:15px" ng-controller="EpicResearch@(Model.backup.EggIncId)">
+<div class="card" style="margin-top:15px" x-data="epicResearchPage()">
 	<h4 class="card-header mb-3 d-flex justify-content-between align-items-center">
 		<span>Epic Research GE Calculator</span>
-		<select id="discount-select" class="form-select form-select-sm" ng-model="Discount">
+		<select id="discount-select" class="form-select form-select-sm" x-model.number="Discount">
 			<option id="discount-0" value="0" selected>Select Discount</option>
 			<option id="discount-25" value="25">25%</option>
 			<option id="discount-30" value="30">30%</option>
@@ -42,31 +42,40 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr ng-repeat="epicResearch in EpicResearchConfig" ng-class="{ 'collapsible-er-row': epicResearch.mappedBackupResearch.level == epicResearch.costs.length }">
-					<td>
-						{{epicResearch.title}}
-						<span class="d-md-none">
-							<span class="badge"
-								  ng-class="{ 'badge-danger': epicResearch.mappedBackupResearch.level == 0, 'badge-warning': epicResearch.mappedBackupResearch.level < epicResearch.costs.length, 'badge-success': epicResearch.mappedBackupResearch.level == epicResearch.costs.length }">
-								{{epicResearch.mappedBackupResearch.level}}/{{epicResearch.costs.length}}
+				<template x-for="er in EpicResearchConfig" :key="er.id">
+					<tr :class="{ 'collapsible-er-row': er.mappedBackupResearch.level === er.costs.length }">
+						<td>
+							<span x-text="er.title"></span>
+							<span class="d-md-none">
+								<span class="badge"
+									  :class="{
+										'text-bg-danger': er.mappedBackupResearch.level === 0,
+										'text-bg-warning': er.mappedBackupResearch.level > 0 && er.mappedBackupResearch.level < er.costs.length,
+										'text-bg-success': er.mappedBackupResearch.level === er.costs.length
+									  }">
+									<span x-text="er.mappedBackupResearch.level + '/' + er.costs.length"></span>
+								</span>
 							</span>
-						</span>
-					</td>
-					<td class="d-none d-md-table-cell">{{epicResearch.description}}</td>
-					<td class="d-none d-md-table-cell">
-						<span class="badge"
-							  ng-class="{ 'badge-danger': epicResearch.mappedBackupResearch.level == 0, 'badge-warning': epicResearch.mappedBackupResearch.level < epicResearch.costs.length, 'badge-success': epicResearch.mappedBackupResearch.level == epicResearch.costs.length }">
-							{{epicResearch.mappedBackupResearch.level}}/{{epicResearch.costs.length}}
-						</span>
-					</td>
-
-					<td ng-if="epicResearch.mappedBackupResearch.level == epicResearch.costs.length" colspan="3">&nbsp;</td>
-					<td ng-if-start="epicResearch.mappedBackupResearch.level < epicResearch.costs.length" class="text-right">{{GetCostForLevels(epicResearch, true) | number:0}}</td>
-					<td>
-						<input type="number" ng-model="epicResearch.levelsToBuy" min="0" max="{{epicResearch.costs.length - epicResearch.mappedBackupResearch.level}}" step="1" style="width: 3em;" />
-					</td>
-					<td ng-if-end class="text-right">{{GetCostForLevels(epicResearch) | number:0}}</td>
-				</tr>
+						</td>
+						<td class="d-none d-md-table-cell" x-text="er.description"></td>
+						<td class="d-none d-md-table-cell">
+							<span class="badge"
+								  :class="{
+									'text-bg-danger': er.mappedBackupResearch.level === 0,
+									'text-bg-warning': er.mappedBackupResearch.level > 0 && er.mappedBackupResearch.level < er.costs.length,
+									'text-bg-success': er.mappedBackupResearch.level === er.costs.length
+								  }">
+								<span x-text="er.mappedBackupResearch.level + '/' + er.costs.length"></span>
+							</span>
+						</td>
+						<td x-show="er.mappedBackupResearch.level === er.costs.length" colspan="3">&nbsp;</td>
+						<td x-show="er.mappedBackupResearch.level < er.costs.length" class="text-end" x-text="Math.round(getCostForLevels(er, true)).toLocaleString()"></td>
+						<td x-show="er.mappedBackupResearch.level < er.costs.length">
+							<input type="number" x-model.number="er.levelsToBuy" :min="0" :max="er.costs.length - er.mappedBackupResearch.level" step="1" style="width: 3em;" />
+						</td>
+						<td x-show="er.mappedBackupResearch.level < er.costs.length" class="text-end" x-text="Math.round(getCostForLevels(er)).toLocaleString()"></td>
+					</tr>
+				</template>
 				@if (Model.epicResearchConfig.Count(er => er.MappedBackupResearch.Level == er.Costs.Count) > 0){
 					<tr class="collapsible-er-row toggleHide">
 						<td colspan="6" style="text-align: center; color:coral">
@@ -76,64 +85,52 @@
 				}
 				<tr>
 					<td colspan="2" class="d-none d-md-table-cell"></td>
-					<td colspan="3" class="text-right">
+					<td colspan="3" class="text-end">
 						<b>
-							@{
-								GEEmoji();
-							} Required
+							@{ GEEmoji(); } Required
 						</b>
 					</td>
-					<td class="text-right"><b>{{TotalGECost() | number:0}}</b></td>
+					<td class="text-end"><b x-text="Math.round(totalGECost()).toLocaleString()"></b></td>
 				</tr>
 				<tr>
 					<td colspan="2" class="d-none d-md-table-cell"></td>
-					<td colspan="3" class="text-right">
-						@{
-							GEEmoji();
-						} Current
+					<td colspan="3" class="text-end">
+						@{ GEEmoji(); } Current
 					</td>
-					<td class="text-right">{{CurrentGE | number:0}}</td>
+					<td class="text-end" x-text="Math.round(currentGE).toLocaleString()"></td>
 				</tr>
-				<tr ng-if-start="TotalGECost() > CurrentGE">
+				<tr x-show="totalGECost() > currentGE">
 					<td colspan="2" class="d-none d-md-table-cell"></td>
-					<td colspan="3" class="text-right">
-						@{
-							GEEmoji();
-						} Needed from Bank
+					<td colspan="3" class="text-end">
+						@{ GEEmoji(); } Needed from Bank
 					</td>
-					<td class="text-right">{{TotalGECost()  - CurrentGE | number:0}}</td>
+					<td class="text-end" x-text="Math.round(totalGECost() - currentGE).toLocaleString()"></td>
 				</tr>
-				<tr ng-if-end>
+				<tr x-show="totalGECost() > currentGE">
 					<td colspan="2" class="d-none d-md-table-cell"></td>
-					<td colspan="3" class="text-right">
-						@{
-							GEEmoji();
-						} In Bank
+					<td colspan="3" class="text-end">
+						@{ GEEmoji(); } In Bank
 						@if(totalBankGE != rawBankGE){
 							<br /><img src="https://cdn.discordapp.com/emojis/1131045418319495369.webp" style="max-height: 15px;" /> @(("ULTRA Bonus"))
 							<br /><hr />
 							GEEmoji(); @((" Total in Bank"))
 						}
 					</td>
-					<td class="text-right">
-						{{RawGEInPiggyBank | number:0}}
-						<span ng-if="@totalBankGE != @rawBankGE">
-							<br />+{{@(totalBankGE - rawBankGE) | number:0}}
+					<td class="text-end">
+						<span x-text="Math.round(rawGEInPiggyBank).toLocaleString()"></span>
+						<span x-show="totalBankGE !== rawBankGE">
+							<br />+<span x-text="Math.round(totalBankGE - rawBankGE).toLocaleString()"></span>
 							<br /><hr />
-							{{@totalBankGE | number:0}}
+							<span x-text="Math.round(totalBankGE).toLocaleString()"></span>
 						</span>
 					</td>
 				</tr>
 				<tr>
 					<td colspan="2" class="d-none d-md-table-cell"></td>
-					<td colspan="3" class="text-right">
-						<b>
-							Total @{
-								GEEmoji();
-							} required
-						</b>
+					<td colspan="3" class="text-end">
+						<b>Total @{ GEEmoji(); } required</b>
 					</td>
-					<td class="text-right"><b>{{Math.max(0, TotalGECost() - CurrentGE - @totalBankGE) | number:0}}</b></td>
+					<td class="text-end"><b x-text="Math.max(0, Math.round(totalGECost() - currentGE - totalBankGE)).toLocaleString()"></b></td>
 				</tr>
 			</tbody>
 		</table>
@@ -147,49 +144,40 @@
 }
 
 <script type="text/javascript">
+	document.addEventListener('alpine:init', () => {
+		Alpine.data('epicResearchPage', () => ({
+			EpicResearchConfig: [],
+			currentGE: 0,
+			rawGEInPiggyBank: 0,
+			totalBankGE: 0,
+			rawBankGE: 0,
+			Discount: 0,
 
-	function scriptToExecute() {
-		window.egg9000module = window.egg9000module || angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages']);
+			init() {
+				const _rawConfig = @Html.Raw(Json.Serialize(Model.epicResearchConfig));
+				this.EpicResearchConfig = _rawConfig;
+				this.EpicResearchConfig.forEach(er => {
+					er.levelsToBuy = er.costs.length - er.mappedBackupResearch.level;
+				});
+				this.currentGE = @(Model.backup.GoldenEggsEarned - Model.backup.GoldenEggsSpent);
+				this.rawGEInPiggyBank = @Model.backup.TotalGEInPiggyBank;
+				this.totalBankGE = @totalBankGE;
+				this.rawBankGE = @rawBankGE;
+			},
 
-		window.egg9000module.controller('EpicResearch@(Model.backup.EggIncId)', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-			$scope.Discount = 0;
-			$scope.EpicResearchConfig = @Html.Raw(Json.Serialize(Model.epicResearchConfig));
-			$scope.CurrentGE = @(Model.backup.GoldenEggsEarned - Model.backup.GoldenEggsSpent);
-			var BankMultiplier = @(!Model.account.HasActiveSubscription() ? 1 : (Model.account.SubscriptionLevel == 0 ? 1.25 : 1.40));
-			$scope.RawGEInPiggyBank = @Model.backup.TotalGEInPiggyBank;
-			$scope.TotalGEInPiggyBank = @Model.backup.TotalGEInPiggyBank * BankMultiplier;
-			$scope.Math = window.Math;
-			$scope.Discount = "0";
-			angular.forEach($scope.EpicResearchConfig, function(epicResearch) { epicResearch.levelsToBuy = epicResearch.costs.length - epicResearch.mappedBackupResearch.level; });
-
-			$scope.GetCostForLevels = function(epicResearch, single = false) {
-				var cost = 0;
-				for (var i = 0; i < epicResearch.levelsToBuy; i++) {
-					if (i >= epicResearch.costs.length || (i > 0 && single)) {
-						break;
-					}
+			getCostForLevels(epicResearch, single = false) {
+				let cost = 0;
+				for (let i = 0; i < epicResearch.levelsToBuy; i++) {
+					if (i >= epicResearch.costs.length || (i > 0 && single)) break;
 					cost += epicResearch.costs[epicResearch.mappedBackupResearch.level + i];
 				}
-                if (epicResearch.order > 90)
-						return cost;
-				return cost * (1 - ($scope.Discount / 100));
+				if (epicResearch.order > 90) return cost;
+				return cost * (1 - (this.Discount / 100));
+			},
+
+			totalGECost() {
+				return this.EpicResearchConfig.reduce((sum, er) => sum + this.getCostForLevels(er), 0);
 			}
-
-			$scope.TotalGECost = function() {
-				var cost = 0;
-				angular.forEach($scope.EpicResearchConfig, function(epicResearch) { cost += $scope.GetCostForLevels(epicResearch); });
-				return cost;
-			}
-
-			$(document).ready(function () {
-				if ($('.bootstrap-dark').length > 0) {
-					$('select[id*="discount"], option[id*="discount"]').css('color', '#c3c3c3');
-				}
-			});
-		}]);
-	}
-
-
-	window.ScriptsToExecute = window.ScriptsToExecute || [];
-	window.ScriptsToExecute.push(scriptToExecute);
+		}));
+	});
 </script>

--- a/EGG9000.Site/Views/MyFarms/-ExternalTools.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ExternalTools.cshtml
@@ -5,7 +5,7 @@
 	var EggIncId = Model.Item1.EggIncId;
 }
 
-<div  ng-controller="ExternalTools@(EggIncId)">
+<div x-data="externalToolsPage()">
 <div class="card externaltools" style="margin-top:15px">
 	<h4 class="card-header">External Tools</h4>
 	<table class="table table-striped">
@@ -71,8 +71,8 @@
 <div class="card" style="margin-top:15px">
 	<h4 class="card-header">Debug Tools</h4>
 	<div class="card-body">
-		<button class="btn btn-primary" ng-click="SendTestDM('dm')">Test notification in DM</button>
-		<button class="btn btn-primary" ng-click="SendTestDM('talktoegg9000')">Test notification in server channel</button>
+		<button class="btn btn-primary" @@click="sendTestDM('dm')">Test notification in DM</button>
+		<button class="btn btn-primary" @@click="sendTestDM('talktoegg9000')">Test notification in server channel</button>
 	</div>
 </div>
 </div>
@@ -84,23 +84,17 @@
 
 
 <script type="text/javascript">
-
-	function scriptToExecute() {
-		window.egg9000module = window.egg9000module || angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages']);
-
-		window.egg9000module.controller('ExternalTools@(EggIncId)', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-            $scope.SendTestDM = function(target) {
-                $http.post("/myfarms/sendtestdm?target=" + target, {}).then(function Success(response) {
-                    alert("Sent");
-                }, function Error(response) {
-                    alert("Error");
-                    console.log(response);
-                });
-            };
-		}]);
-	}
-
-
-	window.ScriptsToExecute = window.ScriptsToExecute || [];
-	window.ScriptsToExecute.push(scriptToExecute);
+    document.addEventListener('alpine:init', () => {
+        Alpine.data('externalToolsPage', () => ({
+            async sendTestDM(target) {
+                try {
+                    await fetch('/myfarms/sendtestdm?target=' + target, { method: 'POST' });
+                    alert('Sent');
+                } catch (e) {
+                    alert('Error');
+                    console.error(e);
+                }
+            }
+        }));
+    });
 </script>

--- a/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-ShipsAndFarms.cshtml
@@ -88,11 +88,11 @@
         color: gray;
     }
 
-    .bootstrap .tooltip-text {
+    .tooltip-text {
         color: black;
     }
 
-    .bootstrap-dark .tooltip-text {
+    [data-bs-theme="dark"] .tooltip-text {
         color: #ccc;
     }
 
@@ -117,7 +117,7 @@
             vertical-align: middle; /* Align the image vertically with the text */
         }
 
-    .bootstrap-dark .tooltip-custom img {
+    [data-bs-theme="dark"] .tooltip-custom img {
         filter: invert(1) !important;
     }
 
@@ -129,22 +129,15 @@
         white-space: nowrap;
         text-align: center; /* Center the text within the tooltip */
         position: absolute;
-    }
-
-    .bootstrap-dark .tooltiptext-custom {
-        background-color: rgba(33, 37, 41, 0.95);
-    }
-
-    .bootstrap .tooltiptext-custom {
         background-color: rgba(235, 239, 242, 0.95);
     }
 
-    .bootstrap-dark .speech-bubble {
+    [data-bs-theme="dark"] .tooltiptext-custom {
         background-color: rgba(33, 37, 41, 0.95);
     }
 
-    .bootstrap .speech-bubble {
-        background-color: rgba(235, 239, 242, 0.95);
+    [data-bs-theme="dark"] .speech-bubble {
+        background-color: rgba(33, 37, 41, 0.95);
     }
 
     .speech-bubble {
@@ -152,6 +145,7 @@
         padding: 10px;
         margin: 10px auto; /* Center the bubble horizontally */
         border-radius: 5px; /* Rounded corners for the bubble */
+        background-color: rgba(235, 239, 242, 0.95);
     }
 
         /* Create the triangle */
@@ -166,11 +160,11 @@
             border-color: #ccc transparent transparent transparent;
         }
 
-    .gray-text-half-margin .bootstrap-dark, .gray-text .bootstrap-dark {
+    [data-bs-theme="dark"] .gray-text-half-margin, [data-bs-theme="dark"] .gray-text {
         color: lightgray;
     }
 
-    .gray-text-half-margin .bootstrap, .gray-text .bootstrap {
+    .gray-text-half-margin, .gray-text {
         color: darkgray;
     }
 
@@ -333,11 +327,11 @@
         font-weight: bold;
     }
 
-    .bootstrap .ship-toggle-button {
+    .ship-toggle-button {
         color: #333333;
     }
 
-    .bootstrap-dark .ship-toggle-button {
+    [data-bs-theme="dark"] .ship-toggle-button {
         color: #d3d3d3;
     }
 
@@ -351,8 +345,8 @@
         border: 1px solid #ccc;
     }
 
-    .bootstrap-dark select, 
-    .bootstrap-dark option {
+    [data-bs-theme="dark"] select,
+    [data-bs-theme="dark"] option {
         border: 1px solid #222;
         background-color: #333;
     }
@@ -364,7 +358,7 @@
         border-radius: 4px;
     }
 
-    .bootstrap-dark .alert-danger {
+    [data-bs-theme="dark"] .alert-danger {
         color: rgb(225, 134, 143) !important;
         background-color: rgb(67, 12, 17) !important;
         border-color: rgb(104, 18, 27) !important;

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -92,22 +92,15 @@
         white-space: nowrap;
         text-align: center; /* Center the text within the tooltip */
         position: absolute;
+        background-color: rgba(130, 135, 140, 0.95);
     }
 
-        .tooltiptext-custom .bootstrap-dark {
+        [data-bs-theme="dark"] .tooltiptext-custom {
             background-color: rgba(33, 37, 41, 0.95);
         }
 
-        .tooltiptext-custom .bootstrap {
-            background-color: rgba(130, 135, 140, 0.95);
-        }
-
-    .bootstrap-dark .speech-bubble {
+    [data-bs-theme="dark"] .speech-bubble {
         background-color: rgba(33, 37, 41, 0.95);
-    }
-
-    .bootstrap .speech-bubble {
-        background-color: rgba(130, 135, 140, 0.95);
     }
 
     .speech-bubble {
@@ -115,6 +108,7 @@
         padding: 10px;
         margin: 10px auto; /* Center the bubble horizontally */
         border-radius: 5px; /* Rounded corners for the bubble */
+        background-color: rgba(130, 135, 140, 0.95);
     }
 
         /* Create the triangle */
@@ -257,7 +251,7 @@
         @for (var index = 0; index < Model.User.EggIncAccounts.Count; index++) {
             var account = Model.User.EggIncAccounts[index];
             <li class="nav-item">
-                <a class="nav-link @(index == 0 ? "active" : "")" id="tab@(account.Id)" data-toggle="tab" href="#user@(index)" role="tab" aria-selected="@(index == 0)">
+                <a class="nav-link @(index == 0 ? "active" : "")" id="tab@(account.Id)" data-bs-toggle="tab" href="#user@(index)" role="tab" aria-selected="@(index == 0)">
                     @account.Backup.UserName
                     <img src="@PlayerGradeDetails.GetImage(account.GetGrade())" style="max-height: 23px;" />
                     @if (account.Backup.PermitLevel == 0) {
@@ -350,40 +344,40 @@
 
             <ul class="nav nav-tabs" role="tablist">
                 <li class="nav-item">
-                    <a class="nav-link active" data-toggle="tab" href="#contracthistory@(index)" role="tab" aria-selected="true">Contract History</a>
+                    <a class="nav-link active" data-bs-toggle="tab" href="#contracthistory@(index)" role="tab" aria-selected="true">Contract History</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#shipsfarms@(index)" role="tab" aria-selected="false">Ships & Farms</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#shipsfarms@(index)" role="tab" aria-selected="false">Ships & Farms</a>
                 </li>
 
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#epicresearch@(index)" role="tab" aria-selected="false">Epic Research</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#epicresearch@(index)" role="tab" aria-selected="false">Epic Research</a>
                 </li>
                 @if (inDB) {
                     var tabName = isAdmin ? $"Merits ({Model.Merits.Count}) & Demerits ({Model.Demerits.Count})" : $"Merits & Demerits";
                     <li class="nav-item">
-                        <a class="nav-link" data-toggle="tab" href="#merits@(index)" role="tab" aria-selected="false">@tabName</a>
+                        <a class="nav-link" data-bs-toggle="tab" href="#merits@(index)" role="tab" aria-selected="false">@tabName</a>
                     </li>
                     @if (snapshots != null) {
                         <li class="nav-item">
-                            <a class="nav-link" data-toggle="tab" href="#ebhistory@(index)" role="tab" aria-selected="false">EB Stats</a>
+                            <a class="nav-link" data-bs-toggle="tab" href="#ebhistory@(index)" role="tab" aria-selected="false">EB Stats</a>
                         </li>
                     }
                 }
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#artifactcombos@(index)" role="tab" aria-selected="false">Artifact Combos</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#artifactcombos@(index)" role="tab" aria-selected="false">Artifact Combos</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#externaltools@(index)" role="tab" aria-selected="false">External Tools</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#externaltools@(index)" role="tab" aria-selected="false">External Tools</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#earningsboostcalc@(index)" role="tab" aria-selected="false">Earnings Boost Calc</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#earningsboostcalc@(index)" role="tab" aria-selected="false">Earnings Boost Calc</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#colleggtibles@(index)" role="tab" aria-selected="false">Colleggtibles</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#colleggtibles@(index)" role="tab" aria-selected="false">Colleggtibles</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" data-toggle="tab" href="#inventory@(index)" role="tab" aria-selected="false">Inventory</a>
+                    <a class="nav-link" data-bs-toggle="tab" href="#inventory@(index)" role="tab" aria-selected="false">Inventory</a>
                 </li>
             </ul>
 
@@ -417,7 +411,7 @@
                                                 @if (Model.Merits.Count > 0) {
                                                     <tbody>
                                                         <tr>
-                                                            <th class="text-left">Date</th>
+                                                            <th class="text-start">Date</th>
                                                             <th>Reason</th>
                                                             @if (isAdmin) {
                                                                 <th></th>
@@ -452,7 +446,7 @@
                                                 <caption style="caption-side: top; text-align: center; font-weight: bold;">Demerits</caption>
                                                 <thead>
                                                     <tr>
-                                                        <th class="text-left">Date</th>
+                                                        <th class="text-start">Date</th>
                                                         <th>Reason</th>
                                                         @if (isAdmin) {
                                                             <th></th>
@@ -572,10 +566,14 @@
                 const hash = url.split("#");
                 var backupNum = hash[1].slice(-1);
                 if (backupNum != "0") {
-                    $('a[href="#user' + backupNum + '"]').tab("show");
+                    // BS5 dropped the jQuery .tab() plugin; use bootstrap.Tab directly
+                    const accountTab = document.querySelector('a[href="#user' + backupNum + '"]');
+                    if (accountTab) bootstrap.Tab.getOrCreateInstance(accountTab).show();
                 }
 
-                $('a[href="#' + hash[1] + '"]').tab("show");
+                // Show the specific inner tab from the URL hash
+                const innerTab = document.querySelector('a[href="#' + hash[1] + '"]');
+                if (innerTab) bootstrap.Tab.getOrCreateInstance(innerTab).show();
                 url = location.href.replace(/\/#/, "#");
                 history.replaceState(null, null, url);
                 setTimeout(() => {
@@ -584,7 +582,7 @@
 
             }
 
-            $('a[data-toggle="tab"]').on("click", function () {
+            $('a[data-bs-toggle="tab"]').on("click", function () {
                 let newUrl;
                 const hash = $(this).attr("href");
 

--- a/EGG9000.Site/Views/MyFarms/ResearchTest.cshtml
+++ b/EGG9000.Site/Views/MyFarms/ResearchTest.cshtml
@@ -46,8 +46,8 @@
     });
 }
 
-<div ng-controller="Page">
-    {{  TotalDiscount }} 
+<div x-data="researchTest()">
+    <span x-text="TotalDiscount"></span>
     <table class="table">
         <thead>
             <tr>
@@ -57,33 +57,56 @@
                 <th>Next Cost</th>
             </tr>
         </thead>
-        <tr ng-repeat="research in allResearch" ng-if="research.CurrentLevel < research.Levels && research.Tier > 0">
-            <td>{{research.Tier}}</td>
-            <td>{{ research.Name }}</td>
+        <template x-for="(research, i) in allResearch" :key="research.ID">
+        <tr x-show="research.CurrentLevel < research.Levels && research.Tier > 0">
+            <td x-text="research.Tier"></td>
+            <td x-text="research.Name"></td>
             <td>
-                <button ng-disabled="research.CurrentLevel == 0" ng-click="research.CurrentLevel = research.CurrentLevel - 1">-</button>
-                <button ng-disabled="research.CurrentLevel == research.Levels" ng-click="research.CurrentLevel = research.CurrentLevel + 1">+</button>
+                <button :disabled="research.CurrentLevel == 0" @@click="research.CurrentLevel--">-</button>
+                <button :disabled="research.CurrentLevel == research.Levels" @@click="research.CurrentLevel++">+</button>
 
-                {{ research.CurrentLevel }}/{{research.Levels}}</td>
-            <td ng-if="research.EoVCosts[research.CurrentLevel] &gt; 0">{{ numberToString( research.EoVCosts[research.CurrentLevel] * TotalDiscount) }}</td>
-            <td ng-if="research.EoVCosts[research.CurrentLevel] &lt;= 0">-</td>
-            <td ng-if="research.EoVCosts[research.CurrentLevel] == null">Completed</td>
-            <td><input ng-model="research.V" />{{numberToString(numberFromString(research.V) / (TotalDiscount + 0.5))}}</td>
-            <td><button ng-click="Submit(research)">Submit</button></td>
+                <span x-text="research.CurrentLevel"></span>/<span x-text="research.Levels"></span></td>
+            <td x-show="research.EoVCosts[research.CurrentLevel] > 0" x-text="numberToString(research.EoVCosts[research.CurrentLevel] * TotalDiscount)"></td>
+            <td x-show="research.EoVCosts[research.CurrentLevel] <= 0">-</td>
+            <td x-show="research.EoVCosts[research.CurrentLevel] == null">Completed</td>
+            <td><input x-model="research.V" /><span x-text="numberToString(numberFromString(research.V) / (TotalDiscount + 0.5))"></span></td>
+            <td><button @@click="Submit(research)">Submit</button></td>
 
 </tr>
+        </template>
     </table>
 </div>
 
 @section Scripts {
     <script>
-        angular.module('egg9000', ['ui.bootstrap', 'angularMoment', 'ngMaterial', 'ngMessages'])
-            .controller('Page', ['$scope', '$rootScope', '$uibModal', 'moment', '$http', '$timeout', '$interval', '$q', function ($scope, $rootScope, $uibModal, moment, $http, $timeout, $interval, $q) {
-                $scope.allResearch = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(allResearch));
-                console.log($scope.allResearch);
-                $scope.TotalDiscount = @Html.Raw(researchDiscount * researchCostDisicountColleggtible * artifactDiscount);
+        document.addEventListener('alpine:init', () => {
+            Alpine.data('researchTest', () => ({
+                allResearch: [],
+                TotalDiscount: @Html.Raw(researchDiscount * researchCostDisicountColleggtible * artifactDiscount),
 
-                const bignums = [
+                init() {
+                    this.allResearch = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(allResearch));
+                },
+
+                Submit(research) {
+                    const value = this.numberFromString(research.V) / (this.TotalDiscount);
+                    research.EoVCosts[research.CurrentLevel] = value;
+                    if (value > 0) {
+                        fetch('/MyFarms/SubmitResearchCost', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({
+                                id: research.ID,
+                                cost: value,
+                                level: research.CurrentLevel + 1
+                            })
+                        }).then(r => r.ok ? alert('Submitted') : r.text().then(t => alert('Error: ' + t)));
+                    } else {
+                        alert('Invalid Value');
+                    }
+                },
+
+                bignums: [
                     [0, ""],
                     [3, "K"],
                     [6, "M"],
@@ -111,26 +134,10 @@
                     [72, "tV"],
                     [75, "qV"],
                     [78, "QV"],
-                ];
-                $scope.Submit = function(research) {
-                    const value = $scope.numberFromString(research.V) / ($scope.TotalDiscount);
-                    research.EoVCosts[research.CurrentLevel] = value;
-                     if (value > 0) {
-                        $http.post('/MyFarms/SubmitResearchCost', {
-                            id: research.ID,
-                            cost: value,
-                            level: research.CurrentLevel + 1
-                        }).then(function(result) {
-                            alert('Submitted');
-                        }, function(err) {
-                            alert('Error: ' + err.data);
-                        });
-                    } else {
-                        alert('Invalid Value');
-                    }
-                }
+                ],
 
-                $scope.numberToString = function(number, showDecimalPlaces = true, numberOfDecimalPlaces = 3) {
+                numberToString(number, showDecimalPlaces = true, numberOfDecimalPlaces = 3) {
+                    const bignums = this.bignums;
                     const negative = number < 0;
                     if (negative) number = -number;
 
@@ -151,9 +158,10 @@
                     outString += suffixEntry[1];
 
                     return outString;
-                }
+                },
 
-                $scope.numberFromString = function(arg) {
+                numberFromString(arg) {
+                    const bignums = this.bignums;
                     const regex = /([\d\.]+)(\w*)/;
                     const match = regex.exec(arg);
                     if (match) {
@@ -168,6 +176,7 @@
                         }
                     }
                 }
-            }]);
+            }));
+        });
     </script>
 }

--- a/EGG9000.Site/Views/Shared/_Layout.cshtml
+++ b/EGG9000.Site/Views/Shared/_Layout.cshtml
@@ -1,12 +1,14 @@
-﻿<!DOCTYPE html>
-<html lang="en">
+@{
+	var darkMode = User?.FindFirst("DarkMode")?.Value == "true";
+}
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="@(darkMode ? "dark" : "")">
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>@ViewData["Title"] - EGG9000.Site</title>
 
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@forevolve/bootstrap-dark@1.0.0/dist/css/toggle-bootstrap.min.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@forevolve/bootstrap-dark@1.0.0/dist/css/toggle-bootstrap-dark.min.css" />
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
 	<link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 
 	<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -18,24 +20,21 @@
 	<meta name="theme-color" content="#ffffff">
 	<style>
 		body {
-			height: auto !important; 
+			height: auto !important;
 		}
 	</style>
 	@RenderSection("Head", required: false)
 </head>
-@{
-	var darkMode = User?.FindFirst("DarkMode")?.Value == "true";
-}
-<body ng-app="egg9000" class="@(darkMode ? "bootstrap-dark" : "bootstrap")">
+<body>
 	<header>
-		<nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3 navbar-themed">
+		<nav class="navbar navbar-expand-sm border-bottom box-shadow mb-3">
 			<div class="container">
 				<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index"><img src="/apple-touch-icon.png" style="height: 28px;" /> EGG9000</a>
-				<button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+				<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
 						aria-expanded="false" aria-label="Toggle navigation">
 					<span class="navbar-toggler-icon"></span>
 				</button>
-				<div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
+				<div class="navbar-collapse collapse flex-sm-row-reverse">
 					<partial name="_LoginPartial" />
 					<ul class="navbar-nav flex-grow-1">
 						<li class="nav-item">
@@ -43,7 +42,7 @@
 						</li>
 						@if (User.Identity.IsAuthenticated) {
 							<li class="nav-item dropdown">
-								<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+								<a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
 								  Leaderboard
 								</a>
 								<div class="dropdown-menu" aria-labelledby="navbarDropdown">
@@ -69,7 +68,7 @@
 								<a class="nav-link" asp-area="" asp-controller="Admin" asp-action="Index">Admin</a>
 							</li>
 							<li class="nav-item">
-								<form class="form-inline" style="display: inline-block;" action="/admin/searchid">
+								<form class="d-flex align-items-center gap-2" style="display: inline-flex !important;" action="/admin/searchid">
 									<input class="form-control" style="width: 150px" placeholder="Search" name="id" />
 								</form>
 
@@ -91,24 +90,13 @@
 			@*&copy; 2020 - EGG9000.Site - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>*@
 		</div>
 	</footer>
-	<script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+	<script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 	<script src="~/lib/js-cookie/dist/js.cookie.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/angular@1.7.6/angular.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.15/lodash.min.js"></script>
-	<script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 	<script src="~/js/site.js" asp-append-version="true"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/2.5.0/ui-bootstrap.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/2.5.0/ui-bootstrap-tpls.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.20.1/moment.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-moment/1.2.0/angular-moment.min.js"></script>
 
-
-	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.12/angular-material.min.css">
-	<script src="https://cdn.jsdelivr.net/npm/angular-animate@1.7.6/angular-animate.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/angular-aria@1.7.6/angular-aria.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/angular-messages@1.7.6/angular-messages.min.js"></script>
-	<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/angular-material/1.1.12/angular-material.min.js"></script>
+	<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"></script>
 	@RenderSection("Scripts", required: false)
 	<script>
 		if (window.ScriptsToExecute) {

--- a/EGG9000.Site/Views/Shared/_LoginPartial.cshtml
+++ b/EGG9000.Site/Views/Shared/_LoginPartial.cshtml
@@ -10,7 +10,7 @@
 
     </li>
     <li class="nav-item">
-        <form  class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
+        <form  class="d-flex align-items-center gap-2" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
             <button  type="submit" class="nav-link btn btn-link">Logout</button>
         </form>
     </li>

--- a/EGG9000.Site/wwwroot/css/site.css
+++ b/EGG9000.Site/wwwroot/css/site.css
@@ -2,9 +2,35 @@
 for details on configuring this project to bundle and minify static web assets. */
 
 a.navbar-brand {
-  white-space: normal;
-  text-align: center;
-  word-break: break-all;
+  white-space: nowrap;
+}
+
+/* Alert close button: remove focus ring */
+.alert .btn-close:focus { outline: none; }
+/* BS5 dark mode inverts .btn-close to white; override back to default dark icon
+   since alert backgrounds are kept at light-mode colors (see overrides below) */
+[data-bs-theme="dark"] .alert .btn-close { filter: none; }
+
+/* Keep alert colors consistent regardless of dark mode */
+[data-bs-theme="dark"] .alert-success {
+    --bs-alert-color: #0f5132;
+    --bs-alert-bg: #d1e7dd;
+    --bs-alert-border-color: #badbcc;
+}
+[data-bs-theme="dark"] .alert-danger {
+    --bs-alert-color: #842029;
+    --bs-alert-bg: #f8d7da;
+    --bs-alert-border-color: #f5c2c7;
+}
+[data-bs-theme="dark"] .alert-warning {
+    --bs-alert-color: #664d03;
+    --bs-alert-bg: #fff3cd;
+    --bs-alert-border-color: #ffecb5;
+}
+[data-bs-theme="dark"] .alert-info {
+    --bs-alert-color: #055160;
+    --bs-alert-bg: #cff4fc;
+    --bs-alert-border-color: #b6effb;
 }
 
 /* Provide sufficient contrast against white background */

--- a/EGG9000.Site/wwwroot/js/eb-stats-chart.js
+++ b/EGG9000.Site/wwwroot/js/eb-stats-chart.js
@@ -232,27 +232,27 @@ function initEbStatsChart(suffix, snapData) {
             renderChart(activeContainerId());
         }
 
-        document.querySelectorAll('[data-bs-toggle="tab"]').forEach(function(tab) {
-            tab.addEventListener('shown.bs.tab', function(e) {
-                if (state.chart) return;
-                var href = e.target.getAttribute('data-bs-target') || e.target.getAttribute('href');
-                if (!href) return;
-                var shownEl = document.querySelector(href);
-                if (shownEl && (shownEl === pane || shownEl.contains(pane)) && pane.classList.contains('active')) {
-                    renderChart(activeContainerId());
-                }
-            });
+        // One delegated listener per chart on document, scoped by this chart's pane.
+        // Attaching per-tab would stack N listener pairs on every tab when N charts init.
+        document.addEventListener('shown.bs.tab', function(e) {
+            if (state.chart) return;
+            var href = e.target.getAttribute('data-bs-target') || e.target.getAttribute('href');
+            if (!href) return;
+            var shownEl = document.querySelector(href);
+            if (shownEl && (shownEl === pane || shownEl.contains(pane)) && pane.classList.contains('active')) {
+                renderChart(activeContainerId());
+            }
+        });
 
-            tab.addEventListener('hidden.bs.tab', function(e) {
-                if (!state.chart) return;
-                var href = e.target.getAttribute('data-bs-target') || e.target.getAttribute('href');
-                if (!href) return;
-                var hiddenEl = document.querySelector(href);
-                if (hiddenEl && (hiddenEl === pane || hiddenEl.contains(pane))) {
-                    state.chart.destroy();
-                    state.chart = null;
-                }
-            });
+        document.addEventListener('hidden.bs.tab', function(e) {
+            if (!state.chart) return;
+            var href = e.target.getAttribute('data-bs-target') || e.target.getAttribute('href');
+            if (!href) return;
+            var hiddenEl = document.querySelector(href);
+            if (hiddenEl && (hiddenEl === pane || hiddenEl.contains(pane))) {
+                state.chart.destroy();
+                state.chart = null;
+            }
         });
     });
 

--- a/EGG9000.Site/wwwroot/js/eb-stats-chart.js
+++ b/EGG9000.Site/wwwroot/js/eb-stats-chart.js
@@ -91,9 +91,7 @@ function initEbStatsChart(suffix, snapData) {
     }
 
     function buildOptions() {
-        var isDark = (typeof getCookie === 'function' && getCookie('Egg9000Theme') === 'bootstrap-dark')
-                  || document.body.classList.contains('bootstrap-dark')
-                  || document.documentElement.classList.contains('bootstrap-dark');
+        var isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark';
         var textColor  = isDark ? '#e9ecef' : '#373d3f';
         var gridColor  = isDark ? '#444'    : '#e0e0e0';
         var axisLabelFmt = function(val) { return typeof val === 'number' ? val.toFixed(2) : val; };
@@ -192,7 +190,7 @@ function initEbStatsChart(suffix, snapData) {
             var containerId = state.expanded ? 'ebStatsChartFull-' + suffix : 'ebStatsChartNarrow-' + suffix;
             renderChart(containerId);
         } else {
-            var isDarkU = document.body.classList.contains('bootstrap-dark') || document.documentElement.classList.contains('bootstrap-dark');
+            var isDarkU = document.documentElement.getAttribute('data-bs-theme') === 'dark';
             var textColorU = isDarkU ? '#e9ecef' : '#373d3f';
             var fmtU = function(val) { return typeof val === 'number' ? val.toFixed(2) : val; };
             state.chart.updateOptions({
@@ -234,25 +232,27 @@ function initEbStatsChart(suffix, snapData) {
             renderChart(activeContainerId());
         }
 
-        $('[data-toggle="tab"]').on('shown.bs.tab.ebstats' + suffix, function(e) {
-            if (state.chart) return;
-            var href = $(e.target).attr('href');
-            if (!href) return;
-            var shownEl = document.querySelector(href);
-            if (shownEl && (shownEl === pane || shownEl.contains(pane)) && pane.classList.contains('active')) {
-                renderChart(activeContainerId());
-            }
-        });
+        document.querySelectorAll('[data-bs-toggle="tab"]').forEach(function(tab) {
+            tab.addEventListener('shown.bs.tab', function(e) {
+                if (state.chart) return;
+                var href = e.target.getAttribute('data-bs-target') || e.target.getAttribute('href');
+                if (!href) return;
+                var shownEl = document.querySelector(href);
+                if (shownEl && (shownEl === pane || shownEl.contains(pane)) && pane.classList.contains('active')) {
+                    renderChart(activeContainerId());
+                }
+            });
 
-        $('[data-toggle="tab"]').on('hidden.bs.tab.ebstats' + suffix, function(e) {
-            if (!state.chart) return;
-            var href = $(e.target).attr('href');
-            if (!href) return;
-            var hiddenEl = document.querySelector(href);
-            if (hiddenEl && (hiddenEl === pane || hiddenEl.contains(pane))) {
-                state.chart.destroy();
-                state.chart = null;
-            }
+            tab.addEventListener('hidden.bs.tab', function(e) {
+                if (!state.chart) return;
+                var href = e.target.getAttribute('data-bs-target') || e.target.getAttribute('href');
+                if (!href) return;
+                var hiddenEl = document.querySelector(href);
+                if (hiddenEl && (hiddenEl === pane || hiddenEl.contains(pane))) {
+                    state.chart.destroy();
+                    state.chart = null;
+                }
+            });
         });
     });
 


### PR DESCRIPTION
Risk: Frontend framework migration
This PR swaps AngularJS (ng-*) for Alpine.js and Bootstrap 3 for Bootstrap 5. Pages previously driven by Angular directives are now Alpine-powered. The two frameworks differ in binding/lifecycle, any remaining ng-* or {{ }} in active views could silently break. BS5 also changes component APIs (data-toggle → data-bs-toggle etc.).

Removed:
  - @forevolve/bootstrap-dark@1.0.0 (2 CSS files) — replaced by BS5 native dark mode
  - angular@1.7.6,  replaced by Alpine.js
  - angular-ui-bootstrap@2.5.0 (JS + tpls)
  - angular-material@1.1.12 (CSS + JS)
  - angular-animate@1.7.6
  - angular-aria@1.7.6
  - angular-messages@1.7.6
  - angular-moment@1.2.0
  - moment.js@2.20.1
  - Google Fonts (Material Icons)
  - Bootstrap bundled from local ~/lib/ → now CDN

  Added:
  - bootstrap@5.3.3 (CSS + JS bundle, CDN)
  - alpinejs@3.14.1 (CDN, defer)

  Updated:
  - jquery 3.5.1 → 3.7.1
  - lodash 4.17.15 → 4.17.21


---

### High-level testing

- [x] Grep each view for leftover `ng-*` / `{{ }}` and `data-toggle`
- [ ] Test `Day1Coops`' drag re-order functionality explicitly
- [x] Check for console errors on any pages

## For page testing specifically

### The following tests:
- [x] Does dynamic content populate?
- [x] Do buttons/modals fire?
- [x] Do forms submit with values

### Should be run against every page/sub-page below:
- [x] Admin
	- [x] Index
	- [x] ConfigureServer
	- [x] EventCustomization (modal + save)
	- [x] FAQCustomization + SaveFAQ (modal + save)
	- [x] LatestDemerits
	- [x] Slackers

- [ ] Contract
	- [ ] Day1Coops (drag-reorder + save)
	- [x] Details
	
- [x] Home
	- [x] Coop
	- [x] Leaderboard(s)
	- [x] Boosts
	- [x] FAQ
	
- [x] MyFarms
	- [x] Index
	- [x] Tab Partials
		- [x] Colleggtibles
		- [x] ContractHistory,
		- [x] EBHistory
		- [x] EarningsBoostCalculator
		- [x] EpicResearch
		- [x] ExternalTools
		- [x] ShipsAndFarms