### PR TITLE
Feat: add in leaderboard json output accessible only via an api key

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,5 @@
+Task 1: complete (working tree, no commits - entities + migration 20260703024523_AddApiKeyRequestLogging)
+Task 2: complete (working tree, no commits - handler write path, fixed test-helper bug in plan's literal test code, 204/204 tests pass)
+Task 3: complete (working tree, no commits - CleanApiKeyRequestLogs.cs, registered in BotHostFactory.cs not Program.cs per repo DI-extraction convention)
+Task 4: complete (working tree, no commits - usage summary + spike flag + InternalsVisibleTo fix, 209/209 tests pass)
+Task 5: complete (working tree, no commits - drill-down action + view)

--- a/EGG9000.Bot/Automated/CleanApiKeyRequestLogs.cs
+++ b/EGG9000.Bot/Automated/CleanApiKeyRequestLogs.cs
@@ -1,0 +1,24 @@
+using EGG9000.Common.Database;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EGG9000.Bot.Automated {
+    public class CleanApiKeyRequestLogs(IServiceProvider provider) : _UpdaterBase<CleanApiKeyRequestLogs>(TimeSpan.FromHours(12), TimeSpan.FromMinutes(5), provider) {
+        public async override Task Run(object state, CancellationToken cancellationToken) {
+            var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var logCutoff = DateTimeOffset.UtcNow.AddDays(-7);
+            var deletedLogs = await _db.ApiKeyRequestLogs.Where(x => x.Timestamp < logCutoff).ExecuteDeleteAsync(cancellationToken);
+
+            var usageCutoff = DateTimeOffset.UtcNow.AddDays(-90).UtcDateTime.Date;
+            var deletedUsage = await _db.ApiKeyDailyUsages.Where(x => x.Date < usageCutoff).ExecuteDeleteAsync(cancellationToken);
+
+            _logger.LogInformation("Deleted {logCount} ApiKeyRequestLogs older than {logCutoff} and {usageCount} ApiKeyDailyUsages older than {usageCutoff}", deletedLogs, logCutoff, deletedUsage, usageCutoff);
+        }
+    }
+}

--- a/EGG9000.Bot/BotHostFactory.cs
+++ b/EGG9000.Bot/BotHostFactory.cs
@@ -198,6 +198,7 @@ public static class BotHostFactory {
             services.AddHostedService<RefreshNasaApod>();
             services.AddHostedService<UpdateBackups>();
             services.AddHostedService<CleanAutomationLogs>();
+            services.AddHostedService<CleanApiKeyRequestLogs>();
             services.AddHostedService<RankupMessageSeeder>();
 
             services.AddSingleton<CoopsBeingCreatedService>();

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -292,6 +292,7 @@ namespace EGG9000.Common.Database {
             builder.Entity<NasaApod>().HasKey(x => x.ID);
             builder.Entity<NasaApod>().Property(x => x.DateString).HasDefaultValueSql("TO_CHAR(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD')");
 
+            builder.Entity<ApiKey>().HasIndex(x => x.KeyHash);
             builder.Entity<DBUser>().HasIndex(x => x.DiscordId);
             builder.Entity<UserCoopXref>().HasIndex(x => new { x.CreatedOn, x.JoinedCoop });
             builder.Entity<Guild>().HasIndex(x => x.DiscordSeverId);

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -133,6 +133,7 @@ namespace EGG9000.Common.Database {
         public DbSet<NasaApod> NasaApods { get; set; }
         public DbSet<SeasonInfo> SeasonInfos { get; set; }
         public DbSet<UserSeasonProgress> UserSeasonProgresses { get; set; }
+        public DbSet<ApiKey> ApiKeys { get; set; }
 
         public FrozenSet<Guild> CachedGuilds {
             get {

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -292,7 +292,7 @@ namespace EGG9000.Common.Database {
             builder.Entity<NasaApod>().HasKey(x => x.ID);
             builder.Entity<NasaApod>().Property(x => x.DateString).HasDefaultValueSql("TO_CHAR(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD')");
 
-            builder.Entity<ApiKey>().HasIndex(x => x.KeyHash);
+            builder.Entity<ApiKey>().HasIndex(x => x.KeyHash).IsUnique();
             builder.Entity<DBUser>().HasIndex(x => x.DiscordId);
             builder.Entity<UserCoopXref>().HasIndex(x => new { x.CreatedOn, x.JoinedCoop });
             builder.Entity<Guild>().HasIndex(x => x.DiscordSeverId);

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -134,6 +134,8 @@ namespace EGG9000.Common.Database {
         public DbSet<SeasonInfo> SeasonInfos { get; set; }
         public DbSet<UserSeasonProgress> UserSeasonProgresses { get; set; }
         public DbSet<ApiKey> ApiKeys { get; set; }
+        public DbSet<ApiKeyRequestLog> ApiKeyRequestLogs { get; set; }
+        public DbSet<ApiKeyDailyUsage> ApiKeyDailyUsages { get; set; }
 
         public FrozenSet<Guild> CachedGuilds {
             get {
@@ -293,6 +295,8 @@ namespace EGG9000.Common.Database {
             builder.Entity<NasaApod>().Property(x => x.DateString).HasDefaultValueSql("TO_CHAR(NOW() AT TIME ZONE 'UTC', 'YYYY-MM-DD')");
 
             builder.Entity<ApiKey>().HasIndex(x => x.KeyHash).IsUnique();
+            builder.Entity<ApiKeyRequestLog>().HasIndex(x => new { x.ApiKeyId, x.Timestamp });
+            builder.Entity<ApiKeyDailyUsage>().HasKey(x => new { x.ApiKeyId, x.Date });
             builder.Entity<DBUser>().HasIndex(x => x.DiscordId);
             builder.Entity<UserCoopXref>().HasIndex(x => new { x.CreatedOn, x.JoinedCoop });
             builder.Entity<Guild>().HasIndex(x => x.DiscordSeverId);

--- a/EGG9000.Common/Database/Entities/ApiKey.cs
+++ b/EGG9000.Common/Database/Entities/ApiKey.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace EGG9000.Common.Database.Entities {
+    public class ApiKey {
+        public Guid Id { get; set; }
+
+        // SHA-256 hex of the raw key (64 lowercase hex chars). Never store the raw key.
+        [Required, MaxLength(64)]
+        public string KeyHash { get; set; }
+
+        // Human-readable label set by the admin who created the key.
+        [Required, MaxLength(100)]
+        public string Label { get; set; }
+
+        public ulong GuildId { get; set; }
+
+        public DateTimeOffset CreatedAt { get; set; }
+
+        // Null = never expires.
+        public DateTimeOffset? ExpiresAt { get; set; }
+
+        public bool Revoked { get; set; }
+    }
+}

--- a/EGG9000.Common/Database/Entities/ApiKeyDailyUsage.cs
+++ b/EGG9000.Common/Database/Entities/ApiKeyDailyUsage.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace EGG9000.Common.Database.Entities {
+    public class ApiKeyDailyUsage {
+        public Guid ApiKeyId { get; set; }
+
+        // Calendar day (UTC), time component always midnight - matches UserSnapShot.Date convention.
+        public DateTime Date { get; set; }
+
+        public int RequestCount { get; set; }
+    }
+}

--- a/EGG9000.Common/Database/Entities/ApiKeyRequestLog.cs
+++ b/EGG9000.Common/Database/Entities/ApiKeyRequestLog.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace EGG9000.Common.Database.Entities {
+    public class ApiKeyRequestLog {
+        public Guid Id { get; set; }
+
+        // Null when the header's hash matched no stored key (brute-force / garbage key attempt).
+        public Guid? ApiKeyId { get; set; }
+
+        // Null whenever ApiKeyId is null - the guild isn't known until a key resolves.
+        public ulong? GuildId { get; set; }
+
+        public string IpAddress { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+        public bool Success { get; set; }
+    }
+}

--- a/EGG9000.Common/Database/Entities/ApiKeyRequestLog.cs
+++ b/EGG9000.Common/Database/Entities/ApiKeyRequestLog.cs
@@ -12,6 +12,9 @@ namespace EGG9000.Common.Database.Entities {
 
         public string IpAddress { get; set; }
 
+        // HTTP method + path, e.g. "GET /LeaderboardJson". Null for pre-existing rows before this column was added.
+        public string Endpoint { get; set; }
+
         public DateTimeOffset Timestamp { get; set; }
 
         public bool Success { get; set; }

--- a/EGG9000.Common/Migrations/20260630124403_AddApiKeys.Designer.cs
+++ b/EGG9000.Common/Migrations/20260630124403_AddApiKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630124403_AddApiKeys")]
+    partial class AddApiKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -51,9 +54,6 @@ namespace EGG9000.Common.Migrations
                         .HasColumnType("boolean");
 
                     b.HasKey("Id");
-
-                    b.HasIndex("KeyHash")
-                        .HasDatabaseName("IX_ApiKeys_KeyHash");
 
                     b.ToTable("ApiKeys");
                 });

--- a/EGG9000.Common/Migrations/20260630124403_AddApiKeys.Designer.cs
+++ b/EGG9000.Common/Migrations/20260630124403_AddApiKeys.Designer.cs
@@ -55,6 +55,10 @@ namespace EGG9000.Common.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("KeyHash")
+                        .IsUnique()
+                        .HasDatabaseName("IX_ApiKeys_KeyHash");
+
                     b.ToTable("ApiKeys");
                 });
 

--- a/EGG9000.Common/Migrations/20260630124403_AddApiKeys.cs
+++ b/EGG9000.Common/Migrations/20260630124403_AddApiKeys.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApiKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiKeys",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    KeyHash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    Label = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    GuildId = table.Column<decimal>(type: "numeric(20,0)", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Revoked = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeys", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeys_KeyHash",
+                table: "ApiKeys",
+                column: "KeyHash");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_ApiKeys_KeyHash",
+                table: "ApiKeys");
+
+            migrationBuilder.DropTable(
+                name: "ApiKeys");
+        }
+    }
+}

--- a/EGG9000.Common/Migrations/20260630124403_AddApiKeys.cs
+++ b/EGG9000.Common/Migrations/20260630124403_AddApiKeys.cs
@@ -31,7 +31,8 @@ namespace EGG9000.Common.Migrations
             migrationBuilder.CreateIndex(
                 name: "IX_ApiKeys_KeyHash",
                 table: "ApiKeys",
-                column: "KeyHash");
+                column: "KeyHash",
+                unique: true);
         }
 
         /// <inheritdoc />

--- a/EGG9000.Common/Migrations/20260703024523_AddApiKeyRequestLogging.Designer.cs
+++ b/EGG9000.Common/Migrations/20260703024523_AddApiKeyRequestLogging.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703024523_AddApiKeyRequestLogging")]
+    partial class AddApiKeyRequestLogging
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EGG9000.Common/Migrations/20260703024523_AddApiKeyRequestLogging.cs
+++ b/EGG9000.Common/Migrations/20260703024523_AddApiKeyRequestLogging.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApiKeyRequestLogging : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiKeyDailyUsages",
+                columns: table => new
+                {
+                    ApiKeyId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RequestCount = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeyDailyUsages", x => new { x.ApiKeyId, x.Date });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ApiKeyRequestLogs",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ApiKeyId = table.Column<Guid>(type: "uuid", nullable: true),
+                    GuildId = table.Column<decimal>(type: "numeric(20,0)", nullable: true),
+                    IpAddress = table.Column<string>(type: "text", nullable: true),
+                    Timestamp = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Success = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeyRequestLogs", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeyRequestLogs_ApiKeyId_Timestamp",
+                table: "ApiKeyRequestLogs",
+                columns: new[] { "ApiKeyId", "Timestamp" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApiKeyDailyUsages");
+
+            migrationBuilder.DropTable(
+                name: "ApiKeyRequestLogs");
+        }
+    }
+}

--- a/EGG9000.Common/Migrations/20260703135104_AddApiKeyRequestLogEndpoint.Designer.cs
+++ b/EGG9000.Common/Migrations/20260703135104_AddApiKeyRequestLogEndpoint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260703135104_AddApiKeyRequestLogEndpoint")]
+    partial class AddApiKeyRequestLogEndpoint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EGG9000.Common/Migrations/20260703135104_AddApiKeyRequestLogEndpoint.cs
+++ b/EGG9000.Common/Migrations/20260703135104_AddApiKeyRequestLogEndpoint.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApiKeyRequestLogEndpoint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Endpoint",
+                table: "ApiKeyRequestLogs",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Endpoint",
+                table: "ApiKeyRequestLogs");
+        }
+    }
+}

