### PR TITLE
Fix: Grade Regressions from All-Grade Coops

### DIFF
--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -180,8 +180,12 @@ namespace EGG9000.Common.Database.Entities {
                         _accounts.ForEach(account => {
                             if(account.RedoLeggacySelection == RedoLeggacyOption.NotSet)
                                 account.RedoLeggacySelection = account.RedoLeggacy ? RedoLeggacyOption.YesAll : RedoLeggacyOption.No;
+                            // Catch LastGrade up from the most-recent backup contract, but only upward.
+                            // A lower-grade contract accepted after PromotionTime is a grade pull (ULTRA
+                            // all-grade coop join), not a demotion, so it must not push LastGrade down.
+                            // Real demotions arrive via the authoritative API grade (UserGrades).
                             var (backupGrade, backupGradeAccepted) = account.Backup?.GetMostRecentContractGrade() ?? (Ei.Contract.Types.PlayerGrade.GradeUnset, DateTimeOffset.MinValue);
-                            if(backupGrade != Ei.Contract.Types.PlayerGrade.GradeUnset && backupGrade != account.LastGrade && backupGradeAccepted > account.PromotionTime) {
+                            if(backupGrade != Ei.Contract.Types.PlayerGrade.GradeUnset && backupGrade > account.LastGrade && backupGradeAccepted > account.PromotionTime) {
                                 account.LastGrade = backupGrade;
                                 needsUpdate = true;
                             }
@@ -453,8 +457,13 @@ namespace EGG9000.Common.Database.Entities {
             // The backup's contract grade beats a possibly-stale LastGrade, but only when that
             // contract was accepted after the last known promotion. Otherwise the promotion is newer
             // than any contract has caught up to, so LastGrade is the truth.
+            // The backup contract grade is only a fallback signal: it may catch LastGrade up when the
+            // player has promoted, but it must never override LastGrade downward. ULTRA players can join
+            // a lower-grade all-grade coop (a grade pull), which leaves a newer lower-grade contract in
+            // the backup that is not a demotion. Real demotions come through the authoritative API grade
+            // (LastGrade, refreshed by UserGrades), not the backup.
             var (backupGrade, accepted) = Backup.GetMostRecentContractGrade();
-            if(backupGrade != Ei.Contract.Types.PlayerGrade.GradeUnset && accepted > PromotionTime)
+            if(backupGrade != Ei.Contract.Types.PlayerGrade.GradeUnset && accepted > PromotionTime && backupGrade > LastGrade)
                 return backupGrade;
 
             return LastGrade != Ei.Contract.Types.PlayerGrade.GradeUnset ? LastGrade : backupGrade;

--- a/EGG9000.Test/DBUserProjection.cs
+++ b/EGG9000.Test/DBUserProjection.cs
@@ -5,8 +5,11 @@ using MessagePack;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+
+using G = Ei.Contract.Types.PlayerGrade;
 
 namespace EGG9000.Test {
     // Guards the InactivePlayers / register projection change. Both call sites stopped loading the
@@ -68,6 +71,49 @@ namespace EGG9000.Test {
         public void NullColumnsYieldNoAccounts() {
             var projected = DBUser.FromAccountColumns(null, null);
             Assert.AreEqual(0, projected.EggIncAccounts.Count);
+        }
+
+        // The EggIncAccounts getter syncs LastGrade from the most-recent backup contract grade. That
+        // sync may only catch the grade up, never push it down. A lower-grade backup contract accepted
+        // after PromotionTime is a grade pull (ULTRA all-grade coop join), not a demotion - it must not
+        // overwrite a higher LastGrade. These build the user via the persisted columns so the getter's
+        // backup-hydration + grade-sync branch runs.
+        private static DBUser UserWithBackupGrade(G lastGrade, long promotionTimeUnix, G backupGrade, long backupAccepted) {
+            var source = new DBUser {
+                EggIncAccounts = new List<EggIncAccount> {
+                    new() {
+                        Id = "EI777",
+                        Name = "Z",
+                        LastGrade = lastGrade,
+                        PromotionTime = DateTimeOffset.FromUnixTimeSeconds(promotionTimeUnix)
+                    }
+                }
+            };
+            source._CustomBackups = MessagePackSerializer.Serialize(new List<CustomBackup> {
+                new() {
+                    EggIncId = "EI777",
+                    Farms = [new CustomFarm { Grade = backupGrade, TimeAccepted = backupAccepted }]
+                }
+            }, DBUser.lz4Options);
+            // Rehydrate from the persisted columns so the getter runs the backup-hydration + grade-sync
+            // branch (the in-memory _accounts cache on `source` would otherwise short-circuit it).
+            return new DBUser {
+                _eggIncIds = source._eggIncIds,
+                _contractRegistrationByte = source._contractRegistrationByte,
+                _CustomBackups = source._CustomBackups
+            };
+        }
+
+        [TestMethod]
+        public void LowerGradeBackupContractDoesNotDemoteLastGrade() {
+            var user = UserWithBackupGrade(G.GradeAaa, 1_000_000_000, G.GradeAa, 2_000_000_000);
+            Assert.AreEqual(G.GradeAaa, user.EggIncAccounts.Single().LastGrade);
+        }
+
+        [TestMethod]
+        public void HigherGradeBackupContractCatchesLastGradeUp() {
+            var user = UserWithBackupGrade(G.GradeAa, 1_000_000_000, G.GradeAaa, 2_000_000_000);
+            Assert.AreEqual(G.GradeAaa, user.EggIncAccounts.Single().LastGrade);
         }
     }
 }

--- a/EGG9000.Test/GetGradeTests.cs
+++ b/EGG9000.Test/GetGradeTests.cs
@@ -43,5 +43,15 @@ namespace EGG9000.Test {
             var account = AccountWith(G.GradeAa, DateTimeOffset.FromUnixTimeSeconds(OldAccept), G.GradeAaa, NewAccept);
             Assert.AreEqual(G.GradeAaa, account.GetGrade());
         }
+
+        [TestMethod]
+        public void Lower_grade_contract_does_not_demote_last_grade() {
+            // Grade-pull case: an AAA player joins a lower-grade (AA) all-grade coop for a guildie.
+            // That AA contract is the most recent one accepted, but joining down is not a demotion -
+            // the backup contract grade is only a fallback and must not override the authoritative
+            // LastGrade downward. GetGrade must stay AAA.
+            var account = AccountWith(G.GradeAaa, DateTimeOffset.FromUnixTimeSeconds(OldAccept), G.GradeAa, NewAccept);
+            Assert.AreEqual(G.GradeAaa, account.GetGrade());
+        }
     }
 }


### PR DESCRIPTION
https://discord.com/channels/656455567858073601/746509501271769210/1521269397069758509

User had an issue where, after joining an all-grade coop in AA with their mini, it was "demoted" from AAA to AA by E9K. This was almost certainly due to the backup-grade tension that we have, and a poor choice of delimeter of "when to take" the value.