### PR TITLE
Chore: organise commands 

### DIFF
--- a/EGG9000.Bot/Commands/ApiVersionCommands.cs
+++ b/EGG9000.Bot/Commands/ApiVersionCommands.cs
@@ -15,7 +15,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 namespace EGG9000.Bot.Commands {
     public static class ApiVersionCommands {
 
-        [SlashCommand(Description = "Update the Egg Inc API version triple at runtime (validated against the live API first).", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "b")]
+        [SlashCommand(Description = "Update the Egg Inc API version triple at runtime (validated against the live API first).", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "bot")]
         public static async Task SetVersions(
             FauxCommand command,
             IServiceProvider provider,

--- a/EGG9000.Bot/Commands/BanCommands.cs
+++ b/EGG9000.Bot/Commands/BanCommands.cs
@@ -88,7 +88,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = unbanEmbed; });
         }
 
-        [SlashCommand(Description = "Kick user with dm", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Kick user with dm", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task Kick(FauxCommand command, ApplicationDbContext db, DiscordHostedService _client, [SlashParam] SocketUser[] users, [SlashParam] string reason, [SlashParam(Required = false)] bool banaccount = false) {
             await command.DeferAsync();
             var guild = _client.Guilds.FirstOrDefault(x => x.TextChannels.Any(y => y.Id == command.Channel.Id));

--- a/EGG9000.Bot/Commands/ConfigureCommands.cs
+++ b/EGG9000.Bot/Commands/ConfigureCommands.cs
@@ -20,7 +20,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
 namespace EGG9000.Bot.Commands {
     /// <summary>
-    /// `/a configure` - the site's Configure Server page, inside Discord. Built
+    /// `/admin configure` - the site's Configure Server page, inside Discord. Built
     /// dynamically: channels/roles from <see cref="GuildChannelType"/> + its Description
     /// prefixes (/TC/, /R/), coop toggles from <see cref="GuildCoopSetting"/>, and scalar
     /// settings from <c>[GuildConfig]</c>-annotated <see cref="Guild"/> properties. Adding
@@ -218,7 +218,7 @@ namespace EGG9000.Bot.Commands {
             return (eb.Build(), cb.Build());
         }
 
-        [SlashCommand(Description = "Configure this server (same as the website)", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "b")]
+        [SlashCommand(Description = "Configure this server (same as the website)", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task Configure(FauxCommand command, ApplicationDbContext db) {
             await command.DeferAsync(ephemeral: true);
             var g = await LoadGuild(db, command.GuildId);

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -404,7 +404,7 @@ namespace EGG9000.Bot.Commands {
             await db.SaveChangesAsync();
         }
 
-        [SlashCommand(Description = "Makes this co-op private", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Makes this co-op private", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task MakePrivate(FauxCommand command, ApplicationDbContext db) {
             await command.DeferAsync();
             var name = new Regex(@"\w+").Match(command.Channel.Name.ToLower()).Value;
@@ -434,7 +434,7 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
-        [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.FarmHand)]
+        [SlashCommand(Description = "Adds an outside co-op so you can track it's progress", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task AddCoop(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client,
             [SlashParam(AutocompleteHandler = typeof(StaffContractAutoComplete))] string contract,
             [SlashParam] string coopname, [SlashParam(AutocompleteHandler = typeof(GradeAutoComplete))] uint grade,
@@ -631,7 +631,7 @@ namespace EGG9000.Bot.Commands {
 
         }
 
-        [SlashCommand(Description = "Delete a contract channel (Please use this instead of deleting the channel in discord)", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Delete a contract channel (Please use this instead of deleting the channel in discord)", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task DeleteContract(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client, ILogger _logger) {
             var guildContract = db.GuildContracts.Include(x => x.Contract).FirstOrDefault(x => x.DiscordChannelId == command.Channel.Id);
             if(guildContract == null) {

--- a/EGG9000.Bot/Commands/DemeritCommands.cs
+++ b/EGG9000.Bot/Commands/DemeritCommands.cs
@@ -22,7 +22,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
 namespace EGG9000.Bot.Commands {
     public static class DemeritCommands {
-        [SlashCommand(Description = "Add demerit to user", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Add demerit to user", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task AddDemerit(FauxCommand command, DiscordSocketClient _client, [SlashParam] SocketGuildUser user, [SlashParam] string reason, ApplicationDbContext db, DiscordHostedService discordClient, [SlashParam(Required = false)] bool hidden = false) {
             await command.DeferAsync(ephemeral: hidden);
             try {
@@ -54,7 +54,7 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
-        [SlashCommand(Description = "Remove latest demerit from user", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Remove latest demerit from user", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task RemoveDemerit(FauxCommand command, [SlashParam] SocketGuildUser user, ApplicationDbContext db) {
             await command.DeferAsync();
             try {
@@ -109,7 +109,7 @@ namespace EGG9000.Bot.Commands {
                 await command.ModifyOriginalResponseAsync(x => x.Embed = EmbedExceptionFrame(e));
             }
         }
-        [SlashCommand(Description = "List demerits for user", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "List demerits for user", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task DemeritsForUser(FauxCommand command, [SlashParam] SocketGuildUser user, ApplicationDbContext db, [SlashParam(Required = false)] bool hidden = false) {
             await command.DeferAsync(ephemeral: hidden);
             try {
@@ -140,7 +140,7 @@ namespace EGG9000.Bot.Commands {
             return demeritDesc;
         }
 
-        [SlashCommand(Description = "Stops user from getting demerit in co-op", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Stops user from getting demerit in co-op", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task NoDemerit(FauxCommand command, [SlashParam] SocketGuildUser user, ApplicationDbContext db) {
             await command.DeferAsync();
             List<UserCoopXref> xref;

--- a/EGG9000.Bot/Commands/EditFaqCommands.cs
+++ b/EGG9000.Bot/Commands/EditFaqCommands.cs
@@ -20,7 +20,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
 namespace EGG9000.Bot.Commands {
     /// <summary>
-    /// `/a editfaq` - in-Discord FAQ topic editing (the website's FAQ Customization page).
+    /// `/admin editfaq` - in-Discord FAQ topic editing (the website's FAQ Customization page).
     /// Lists/adds/edits/deletes the guild's <see cref="FAQTopic"/> rows with the same
     /// component+modal UX as <see cref="RankupCommands"/>; writes the same table and invalidates
     /// the same cache. Explanation/preview run through <see cref="MessageFormatter"/>.
@@ -96,7 +96,7 @@ namespace EGG9000.Bot.Commands {
                 .AddTextInputSafe("Embed color (6-hex, optional)", customId: "color", value: existing?.EmbedColorHex, required: false, maxLength: 7)
                 .AddTextInputSafe("Image URL (optional)", customId: "image", value: existing?.ImageUrl, required: false, maxLength: 400);
 
-        [SlashCommand(Description = "Edit this server's FAQ topics", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "b")]
+        [SlashCommand(Description = "Edit this server's FAQ topics", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task EditFaq(FauxCommand command, ApplicationDbContext db, DiscordHostedService client) {
             await command.DeferAsync(ephemeral: true);
             var g = await LoadGuild(db, command.GuildId);

--- a/EGG9000.Bot/Commands/MeritCommands.cs
+++ b/EGG9000.Bot/Commands/MeritCommands.cs
@@ -17,7 +17,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
 namespace EGG9000.Bot.Commands {
     public static class MeritCommands {
-        [SlashCommand(Description = "Add merit to user(s)", AdminOnly = StaffOnlyLevel.ChickenTender)]
+        [SlashCommand(Description = "Add merit to user(s)", AdminOnly = StaffOnlyLevel.ChickenTender, ParentCommand = "a")]
         public static async Task AddMerit(FauxCommand command, ApplicationDbContext db, DiscordSocketClient _client,
             [SlashParam(Description = "Merit Reason")] string reason,
             [SlashParam] SocketGuildUser[] users
@@ -65,7 +65,7 @@ namespace EGG9000.Bot.Commands {
 
         }
 
-        [SlashCommand(Description = "Remove merit from user", AdminOnly = StaffOnlyLevel.FarmHand)]
+        [SlashCommand(Description = "Remove merit from user", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task RemoveMerit(FauxCommand command, [SlashParam] SocketGuildUser user, ApplicationDbContext db) {
             try {
                 var admin = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == command.User.Id);
@@ -88,7 +88,7 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
-        [SlashCommand(Description = "List merits for user", AdminOnly = StaffOnlyLevel.FarmHand)]
+        [SlashCommand(Description = "List merits for user", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task MeritsForUser(FauxCommand command, [SlashParam] SocketGuildUser targetUser, ApplicationDbContext db) {
             try {
                 var user = await db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == targetUser.Id);

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -169,7 +169,7 @@ namespace EGG9000.Bot.Commands {
             });
         }
 
-        [SlashCommand(Description = "Rename a co-op channel to mistype", AdminOnly = StaffOnlyLevel.FarmHand)]
+        [SlashCommand(Description = "Rename a co-op channel to mistype", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task RenameCoop(FauxCommand command, ApplicationDbContext db, [SlashParam] string correctcoopname) {
             await command.DeferAsync();
             var targetCoop = await db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
@@ -184,7 +184,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => x.Content = $"Co-op renamed to {correctcoopname}");
         }
 
-        [SlashCommand(Description = "Trigger an update for a co-op or contract channel", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
+        [SlashCommand(Description = "Trigger an update for a co-op or contract channel", AdminOnly = StaffOnlyLevel.CluckingCoordinator, ParentCommand = "a")]
         public static async Task UpdateChannel(FauxCommand command, ApplicationDbContext db, ThreadsCoopStatusUpdater coopStatusUpdaterThreads, DiscordSocketClient discord, ContractUpdater contractUpdater) {
             await command.DeferAsync(ephemeral: true);
             var targetCoop = await db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
@@ -213,7 +213,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => x.Embed = EmbedError($"Command only works in contract or co-op channels"));
         }
 
-        [SlashCommand(Description = "Adds a temporary role for users that last a specific amount of time", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
+        [SlashCommand(Description = "Adds a temporary role for users that last a specific amount of time", AdminOnly = StaffOnlyLevel.CluckingCoordinator, ParentCommand = "a")]
         public static async Task TempRole(FauxCommand command, ApplicationDbContext db, DiscordSocketClient client, [SlashParam] SocketRole role, [SlashParam] string timespan, [SlashParam] string reason, [SlashParam] SocketGuildUser[] users) {
             DateTimeOffset expireTime;
             try {

--- a/EGG9000.Bot/Commands/Ping.cs
+++ b/EGG9000.Bot/Commands/Ping.cs
@@ -12,7 +12,7 @@ namespace EGG9000.Bot.Commands {
             await command.RespondAsync("Pong!", ephemeral: false);
         }
 
-        [SlashCommand(Description = "Test to see if bot is alive/check version", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Test to see if bot is alive/check version", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task Ping(FauxCommand command, ILogger _logger, [SlashParam(Required = false)] bool showInChannel = false) {
 
             var gitVersion = string.Empty;

--- a/EGG9000.Bot/Commands/RankupCommands.cs
+++ b/EGG9000.Bot/Commands/RankupCommands.cs
@@ -19,7 +19,7 @@ using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
 namespace EGG9000.Bot.Commands {
     /// <summary>
-    /// `/a rankup` - per-guild rank-up announcement customization: master + exclusive-pool
+    /// `/admin rankup` - per-guild rank-up announcement customization: master + exclusive-pool
     /// toggles, the per-group notify filter, and the message pools (Global + one per rank
     /// group). Messages are <see cref="RankupMessage"/> rows scoped by GroupBaseOom and
     /// support {{user}} {{rank}} {{eb}} {{oom}} {{emoji:x}} {{command:x}} tokens. Mirrors the
@@ -117,7 +117,7 @@ namespace EGG9000.Bot.Commands {
             return (eb.Build(), cb.Build());
         }
 
-        [SlashCommand(Description = "Customize this server's rank-up announcements", AdminOnly = StaffOnlyLevel.CluckingCoordinator, ParentCommand = "a")]
+        [SlashCommand(Description = "Customize this server's rank-up announcements", AdminOnly = StaffOnlyLevel.CluckingCoordinator, ParentCommand = "admin")]
         public static async Task Rankup(FauxCommand command, ApplicationDbContext db) {
             await command.DeferAsync(ephemeral: true);
             var g = await LoadGuild(db, command.GuildId);

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -230,7 +230,7 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
-        [SlashCommand(Description = "Select X random users with Y role", AdminOnly = StaffOnlyLevel.FarmHand)]
+        [SlashCommand(Description = "Select X random users with Y role", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task SelectRoleUsers(FauxCommand command, DiscordSocketClient client, [SlashParam(Required = true)] int numberOfUsers,
             [SlashParam(Required = true, Description = "Role the user(s) should have")] SocketRole role, [SlashParam(Required = false, Description = "Second role [...]")] SocketRole role2, [SlashParam(Required = false, Description = "Third role [...]")] SocketRole role3,
             [SlashParam(Required = false, Description = "Role the user(s) should NOT have")] SocketRole antiRole, [SlashParam(Required = false, Description = "Second role [...]")] SocketRole antiRole2, [SlashParam(Required = false, Description = "Third role [...]")] SocketRole antiRole3) {
@@ -272,31 +272,8 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
-        [SlashCommand(Description = "Add a temporary prefex for a users co-op (PrefixWord11)", AdminOnly = StaffOnlyLevel.CluckingCoordinator)]
-        public static async Task TemporaryPrefix(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketGuildUser user, [SlashParam] string prefix, [SlashParam] string timespan) {
-            DateTimeOffset expireTime;
-            try {
-                expireTime = timespan.AddTimeSpanString(DateTimeOffset.UtcNow);
-            } catch(Exception ex) {
-                await command.RespondAsync(content: "", embed: EmbedError($"Unable to parse the timespan `{timespan}`, {ex.Message}"));
-                return;
-            }
-            await command.DeferAsync();
 
-            var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == user.Id);
-            if(dbuser == null) {
-                await command.ModifyOriginalResponseAsync(x => { x.Content = $""; x.Embed = EmbedError($"Unable to locate DBUser entry for <@{user.Id}>"); });
-                return;
-            }
-
-            dbuser.CustomCoopName = prefix;
-            dbuser.ExpireCustomCoopName = expireTime;
-            await db.SaveChangesAsync();
-
-            await command.ModifyOriginalResponseAsync(x => x.Content = $"Added the co-op prefix `{prefix}` to {user.Mention} until <t:{expireTime.ToUnixTimeSeconds()}:f>. They will have any co-ops they are in named after them during that time.");
-        }
-
-        [SlashCommand(Description = "Get the bot's status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Get the bot's status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task Status(FauxCommand command, ApplicationDbContext db, IServiceProvider serviceProvider) {
             var lastComplete = await db.AutomationLogs.Where(x => x.EndTime.HasValue).GroupBy(x => x.Type).Select(x => x.OrderByDescending(y => y.EndTime).First()).ToListAsync();
             var last24 = await db.AutomationLogs.Where(x => x.StartTime > DateTimeOffset.UtcNow.AddDays(-1) && x.EndTime.HasValue).ToListAsync();
@@ -335,7 +312,7 @@ namespace EGG9000.Bot.Commands {
             await command.RespondAsync($"```\n{GetTable(table)}```");
         }
 
-        [SlashCommand(Description = "Restart an automated service", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Restart an automated service", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task RestartService(FauxCommand command, [SlashParam(AutocompleteHandler = typeof(ServiceNameAutoComplete))] string serviceName, IServiceProvider serviceProvider, JobService jobService) {
             await command.DeferAsync();
             var service = serviceProvider.GetServices<IHostedService>().FirstOrDefault(x => x.GetType().Name == serviceName);
@@ -379,7 +356,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess($"Restarted {serviceName}"); });
         }
 
-        [SlashCommand(Description = "Stop an automated service", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Stop an automated service", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task StopService(FauxCommand command, [SlashParam(AutocompleteHandler = typeof(ServiceNameAutoComplete))] string serviceName, IServiceProvider serviceProvider, JobService jobService) {
             await command.DeferAsync();
             var service = serviceProvider.GetServices<IHostedService>().FirstOrDefault(x => x.GetType().Name == serviceName);
@@ -414,7 +391,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess($"Stopped {serviceName}"); });
         }
 
-        [SlashCommand(Description = "Run automated service now", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Run automated service now", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task RunService(FauxCommand command, [SlashParam(AutocompleteHandler = typeof(ServiceNameAutoComplete))] string serviceName, IServiceProvider serviceProvider, JobService jobService) {
             await command.DeferAsync();
             var service = serviceProvider.GetServices<IHostedService>().FirstOrDefault(x => x.GetType().Name == serviceName);
@@ -449,7 +426,7 @@ namespace EGG9000.Bot.Commands {
             await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedSuccess($"Ran {serviceName}"); });
         }
 
-        [SlashCommand(Description = "Start an automated service", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Start an automated service", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task StartService(FauxCommand command, [SlashParam(AutocompleteHandler = typeof(ServiceNameAutoComplete))] string serviceName, IServiceProvider serviceProvider, JobService jobService) {
             await command.DeferAsync();
             var service = serviceProvider.GetServices<IHostedService>().FirstOrDefault(x => x.GetType().Name == serviceName);
@@ -496,7 +473,7 @@ namespace EGG9000.Bot.Commands {
             await command.Channel.SendMessageAsync($"{pings} {message}");
         }
 
-        [SlashCommand(Description = "Fix where the server doesn't show them as joined", AdminOnly = StaffOnlyLevel.FarmHand)]
+        [SlashCommand(Description = "Fix where the server doesn't show them as joined", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
         public static async Task FixJoinIssue(FauxCommand command, [SlashParam(AutocompleteHandler = typeof(UserAccountChannelSpecificAutoComplete))] string useraccount, ApplicationDbContext db) {
             await command.DeferAsync(ephemeral: true);
 
@@ -700,7 +677,7 @@ namespace EGG9000.Bot.Commands {
             return cb.Build();
         }
 
-        [SlashCommand(Description = "System load: runtime, Discord, DB, process (health-colored)", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "b")]
+        [SlashCommand(Description = "System load: runtime, Discord, DB, process (health-colored)", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "bot")]
         public static async Task SysLoad(FauxCommand command, ApplicationDbContext db, DiscordSocketClient client, IServiceProvider serviceProvider,
             [SlashParam(Required = false, Description = "Auto-refresh every N seconds (1-30, stops after 30s total)")] int refreshseconds = 0,
             [SlashParam(Required = false, Description = "Post visibly in the channel instead of only to you")] bool showinchannel = false) {
@@ -786,7 +763,7 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
-        [SlashCommand(Description = "One-look bot/DB/deploy/load status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "One-look bot/DB/deploy/load status", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task BotStatus(FauxCommand command, ApplicationDbContext db, IServiceProvider serviceProvider, CoopStatsCache stats) {
             await command.DeferAsync(ephemeral: true);
 
@@ -847,7 +824,7 @@ namespace EGG9000.Bot.Commands {
             await command.RespondAsync($"```\n{GetTable(rows)}```", ephemeral: true);
         }
 
-        [SlashCommand(Description = "Active Co-op Stats", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "a")]
+        [SlashCommand(Description = "Active Co-op Stats", AdminOnly = StaffOnlyLevel.FarmHand, ParentCommand = "bot")]
         public static async Task CoopStats(FauxCommand command, ApplicationDbContext db) {
             await command.DeferAsync();
             var coops = await db.Coops.Where(x => !x.Finished && x.Status != CoopStatusEnum.Failed && x.GuildId == command.GuildId && !x.DeletedChannel && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
@@ -890,7 +867,7 @@ namespace EGG9000.Bot.Commands {
             await command.RespondAsync($"{user.Mention} is disabled.");
         }
 
-        [SlashCommand(Description = "Re-enable user", AdminOnly = StaffOnlyLevel.Admin)]
+        [SlashCommand(Description = "Re-enable user", AdminOnly = StaffOnlyLevel.Admin, ParentCommand = "admin")]
         public static async Task Enable(FauxCommand command, ApplicationDbContext db, [SlashParam] SocketUser user) {
             var dbuser = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == user.Id);
             if(dbuser == null) {


### PR DESCRIPTION
Two new command groups: 
- `/admin`
- `/bot`

Commands moved to `/admin`:
- `/kick`
- `/b configure`
- `/makeprivate`
- `/deletecontract`
- `/adddemerit`
- `/removedemerit`
- `/demeritsforuser`
- `/nodemerit`
- `/b rankup`
- `/b editfaq`
- `/enable`

Commands moved to `/bot`: 
- `/b setversions`
- `/a restartservice`
- `/a startservice` 
- `/a stopservice`
- `/a runservice`
- `/a ping`
- `/a status`
- `/a botstatus`
- `/b sysload`
- `/a coopstats`

Commands moved into `/a`:
- `/addcoop`  (needs override to only allow FH+)
- `/addmerit`
-  `/removemerit` (needs override to only allow FH+)
- `/meritsforuser` (needs override to only allow FH+)
- `/renamecoop` (needs override to only allow  FH+)
- `/updatechannel` (needs override to only allow CC+)
- `/temprole`  (needs override to only allow CC+)
- `/selectroleusers` (needs override to only allow FH+)
- `/fixjoinissue` (needs override to only allow FH+)

Removed Duplicate temporary coop name command `/temporaryprefix` in favour of existing `/a tempcustomcoopname`