--- a/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/EGG9000.Common/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -53,6 +53,7 @@ namespace EGG9000.Common.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("KeyHash")
+                        .IsUnique()
                         .HasDatabaseName("IX_ApiKeys_KeyHash");
 
                     b.ToTable("ApiKeys");

--- a/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
+++ b/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,49 @@
+using EGG9000.Common.Database;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace EGG9000.Site.Auth {
+    public class ApiKeyAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IDbContextFactory<ApplicationDbContext> dbFactory)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder) {
+
+        public const string SchemeName = "ApiKey";
+        public const string HeaderName = "X-Api-Key";
+
+        protected override async Task<AuthenticateResult> HandleAuthenticateAsync() {
+            if (!Request.Headers.TryGetValue(HeaderName, out var rawKeyValues) || rawKeyValues.Count == 0)
+                return AuthenticateResult.NoResult();
+
+            var rawKey = rawKeyValues[0]!.Trim();
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey))).ToLowerInvariant();
+
+            await using var db = dbFactory.CreateDbContext();
+            var key = await db.ApiKeys.FirstOrDefaultAsync(k =>
+                k.KeyHash == hash &&
+                !k.Revoked &&
+                (k.ExpiresAt == null || k.ExpiresAt > DateTimeOffset.UtcNow));
+
+            if (key == null)
+                return AuthenticateResult.Fail("Invalid or expired API key.");
+
+            var claims = new[] {
+                new Claim("GuildId", key.GuildId.ToString()),
+                new Claim("ApiKeyId", key.Id.ToString())
+            };
+            var identity = new ClaimsIdentity(claims, SchemeName);
+            var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
+            return AuthenticateResult.Success(ticket);
+        }
+    }
+}

--- a/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
+++ b/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
@@ -29,6 +29,7 @@ namespace EGG9000.Site.Auth {
             var rawKey = rawKeyValues[0]!.Trim();
             var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey))).ToLowerInvariant();
             var ipAddress = Context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var endpoint = $"{Request.Method} {Request.Path}";
 
             await using var db = dbFactory.CreateDbContext();
             var key = await db.ApiKeys.FirstOrDefaultAsync(k => k.KeyHash == hash);
@@ -36,7 +37,7 @@ namespace EGG9000.Site.Auth {
             var valid = key != null && !key.Revoked && (key.ExpiresAt == null || key.ExpiresAt > DateTimeOffset.UtcNow);
 
             try {
-                await LogRequestAsync(db, key, ipAddress, valid);
+                await LogRequestAsync(db, key, ipAddress, endpoint, valid);
             } catch (Exception ex) {
                 Logger.LogError(ex, "Failed to write API key request log/usage for key {ApiKeyId}.", key?.Id);
             }
@@ -53,7 +54,7 @@ namespace EGG9000.Site.Auth {
             return AuthenticateResult.Success(ticket);
         }
 
-        private static async Task LogRequestAsync(ApplicationDbContext db, ApiKey key, string ipAddress, bool success) {
+        private static async Task LogRequestAsync(ApplicationDbContext db, ApiKey key, string ipAddress, string endpoint, bool success) {
             var now = DateTimeOffset.UtcNow;
 
             db.ApiKeyRequestLogs.Add(new ApiKeyRequestLog {
@@ -61,6 +62,7 @@ namespace EGG9000.Site.Auth {
                 ApiKeyId = key?.Id,
                 GuildId = key?.GuildId,
                 IpAddress = ipAddress,
+                Endpoint = endpoint,
                 Timestamp = now,
                 Success = success
             });

--- a/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
+++ b/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
@@ -35,7 +35,11 @@ namespace EGG9000.Site.Auth {
 
             var valid = key != null && !key.Revoked && (key.ExpiresAt == null || key.ExpiresAt > DateTimeOffset.UtcNow);
 
-            await LogRequestAsync(db, key, ipAddress, valid);
+            try {
+                await LogRequestAsync(db, key, ipAddress, valid);
+            } catch (Exception ex) {
+                Logger.LogError(ex, "Failed to write API key request log/usage for key {ApiKeyId}.", key?.Id);
+            }
 
             if (!valid)
                 return AuthenticateResult.Fail("Invalid or expired API key.");
@@ -61,16 +65,28 @@ namespace EGG9000.Site.Auth {
                 Success = success
             });
 
-            if (key != null) {
-                var today = now.UtcDateTime.Date;
-                var usage = await db.ApiKeyDailyUsages.FirstOrDefaultAsync(u => u.ApiKeyId == key.Id && u.Date == today);
-                if (usage == null) {
-                    db.ApiKeyDailyUsages.Add(new ApiKeyDailyUsage { ApiKeyId = key.Id, Date = today, RequestCount = 1 });
-                } else {
-                    usage.RequestCount++;
-                }
+            await db.SaveChangesAsync();
+
+            if (key != null)
+                await IncrementDailyUsageAsync(db, key.Id, now.UtcDateTime.Date);
+        }
+
+        private static async Task IncrementDailyUsageAsync(ApplicationDbContext db, Guid apiKeyId, DateTime today) {
+            if (db.Database.IsNpgsql()) {
+                await db.Database.ExecuteSqlInterpolatedAsync($"""
+                    INSERT INTO "ApiKeyDailyUsages" ("ApiKeyId", "Date", "RequestCount")
+                    VALUES ({apiKeyId}, {today}, 1)
+                    ON CONFLICT ("ApiKeyId", "Date") DO UPDATE SET "RequestCount" = "ApiKeyDailyUsages"."RequestCount" + 1
+                    """);
+                return;
             }
 
+            var usage = await db.ApiKeyDailyUsages.FirstOrDefaultAsync(u => u.ApiKeyId == apiKeyId && u.Date == today);
+            if (usage == null) {
+                db.ApiKeyDailyUsages.Add(new ApiKeyDailyUsage { ApiKeyId = apiKeyId, Date = today, RequestCount = 1 });
+            } else {
+                usage.RequestCount++;
+            }
             await db.SaveChangesAsync();
         }
     }

--- a/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
+++ b/EGG9000.Site/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,4 +1,5 @@
 using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -27,14 +28,16 @@ namespace EGG9000.Site.Auth {
 
             var rawKey = rawKeyValues[0]!.Trim();
             var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey))).ToLowerInvariant();
+            var ipAddress = Context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
 
             await using var db = dbFactory.CreateDbContext();
-            var key = await db.ApiKeys.FirstOrDefaultAsync(k =>
-                k.KeyHash == hash &&
-                !k.Revoked &&
-                (k.ExpiresAt == null || k.ExpiresAt > DateTimeOffset.UtcNow));
+            var key = await db.ApiKeys.FirstOrDefaultAsync(k => k.KeyHash == hash);
 
-            if (key == null)
+            var valid = key != null && !key.Revoked && (key.ExpiresAt == null || key.ExpiresAt > DateTimeOffset.UtcNow);
+
+            await LogRequestAsync(db, key, ipAddress, valid);
+
+            if (!valid)
                 return AuthenticateResult.Fail("Invalid or expired API key.");
 
             var claims = new[] {
@@ -44,6 +47,31 @@ namespace EGG9000.Site.Auth {
             var identity = new ClaimsIdentity(claims, SchemeName);
             var ticket = new AuthenticationTicket(new ClaimsPrincipal(identity), SchemeName);
             return AuthenticateResult.Success(ticket);
+        }
+
+        private static async Task LogRequestAsync(ApplicationDbContext db, ApiKey key, string ipAddress, bool success) {
+            var now = DateTimeOffset.UtcNow;
+
+            db.ApiKeyRequestLogs.Add(new ApiKeyRequestLog {
+                Id = Guid.NewGuid(),
+                ApiKeyId = key?.Id,
+                GuildId = key?.GuildId,
+                IpAddress = ipAddress,
+                Timestamp = now,
+                Success = success
+            });
+
+            if (key != null) {
+                var today = now.UtcDateTime.Date;
+                var usage = await db.ApiKeyDailyUsages.FirstOrDefaultAsync(u => u.ApiKeyId == key.Id && u.Date == today);
+                if (usage == null) {
+                    db.ApiKeyDailyUsages.Add(new ApiKeyDailyUsage { ApiKeyId = key.Id, Date = today, RequestCount = 1 });
+                } else {
+                    usage.RequestCount++;
+                }
+            }
+
+            await db.SaveChangesAsync();
         }
     }
 }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -29,9 +29,11 @@ using Newtonsoft.Json;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -1500,6 +1502,66 @@ music
             }
 
             return View(creators);
+        }
+
+        public class ApiKeysViewModel {
+            public List<ApiKey> Keys { get; set; }
+            // Non-null only immediately after creation — shown once to the admin, never stored.
+            public string NewRawKey { get; set; }
+        }
+
+        [Authorize(Roles = "Admin,GuildAdmin")]
+        public async Task<IActionResult> ApiKeys() {
+            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+            var keys = await _db.ApiKeys
+                .Where(k => k.GuildId == guildId)
+                .OrderByDescending(k => k.CreatedAt)
+                .ToListAsync();
+            var newKey = TempData["NewApiKey"] as string;
+            return View(new ApiKeysViewModel { Keys = keys, NewRawKey = newKey });
+        }
+
+        [Authorize(Roles = "Admin,GuildAdmin")]
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreateApiKey([FromForm] string label, [FromForm] string expiresAt) {
+            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+
+            // Generate a cryptographically random 32-byte key, prefix with "egg_".
+            var rawBytes = RandomNumberGenerator.GetBytes(32);
+            var rawKey = "egg_" + Convert.ToBase64String(rawBytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+            var hash = Convert.ToHexString(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(rawKey))).ToLowerInvariant();
+
+            DateTimeOffset? expires = null;
+            if(!string.IsNullOrWhiteSpace(expiresAt) && DateTimeOffset.TryParse(expiresAt, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var parsedExpiry))
+                expires = parsedExpiry;
+
+            _db.ApiKeys.Add(new ApiKey {
+                Id = Guid.NewGuid(),
+                KeyHash = hash,
+                Label = label?.Trim() ?? "Unnamed",
+                GuildId = guildId,
+                CreatedAt = DateTimeOffset.UtcNow,
+                ExpiresAt = expires,
+                Revoked = false
+            });
+            await _db.SaveChangesAsync();
+
+            // Pass raw key via TempData so it is shown once without appearing in the URL.
+            TempData["NewApiKey"] = rawKey;
+            return RedirectToAction("ApiKeys");
+        }
+
+        [Authorize(Roles = "Admin,GuildAdmin")]
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> RevokeApiKey([FromQuery] Guid id) {
+            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+            var key = await _db.ApiKeys.FirstOrDefaultAsync(k => k.Id == id && k.GuildId == guildId);
+            if(key == null) return NotFound();
+            key.Revoked = true;
+            await _db.SaveChangesAsync();
+            return RedirectToAction("ApiKeys");
         }
     }
 }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -1513,27 +1513,30 @@ music
         }
 
         public class ApiKeysViewModel {
+            public ulong GuildId { get; set; }
             public List<ApiKey> Keys { get; set; }
-            // Non-null only immediately after creation — shown once to the admin, never stored.
+            // Non-null only immediately after creation - shown once to the admin, never stored.
             public string NewRawKey { get; set; }
         }
 
         [Authorize(Roles = "Admin,GuildAdmin")]
-        public async Task<IActionResult> ApiKeys() {
-            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+        public async Task<IActionResult> ApiKeys(ulong? id) {
+            var guildId = id ?? GetGuildID();
+            if(!VerifyId(guildId)) return NotFound();
             var keys = await _db.ApiKeys
                 .Where(k => k.GuildId == guildId)
                 .OrderByDescending(k => k.CreatedAt)
                 .ToListAsync();
             var newKey = TempData["NewApiKey"] as string;
-            return View(new ApiKeysViewModel { Keys = keys, NewRawKey = newKey });
+            return View(new ApiKeysViewModel { GuildId = guildId, Keys = keys, NewRawKey = newKey });
         }
 
         [Authorize(Roles = "Admin,GuildAdmin")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> CreateApiKey([FromForm] string label, [FromForm] string expiresAt) {
-            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+        public async Task<IActionResult> CreateApiKey([FromForm] ulong? id, [FromForm] string label, [FromForm] string expiresAt) {
+            var guildId = id ?? GetGuildID();
+            if(!VerifyId(guildId)) return NotFound();
 
             // Generate a cryptographically random 32-byte key, prefix with "egg_".
             var rawBytes = RandomNumberGenerator.GetBytes(32);
@@ -1557,19 +1560,20 @@ music
 
             // Pass raw key via TempData so it is shown once without appearing in the URL.
             TempData["NewApiKey"] = rawKey;
-            return RedirectToAction("ApiKeys");
+            return RedirectToAction("ApiKeys", new { id = guildId });
         }
 
         [Authorize(Roles = "Admin,GuildAdmin")]
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> RevokeApiKey([FromQuery] Guid id) {
-            var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
-            var key = await _db.ApiKeys.FirstOrDefaultAsync(k => k.Id == id && k.GuildId == guildId);
+        public async Task<IActionResult> RevokeApiKey([FromQuery] Guid id, [FromQuery] ulong? guildId) {
+            var resolvedGuildId = guildId ?? GetGuildID();
+            if(!VerifyId(resolvedGuildId)) return NotFound();
+            var key = await _db.ApiKeys.FirstOrDefaultAsync(k => k.Id == id && k.GuildId == resolvedGuildId);
             if(key == null) return NotFound();
             key.Revoked = true;
             await _db.SaveChangesAsync();
-            return RedirectToAction("ApiKeys");
+            return RedirectToAction("ApiKeys", new { id = resolvedGuildId });
         }
     }
 }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -1512,23 +1512,79 @@ music
             return View(creators);
         }
 
+        public class ApiKeyUsageSummary {
+            public int RequestsToday { get; set; }
+            public int RequestsLast7Days { get; set; }
+            public int UniqueIps7Days { get; set; }
+            public bool IsSpike { get; set; }
+        }
+
         public class ApiKeysViewModel {
             public ulong GuildId { get; set; }
             public List<ApiKey> Keys { get; set; }
+            public Dictionary<Guid, ApiKeyUsageSummary> KeyUsage { get; set; }
             // Non-null only immediately after creation - shown once to the admin, never stored.
             public string NewRawKey { get; set; }
+            public int UnrecognizedAttempts7Days { get; set; }
+        }
+
+        // Baseline floor prevents a near-zero-traffic key from flagging as a spike off a tiny denominator
+        // (e.g. baseline 2 -> today 10 is technically 5x but not meaningfully abusive).
+        internal static bool ComputeIsSpike(int todayCount, double baselineAverage) {
+            var effectiveBaseline = Math.Max(baselineAverage, 50);
+            return todayCount > effectiveBaseline * 5;
         }
 
         [Authorize(Roles = "Admin,GuildAdmin")]
         public async Task<IActionResult> ApiKeys(ulong? id) {
             var guildId = id ?? GetGuildID();
             if(!VerifyId(guildId)) return NotFound();
+
             var keys = await _db.ApiKeys
                 .Where(k => k.GuildId == guildId)
                 .OrderByDescending(k => k.CreatedAt)
                 .ToListAsync();
+
+            var keyIds = keys.Select(k => k.Id).ToList();
+            var sevenDaysAgo = DateTimeOffset.UtcNow.AddDays(-7);
+            var today = DateTime.UtcNow.Date;
+
+            var recentLogs = await _db.ApiKeyRequestLogs
+                .Where(l => l.ApiKeyId != null && keyIds.Contains(l.ApiKeyId.Value) && l.Timestamp >= sevenDaysAgo)
+                .ToListAsync();
+
+            var recentUsage = await _db.ApiKeyDailyUsages
+                .Where(u => keyIds.Contains(u.ApiKeyId) && u.Date >= today.AddDays(-7))
+                .ToListAsync();
+
+            var keyUsage = new Dictionary<Guid, ApiKeyUsageSummary>();
+            foreach(var key in keys) {
+                var keyLogs = recentLogs.Where(l => l.ApiKeyId == key.Id).ToList();
+                var keyUsageRows = recentUsage.Where(u => u.ApiKeyId == key.Id).ToList();
+                var todayCount = keyUsageRows.FirstOrDefault(u => u.Date == today)?.RequestCount ?? 0;
+                var baselineRows = keyUsageRows.Where(u => u.Date < today).ToList();
+                var baselineAverage = baselineRows.Count > 0 ? baselineRows.Average(u => u.RequestCount) : 0;
+
+                keyUsage[key.Id] = new ApiKeyUsageSummary {
+                    RequestsToday = todayCount,
+                    RequestsLast7Days = keyLogs.Count,
+                    UniqueIps7Days = keyLogs.Select(l => l.IpAddress).Distinct().Count(),
+                    IsSpike = ComputeIsSpike(todayCount, baselineAverage)
+                };
+            }
+
+            var unrecognizedAttempts = User.IsInRole("Admin")
+                ? await _db.ApiKeyRequestLogs.CountAsync(l => l.ApiKeyId == null && l.Timestamp >= sevenDaysAgo)
+                : 0;
+
             var newKey = TempData["NewApiKey"] as string;
-            return View(new ApiKeysViewModel { GuildId = guildId, Keys = keys, NewRawKey = newKey });
+            return View(new ApiKeysViewModel {
+                GuildId = guildId,
+                Keys = keys,
+                KeyUsage = keyUsage,
+                NewRawKey = newKey,
+                UnrecognizedAttempts7Days = unrecognizedAttempts
+            });
         }
 
         [Authorize(Roles = "Admin,GuildAdmin")]
@@ -1574,6 +1630,29 @@ music
             key.Revoked = true;
             await _db.SaveChangesAsync();
             return RedirectToAction("ApiKeys", new { id = resolvedGuildId });
+        }
+
+        public class ApiKeyRequestLogViewModel {
+            public string KeyLabel { get; set; }
+            public List<ApiKeyRequestLog> Entries { get; set; }
+        }
+
+        [Authorize(Roles = "Admin,GuildAdmin")]
+        public async Task<IActionResult> ApiKeyRequestLog(Guid apiKeyId, ulong? guildId) {
+            var resolvedGuildId = guildId ?? GetGuildID();
+            if(!VerifyId(resolvedGuildId)) return NotFound();
+
+            var key = await _db.ApiKeys.FirstOrDefaultAsync(k => k.Id == apiKeyId && k.GuildId == resolvedGuildId);
+            if(key == null) return NotFound();
+
+            var sevenDaysAgo = DateTimeOffset.UtcNow.AddDays(-7);
+            var entries = await _db.ApiKeyRequestLogs
+                .Where(l => l.ApiKeyId == apiKeyId && l.Timestamp >= sevenDaysAgo)
+                .OrderByDescending(l => l.Timestamp)
+                .Take(500)
+                .ToListAsync();
+
+            return View(new ApiKeyRequestLogViewModel { KeyLabel = key.Label, Entries = entries });
         }
     }
 }

--- a/EGG9000.Site/Controllers/HomeController.cs
+++ b/EGG9000.Site/Controllers/HomeController.cs
@@ -10,6 +10,7 @@ using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Factories;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
+using EGG9000.Site.Auth;
 using EGG9000.Site.Models;
 using EGG9000.Site.Services;
 
@@ -563,6 +564,40 @@ namespace EGG9000.Site.Controllers {
             public double SoulEggs { get; set; }
             public ushort EggsOfProphecy { get; set; }
             public bool ProPermit { get; set; }
+        }
+
+        public class LeaderboardApiItem {
+            public string DiscordName { get; set; }
+            public ulong DiscordId { get; set; }
+            public string EggIncName { get; set; }
+            public double EarningsBonus { get; set; }
+            public double SoulEggs { get; set; }
+            public ushort EggsOfProphecy { get; set; }
+            public double MER { get; set; }
+            public uint EggsOfTruth { get; set; }
+            public ulong NumPrestiges { get; set; }
+        }
+
+        [Authorize(AuthenticationSchemes = ApiKeyAuthenticationHandler.SchemeName)]
+        [HttpGet]
+        public async Task<IActionResult> LeaderboardJson() {
+            var guildId = ulong.Parse(User.Claims.First(x => x.Type == "GuildId").Value);
+            var guild = _discord.Guilds.FirstOrDefault(x => x.Id == guildId);
+            if (guild == null) return StatusCode(503);
+            await guild.DownloadUsersAsync();
+            var leaderboard = await _getLeaderboard(guildId);
+            var result = leaderboard.Select(x => new LeaderboardApiItem {
+                DiscordName = x.DisplayName,
+                DiscordId = x.DisplayDiscordId,
+                EggIncName = x.Backup.UserName,
+                EarningsBonus = x.Backup.EarningsBonus,
+                SoulEggs = x.Backup.SoulEggs,
+                EggsOfProphecy = x.Backup.EggsOfProphecy,
+                MER = x.Backup.MER,
+                EggsOfTruth = x.Backup.EggsOfTruth,
+                NumPrestiges = x.Backup.NumPrestiges
+            }).ToList();
+            return Json(result);
         }
 
         [Authorize]

--- a/EGG9000.Site/EGG9000.Site.csproj
+++ b/EGG9000.Site/EGG9000.Site.csproj
@@ -81,6 +81,9 @@
     <ProjectReference Include="..\EGG9000.Common\EGG9000.Common.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="EGG9000.Test" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Update="Views\Admin\StandardPermit.cshtml">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -8,11 +8,13 @@ using EGG9000.Common.Database;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.Mocks;
 using EGG9000.Common.Services;
+using EGG9000.Site.Auth;
 using EGG9000.Site.Data;
 using EGG9000.Site.Services;
 
 using MassTransit;
 
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -221,7 +223,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
         options.LoginPath = $"/Identity/Account/Login";
         options.LogoutPath = $"/Identity/Account/Logout";
         options.AccessDeniedPath = $"/Identity/Account/AccessDenied";
-    });
+    }).AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
+        ApiKeyAuthenticationHandler.SchemeName, null);
 
 
 

--- a/EGG9000.Site/Views/Admin/ApiKeyRequestLog.cshtml
+++ b/EGG9000.Site/Views/Admin/ApiKeyRequestLog.cshtml
@@ -1,0 +1,38 @@
+@model EGG9000.Site.Controllers.AdminController.ApiKeyRequestLogViewModel
+@{
+    ViewData["Title"] = "API Key Request Log";
+}
+
+<h2>Request log: @Model.KeyLabel</h2>
+<p>Last 7 days, most recent 500 requests.</p>
+
+@if (!Model.Entries.Any()) {
+    <p>No requests logged in this window.</p>
+} else {
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Timestamp (UTC)</th>
+                <th>IP address</th>
+                <th>Result</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var entry in Model.Entries) {
+                <tr>
+                    <td>@entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                    <td>@entry.IpAddress</td>
+                    <td>
+                        @if (entry.Success) {
+                            <span class="badge bg-success">Success</span>
+                        } else {
+                            <span class="badge bg-danger">Failed</span>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<a href="/Admin/ApiKeys" class="btn btn-secondary">Back to API Keys</a>

--- a/EGG9000.Site/Views/Admin/ApiKeyRequestLog.cshtml
+++ b/EGG9000.Site/Views/Admin/ApiKeyRequestLog.cshtml
@@ -13,6 +13,7 @@
         <thead>
             <tr>
                 <th>Timestamp (UTC)</th>
+                <th>Endpoint</th>
                 <th>IP address</th>
                 <th>Result</th>
             </tr>
@@ -21,6 +22,7 @@
             @foreach (var entry in Model.Entries) {
                 <tr>
                     <td>@entry.Timestamp.ToString("yyyy-MM-dd HH:mm:ss")</td>
+                    <td>@entry.Endpoint</td>
                     <td>@entry.IpAddress</td>
                     <td>
                         @if (entry.Success) {

--- a/EGG9000.Site/Views/Admin/ApiKeys.cshtml
+++ b/EGG9000.Site/Views/Admin/ApiKeys.cshtml
@@ -1,0 +1,74 @@
+@model EGG9000.Site.Controllers.AdminController.ApiKeysViewModel
+@{
+    ViewData["Title"] = "API Keys";
+}
+
+<h2>API Keys</h2>
+<p>API keys let external tools fetch leaderboard data as JSON. Each key is guild-scoped and read-only. The raw key is shown <strong>once</strong> when created — copy it immediately.</p>
+
+@if (Model.NewRawKey != null) {
+    <div class="alert alert-success" role="alert">
+        <strong>New key created.</strong> Copy it now — it will not be shown again.<br />
+        <code>@Model.NewRawKey</code>
+    </div>
+}
+
+<h4>Existing Keys</h4>
+@if (!Model.Keys.Any()) {
+    <p>No keys yet.</p>
+} else {
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Label</th>
+                <th>Created</th>
+                <th>Expires</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var key in Model.Keys) {
+                <tr>
+                    <td>@key.Label</td>
+                    <td>@key.CreatedAt.ToString("yyyy-MM-dd HH:mm") UTC</td>
+                    <td>@(key.ExpiresAt.HasValue ? key.ExpiresAt.Value.ToString("yyyy-MM-dd") : "Never")</td>
+                    <td>
+                        @if (key.Revoked) {
+                            <span class="badge bg-danger">Revoked</span>
+                        } else if (key.ExpiresAt.HasValue && key.ExpiresAt < DateTimeOffset.UtcNow) {
+                            <span class="badge bg-warning text-dark">Expired</span>
+                        } else {
+                            <span class="badge bg-success">Active</span>
+                        }
+                    </td>
+                    <td>
+                        @if (!key.Revoked) {
+                            <form method="post" action="/Admin/RevokeApiKey?id=@key.Id" style="display:inline">
+                                @Html.AntiForgeryToken()
+                                <button type="submit" class="btn btn-sm btn-danger"
+                                        onclick="return confirm('Revoke key &quot;@key.Label&quot;? This cannot be undone.')">
+                                    Revoke
+                                </button>
+                            </form>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+}
+
+<h4>Create New Key</h4>
+<form method="post" action="/Admin/CreateApiKey">
+    @Html.AntiForgeryToken()
+    <div class="mb-3">
+        <label for="label" class="form-label">Label</label>
+        <input type="text" class="form-control" id="label" name="label" required maxlength="100" placeholder="e.g. Stats Dashboard" />
+    </div>
+    <div class="mb-3">
+        <label for="expiresAt" class="form-label">Expiry date (optional)</label>
+        <input type="date" class="form-control" id="expiresAt" name="expiresAt" />
+    </div>
+    <button type="submit" class="btn btn-primary">Generate Key</button>
+</form>

--- a/EGG9000.Site/Views/Admin/ApiKeys.cshtml
+++ b/EGG9000.Site/Views/Admin/ApiKeys.cshtml
@@ -4,11 +4,11 @@
 }
 
 <h2>API Keys</h2>
-<p>API keys let external tools fetch leaderboard data as JSON. Each key is guild-scoped and read-only. The raw key is shown <strong>once</strong> when created — copy it immediately.</p>
+<p>API keys let external tools fetch leaderboard data as JSON. Each key is guild-scoped and read-only. The raw key is shown <strong>once</strong> when created - copy it immediately.</p>
 
 @if (Model.NewRawKey != null) {
     <div class="alert alert-success" role="alert">
-        <strong>New key created.</strong> Copy it now — it will not be shown again.<br />
+        <strong>New key created.</strong> Copy it now - it will not be shown again.<br />
         <code>@Model.NewRawKey</code>
     </div>
 }
@@ -44,7 +44,7 @@
                     </td>
                     <td>
                         @if (!key.Revoked) {
-                            <form method="post" action="/Admin/RevokeApiKey?id=@key.Id" style="display:inline">
+                            <form method="post" action="/Admin/RevokeApiKey?id=@key.Id&guildId=@Model.GuildId" style="display:inline">
                                 @Html.AntiForgeryToken()
                                 <button type="submit" class="btn btn-sm btn-danger"
                                         onclick="return confirm('Revoke key &quot;@key.Label&quot;? This cannot be undone.')">
@@ -62,6 +62,7 @@
 <h4>Create New Key</h4>
 <form method="post" action="/Admin/CreateApiKey">
     @Html.AntiForgeryToken()
+    <input type="hidden" name="id" value="@Model.GuildId" />
     <div class="mb-3">
         <label for="label" class="form-label">Label</label>
         <input type="text" class="form-control" id="label" name="label" required maxlength="100" placeholder="e.g. Stats Dashboard" />

--- a/EGG9000.Site/Views/Admin/ApiKeys.cshtml
+++ b/EGG9000.Site/Views/Admin/ApiKeys.cshtml
@@ -13,6 +13,12 @@
     </div>
 }
 
+@if (User.IsInRole("Admin") && Model.UnrecognizedAttempts7Days > 0) {
+    <div class="alert alert-warning" role="alert">
+        <strong>@Model.UnrecognizedAttempts7Days</strong> requests in the last 7 days used an API key that matched nothing on file (across all guilds).
+    </div>
+}
+
 <h4>Existing Keys</h4>
 @if (!Model.Keys.Any()) {
     <p>No keys yet.</p>
@@ -24,13 +30,22 @@
                 <th>Created</th>
                 <th>Expires</th>
                 <th>Status</th>
+                <th>Today</th>
+                <th>Last 7 days</th>
+                <th>Unique IPs (7d)</th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
             @foreach (var key in Model.Keys) {
+                var usage = Model.KeyUsage[key.Id];
                 <tr>
-                    <td>@key.Label</td>
+                    <td>
+                        @key.Label
+                        @if (usage.IsSpike) {
+                            <span class="badge bg-danger" title="Today's usage is more than 5x this key's trailing baseline">Spike</span>
+                        }
+                    </td>
                     <td>@key.CreatedAt.ToString("yyyy-MM-dd HH:mm") UTC</td>
                     <td>@(key.ExpiresAt.HasValue ? key.ExpiresAt.Value.ToString("yyyy-MM-dd") : "Never")</td>
                     <td>
@@ -42,7 +57,11 @@
                             <span class="badge bg-success">Active</span>
                         }
                     </td>
+                    <td>@usage.RequestsToday</td>
+                    <td>@usage.RequestsLast7Days</td>
+                    <td>@usage.UniqueIps7Days</td>
                     <td>
+                        <a href="/Admin/ApiKeyRequestLog?apiKeyId=@key.Id&guildId=@Model.GuildId" class="btn btn-sm btn-outline-secondary">View log</a>
                         @if (!key.Revoked) {
                             <form method="post" action="/Admin/RevokeApiKey?id=@key.Id&guildId=@Model.GuildId" style="display:inline">
                                 @Html.AntiForgeryToken()

--- a/EGG9000.Site/Views/Admin/Index.cshtml
+++ b/EGG9000.Site/Views/Admin/Index.cshtml
@@ -23,6 +23,12 @@
 		}
 	</div>
 }
+@if (User.IsInRole("Admin") || User.IsInRole("GuildAdmin")) {
+	<div style="padding-bottom: 0.75%">
+		Integrations<br />
+		<a href="/admin/apikeys" class="btn btn-primary">API Keys</a>
+	</div>
+}
 <div style="padding-bottom: 0.75%">
 	Player Reports<br />
 	<a href="/admin/sleepers" class="btn btn-primary">Sleepers</a>

--- a/EGG9000.Test/AdminApiKeyUsageTests.cs
+++ b/EGG9000.Test/AdminApiKeyUsageTests.cs
@@ -1,0 +1,35 @@
+using EGG9000.Site.Controllers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class AdminApiKeyUsageTests {
+        [TestMethod]
+        public void BelowFiveTimesBaseline_IsNotSpike() {
+            Assert.IsFalse(AdminController.ComputeIsSpike(todayCount: 200, baselineAverage: 50));
+        }
+
+        [TestMethod]
+        public void AboveFiveTimesBaseline_IsSpike() {
+            Assert.IsTrue(AdminController.ComputeIsSpike(todayCount: 251, baselineAverage: 50));
+        }
+
+        [TestMethod]
+        public void ExactlyFiveTimesBaseline_IsNotSpike() {
+            Assert.IsFalse(AdminController.ComputeIsSpike(todayCount: 250, baselineAverage: 50));
+        }
+
+        [TestMethod]
+        public void LowBaselineUsesFloorOfFifty() {
+            // baseline of 2 -> floor kicks in at 50, so 10 requests today (5x the raw baseline) is NOT a spike.
+            Assert.IsFalse(AdminController.ComputeIsSpike(todayCount: 10, baselineAverage: 2));
+        }
+
+        [TestMethod]
+        public void LowBaselineStillFlagsRealSpike() {
+            // 300 requests against a near-zero baseline still exceeds the 50-floor x5 threshold.
+            Assert.IsTrue(AdminController.ComputeIsSpike(todayCount: 300, baselineAverage: 2));
+        }
+    }
+}

--- a/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
+++ b/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,119 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Site.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ApiKeyAuthenticationHandlerTests {
+        private static string HashKey(string rawKey)
+            => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey))).ToLowerInvariant();
+
+        private static ApiKey MakeKey(string rawKey, bool revoked = false, DateTimeOffset? expiresAt = null)
+            => new ApiKey {
+                Id = Guid.NewGuid(),
+                KeyHash = HashKey(rawKey),
+                Label = "test",
+                GuildId = 12345UL,
+                CreatedAt = DateTimeOffset.UtcNow.AddDays(-1),
+                ExpiresAt = expiresAt,
+                Revoked = revoked
+            };
+
+        // Minimal stub — returns a default AuthenticationSchemeOptions for any scheme name.
+        private class StubOptionsMonitor : IOptionsMonitor<AuthenticationSchemeOptions> {
+            public AuthenticationSchemeOptions CurrentValue => new();
+            public AuthenticationSchemeOptions Get(string name) => new();
+            public IDisposable OnChange(Action<AuthenticationSchemeOptions, string> listener) => null;
+        }
+
+        // Minimal factory shim so we can inject a test DB without touching DI.
+        private class TestDbContextFactory(DbContextOptions<ApplicationDbContext> options)
+            : IDbContextFactory<ApplicationDbContext> {
+            public ApplicationDbContext CreateDbContext() => new ApplicationDbContext(options);
+        }
+
+        private static async Task<AuthenticateResult> RunHandler(ApiKey storedKey, string headerValue) {
+            var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            var factory = new TestDbContextFactory(dbOptions);
+            if (storedKey != null) {
+                using var seed = factory.CreateDbContext();
+                seed.ApiKeys.Add(storedKey);
+                await seed.SaveChangesAsync();
+            }
+
+            var handler = new ApiKeyAuthenticationHandler(
+                new StubOptionsMonitor(),
+                NullLoggerFactory.Instance,
+                UrlEncoder.Default,
+                factory);
+
+            var context = new DefaultHttpContext();
+            if (headerValue != null)
+                context.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = headerValue;
+
+            await handler.InitializeAsync(
+                new AuthenticationScheme(ApiKeyAuthenticationHandler.SchemeName, null, typeof(ApiKeyAuthenticationHandler)),
+                context);
+
+            return await handler.AuthenticateAsync();
+        }
+
+        [TestMethod]
+        public async Task NoHeader_ReturnsNoResult() {
+            var result = await RunHandler(MakeKey("validkey"), headerValue: null);
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsNull(result.Failure);  // NoResult, not Fail
+        }
+
+        [TestMethod]
+        public async Task ValidKey_ReturnsSuccess_WithGuildIdClaim() {
+            var key = MakeKey("myrawkey");
+            var result = await RunHandler(key, "myrawkey");
+            Assert.IsTrue(result.Succeeded);
+            Assert.AreEqual("12345", result.Principal!.FindFirst("GuildId")!.Value);
+        }
+
+        [TestMethod]
+        public async Task WrongKey_ReturnsFail() {
+            var key = MakeKey("correctkey");
+            var result = await RunHandler(key, "wrongkey");
+            Assert.IsFalse(result.Succeeded);
+            Assert.IsNotNull(result.Failure);
+        }
+
+        [TestMethod]
+        public async Task RevokedKey_ReturnsFail() {
+            var key = MakeKey("revokedkey", revoked: true);
+            var result = await RunHandler(key, "revokedkey");
+            Assert.IsFalse(result.Succeeded);
+        }
+
+        [TestMethod]
+        public async Task ExpiredKey_ReturnsFail() {
+            var key = MakeKey("expiredkey", expiresAt: DateTimeOffset.UtcNow.AddHours(-1));
+            var result = await RunHandler(key, "expiredkey");
+            Assert.IsFalse(result.Succeeded);
+        }
+
+        [TestMethod]
+        public async Task NotYetExpiredKey_ReturnsSuccess() {
+            var key = MakeKey("futurekey", expiresAt: DateTimeOffset.UtcNow.AddDays(30));
+            var result = await RunHandler(key, "futurekey");
+            Assert.IsTrue(result.Succeeded);
+        }
+    }
+}

--- a/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
+++ b/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
@@ -31,7 +31,7 @@ namespace EGG9000.Test {
                 Revoked = revoked
             };
 
-        // Minimal stub — returns a default AuthenticationSchemeOptions for any scheme name.
+        // Minimal stub - returns a default AuthenticationSchemeOptions for any scheme name.
         private class StubOptionsMonitor : IOptionsMonitor<AuthenticationSchemeOptions> {
             public AuthenticationSchemeOptions CurrentValue => new();
             public AuthenticationSchemeOptions Get(string name) => new();

--- a/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
+++ b/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
@@ -35,8 +35,8 @@ namespace EGG9000.Test {
         // Minimal stub - returns a default AuthenticationSchemeOptions for any scheme name.
         private class StubOptionsMonitor : IOptionsMonitor<AuthenticationSchemeOptions> {
             public AuthenticationSchemeOptions CurrentValue => new();
-            public AuthenticationSchemeOptions Get(string name) => new();
-            public IDisposable OnChange(Action<AuthenticationSchemeOptions, string> listener) => null;
+            public AuthenticationSchemeOptions Get(string? name) => new();
+            public IDisposable? OnChange(Action<AuthenticationSchemeOptions, string> listener) => null;
         }
 
         // Minimal factory shim so we can inject a test DB without touching DI.
@@ -45,7 +45,7 @@ namespace EGG9000.Test {
             public ApplicationDbContext CreateDbContext() => new ApplicationDbContext(options);
         }
 
-        private static async Task<AuthenticateResult> RunHandler(ApiKey storedKey, string headerValue) {
+        private static async Task<AuthenticateResult> RunHandler(ApiKey storedKey, string? headerValue) {
             var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseInMemoryDatabase(Guid.NewGuid().ToString())
                 .Options;
@@ -117,7 +117,7 @@ namespace EGG9000.Test {
             Assert.IsTrue(result.Succeeded);
         }
 
-        private static async Task<(AuthenticateResult Result, ApplicationDbContext Db)> RunHandlerWithDb(ApiKey storedKey, string headerValue, string remoteIp = "203.0.113.5", string dbName = null) {
+        private static async Task<(AuthenticateResult Result, ApplicationDbContext Db)> RunHandlerWithDb(ApiKey? storedKey, string? headerValue, string remoteIp = "203.0.113.5", string? dbName = null) {
             var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
                 .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
                 .Options;

--- a/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
+++ b/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
@@ -136,6 +136,8 @@ namespace EGG9000.Test {
 
             var context = new DefaultHttpContext();
             context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse(remoteIp);
+            context.Request.Method = "GET";
+            context.Request.Path = "/LeaderboardJson";
             if (headerValue != null)
                 context.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = headerValue;
 
@@ -158,6 +160,7 @@ namespace EGG9000.Test {
             Assert.AreEqual(key.Id, logRow.ApiKeyId);
             Assert.AreEqual(12345UL, logRow.GuildId);
             Assert.AreEqual("203.0.113.5", logRow.IpAddress);
+            Assert.AreEqual("GET /LeaderboardJson", logRow.Endpoint);
             Assert.IsTrue(logRow.Success);
 
             var usageRow = await db.ApiKeyDailyUsages.SingleAsync();

--- a/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
+++ b/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
@@ -11,6 +11,7 @@ using System;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace EGG9000.Test {
@@ -193,6 +194,53 @@ namespace EGG9000.Test {
             var (_, db) = await RunHandlerWithDb(MakeKey("unused"), headerValue: null);
 
             Assert.AreEqual(0, await db.ApiKeyRequestLogs.CountAsync());
+        }
+
+        [TestMethod]
+        public async Task ValidKey_StillSucceeds_WhenLogWriteThrows() {
+            var key = MakeKey("resilientkey");
+            var dbName = Guid.NewGuid().ToString();
+
+            var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(dbName)
+                .Options;
+            var factory = new TestDbContextFactory(dbOptions);
+            using (var seed = factory.CreateDbContext()) {
+                seed.ApiKeys.Add(key);
+                await seed.SaveChangesAsync();
+            }
+
+            var brokenFactory = new ThrowingDbContextFactory(dbOptions);
+            var handler = new ApiKeyAuthenticationHandler(
+                new StubOptionsMonitor(),
+                NullLoggerFactory.Instance,
+                UrlEncoder.Default,
+                brokenFactory);
+
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse("203.0.113.5");
+            context.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = "resilientkey";
+
+            await handler.InitializeAsync(
+                new AuthenticationScheme(ApiKeyAuthenticationHandler.SchemeName, null, typeof(ApiKeyAuthenticationHandler)),
+                context);
+
+            var result = await handler.AuthenticateAsync();
+
+            Assert.IsTrue(result.Succeeded);
+            Assert.AreEqual("12345", result.Principal!.FindFirst("GuildId")!.Value);
+        }
+
+        // Wraps a real ApplicationDbContext but makes SaveChangesAsync throw on every call after the
+        // first, so the key lookup succeeds but the subsequent log write fails - proving auth doesn't
+        // depend on the log write succeeding.
+        private class ThrowingDbContextFactory(DbContextOptions<ApplicationDbContext> options) : IDbContextFactory<ApplicationDbContext> {
+            public ApplicationDbContext CreateDbContext() => new ThrowingSaveChangesDbContext(options);
+        }
+
+        private class ThrowingSaveChangesDbContext(DbContextOptions<ApplicationDbContext> options) : ApplicationDbContext(options) {
+            public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+                => throw new InvalidOperationException("Simulated DB failure during log write.");
         }
     }
 }

--- a/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
+++ b/EGG9000.Test/ApiKeyAuthenticationHandlerTests.cs
@@ -115,5 +115,84 @@ namespace EGG9000.Test {
             var result = await RunHandler(key, "futurekey");
             Assert.IsTrue(result.Succeeded);
         }
+
+        private static async Task<(AuthenticateResult Result, ApplicationDbContext Db)> RunHandlerWithDb(ApiKey storedKey, string headerValue, string remoteIp = "203.0.113.5", string dbName = null) {
+            var dbOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(dbName ?? Guid.NewGuid().ToString())
+                .Options;
+            var factory = new TestDbContextFactory(dbOptions);
+            if (storedKey != null) {
+                using var seed = factory.CreateDbContext();
+                seed.ApiKeys.Add(storedKey);
+                await seed.SaveChangesAsync();
+            }
+
+            var handler = new ApiKeyAuthenticationHandler(
+                new StubOptionsMonitor(),
+                NullLoggerFactory.Instance,
+                UrlEncoder.Default,
+                factory);
+
+            var context = new DefaultHttpContext();
+            context.Connection.RemoteIpAddress = System.Net.IPAddress.Parse(remoteIp);
+            if (headerValue != null)
+                context.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = headerValue;
+
+            await handler.InitializeAsync(
+                new AuthenticationScheme(ApiKeyAuthenticationHandler.SchemeName, null, typeof(ApiKeyAuthenticationHandler)),
+                context);
+
+            var result = await handler.AuthenticateAsync();
+            return (result, factory.CreateDbContext());
+        }
+
+        [TestMethod]
+        public async Task ValidKey_WritesRequestLogAndDailyUsage() {
+            var key = MakeKey("logtestkey");
+            var (result, db) = await RunHandlerWithDb(key, "logtestkey");
+
+            Assert.IsTrue(result.Succeeded);
+
+            var logRow = await db.ApiKeyRequestLogs.SingleAsync();
+            Assert.AreEqual(key.Id, logRow.ApiKeyId);
+            Assert.AreEqual(12345UL, logRow.GuildId);
+            Assert.AreEqual("203.0.113.5", logRow.IpAddress);
+            Assert.IsTrue(logRow.Success);
+
+            var usageRow = await db.ApiKeyDailyUsages.SingleAsync();
+            Assert.AreEqual(key.Id, usageRow.ApiKeyId);
+            Assert.AreEqual(1, usageRow.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task ValidKey_SecondRequestSameDay_IncrementsDailyUsage() {
+            var key = MakeKey("counterkey");
+            var dbName = Guid.NewGuid().ToString();
+            await RunHandlerWithDb(key, "counterkey", dbName: dbName);
+            var (_, db) = await RunHandlerWithDb(storedKey: null, headerValue: "counterkey", dbName: dbName);
+
+            var usageRow = await db.ApiKeyDailyUsages.SingleAsync();
+            Assert.AreEqual(2, usageRow.RequestCount);
+        }
+
+        [TestMethod]
+        public async Task UnmatchedKey_WritesRequestLogWithNullApiKeyId() {
+            var (result, db) = await RunHandlerWithDb(storedKey: null, headerValue: "nonexistentkey");
+
+            Assert.IsFalse(result.Succeeded);
+
+            var logRow = await db.ApiKeyRequestLogs.SingleAsync();
+            Assert.IsNull(logRow.ApiKeyId);
+            Assert.IsNull(logRow.GuildId);
+            Assert.IsFalse(logRow.Success);
+            Assert.AreEqual("203.0.113.5", logRow.IpAddress);
+        }
+
+        [TestMethod]
+        public async Task NoHeader_DoesNotWriteRequestLog() {
+            var (_, db) = await RunHandlerWithDb(MakeKey("unused"), headerValue: null);
+
+            Assert.AreEqual(0, await db.ApiKeyRequestLogs.CountAsync());
+        }
     }
 }

--- a/EGG9000.Test/EGG9000.Test.csproj
+++ b/EGG9000.Test/EGG9000.Test.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="MessagePack" Version="3.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
@@ -36,5 +37,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EGG9000.Common\EGG9000.Common.csproj" />
+    <ProjectReference Include="..\EGG9000.Site\EGG9000.Site.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds in support for API keys managed via Admin UI. 
/Home/LeaderboardJson takes in X-API-Key header to return the leaderboard as JSON, currently the fields being returned are: 
- DiscordName 
- DiscordId 
- EggIncName 
- EarningsBonus 
- SoulEggs 
- EggsOfProphecy 
- MER 
- EggsOfTruth 
- NumPrestiges 

Having it gated behind an api key limits access and misuse. 