### PR TITLE
fix: add back pe filter for only leggacy contracts

### DIFF
--- a/EGG9000.Bot/Commands/ContractSettings.cs
+++ b/EGG9000.Bot/Commands/ContractSettings.cs
@@ -162,17 +162,10 @@ namespace EGG9000.Bot.Commands {
             return props;
         }
 
-        public static Dictionary<Ei.RewardType, string> GetRewardDictionary() {
-            return new Dictionary<Ei.RewardType, string> {
-                { Ei.RewardType.Artifact, "Artifacts" },
-                { Ei.RewardType.PiggyMultiplier, "Piggy Bank" },
-                { Ei.RewardType.ShellScript, "Shell Tickets" },
-                { Ei.RewardType.Gold, "Golden Eggs" },
-                { Ei.RewardType.Boost, "Any Boost" },
-                { Ei.RewardType.EpicResearchItem, "Epic Research" },
-                { Ei.RewardType.UnknownReward, "** Any Reward **" },
-            };
-        }
+        // Single source of truth for reward labels; the shared dictionary includes EggsOfProphecy,
+        // which must be present here — accounts can legitimately carry PE in their RewardFilter and
+        // the main-menu render indexes this dictionary with every filter entry.
+        public static Dictionary<Ei.RewardType, string> GetRewardDictionary() => ContractSettingsHelpers.GetRewardDictionary();
 
         [ComponentCommand]
         public static async Task MCSMenu(SocketMessageComponent component, [ComponentData] string data, ApplicationDbContext db) {

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -232,6 +232,10 @@ namespace EGG9000.Bot.Commands {
                 AutoRegisterRewards = existingAccount.AutoRegisterRewards,
                 PingForNCUltra = existingAccount.PingForNCUltra,
                 DoTwoToThreeContracts = existingAccount.DoTwoToThreeContracts,
+                // Must carry the consolidated settings blob across. Without it the next load re-runs
+                // FromLegacyKeys, which discards every post-V2 edit, and permanently loses PE, since
+                // the one-shot PE heal has already stripped PE from LeggacyAutoRegisterRewards.
+                Assignment = existingAccount.Assignment,
             };
 
             if(user.EggIncAccounts.Count > 1) user.EggIncAccounts[accountnumber - 1] = newAccount;

--- a/EGG9000.Common/Contracts/Assignment/AssignmentSettingsMigration.cs
+++ b/EGG9000.Common/Contracts/Assignment/AssignmentSettingsMigration.cs
@@ -26,17 +26,13 @@ namespace EGG9000.Common.Contracts.Assignment {
             };
         }
 
-        // Legacy list wins if set, else the main list. Only the "any reward" sentinel is stripped.
-        // PE is kept when migrating from the legacy filter (V1 preserved it there); only the new-contract
-        // filter stripped PE (seasonal PE was handled separately). Stripping PE here was the V2 regression.
+        // Legacy list wins if set, else the main list. PE is kept when migrating from the legacy filter
+        // (V1 preserved it there); only the new-contract filter stripped PE (seasonal PE was handled
+        // separately). Stripping PE from the legacy source was the V2 regression.
         private static List<Ei.RewardType> SingleRewardFilter(EggIncAccount a) {
             if(a.LeggacyAutoRegisterRewards is { Count: > 0 })
-                return a.LeggacyAutoRegisterRewards
-                    .Where(r => r != Ei.RewardType.UnknownReward)
-                    .ToList();
-            return (a.AutoRegisterRewards ?? new List<Ei.RewardType>())
-                .Where(r => r != Ei.RewardType.EggsOfProphecy && r != Ei.RewardType.UnknownReward)
-                .ToList();
+                return RewardMatch.Sanitize(a.LeggacyAutoRegisterRewards);
+            return RewardMatch.Sanitize(a.AutoRegisterRewards, stripPe: true);
         }
 
         // Seasonal is mandatory in v2. Only the explicit CS-threshold option carries a mode across;

--- a/EGG9000.Common/Contracts/Assignment/AssignmentSettingsMigration.cs
+++ b/EGG9000.Common/Contracts/Assignment/AssignmentSettingsMigration.cs
@@ -26,10 +26,15 @@ namespace EGG9000.Common.Contracts.Assignment {
             };
         }
 
-        // Legacy list wins if set, else the main list; PE and the "any reward" sentinel are stripped.
+        // Legacy list wins if set, else the main list. Only the "any reward" sentinel is stripped.
+        // PE is kept when migrating from the legacy filter (V1 preserved it there); only the new-contract
+        // filter stripped PE (seasonal PE was handled separately). Stripping PE here was the V2 regression.
         private static List<Ei.RewardType> SingleRewardFilter(EggIncAccount a) {
-            var source = a.LeggacyAutoRegisterRewards is { Count: > 0 } ? a.LeggacyAutoRegisterRewards : a.AutoRegisterRewards;
-            return (source ?? new List<Ei.RewardType>())
+            if(a.LeggacyAutoRegisterRewards is { Count: > 0 })
+                return a.LeggacyAutoRegisterRewards
+                    .Where(r => r != Ei.RewardType.UnknownReward)
+                    .ToList();
+            return (a.AutoRegisterRewards ?? new List<Ei.RewardType>())
                 .Where(r => r != Ei.RewardType.EggsOfProphecy && r != Ei.RewardType.UnknownReward)
                 .ToList();
         }

--- a/EGG9000.Common/Contracts/Assignment/ContractSettingField.cs
+++ b/EGG9000.Common/Contracts/Assignment/ContractSettingField.cs
@@ -43,7 +43,7 @@ namespace EGG9000.Common.Contracts.Assignment {
                     return ParseBool(value, out var after) ? Set(() => s.Seasonal.RewardFilterAfter = after) : Bad();
                 case "rewardFilter":
                     return ParseRewards(value, out var rf)
-                        ? Set(() => s.RewardFilter = rf.Where(r => r != Ei.RewardType.UnknownReward).ToList())
+                        ? Set(() => s.RewardFilter = RewardMatch.Sanitize(rf))
                         : Bad();
                 default:
                     return new ContractSettingResult(ContractSettingApplyStatus.UnknownField);

--- a/EGG9000.Common/Contracts/Assignment/ContractSettingField.cs
+++ b/EGG9000.Common/Contracts/Assignment/ContractSettingField.cs
@@ -43,7 +43,7 @@ namespace EGG9000.Common.Contracts.Assignment {
                     return ParseBool(value, out var after) ? Set(() => s.Seasonal.RewardFilterAfter = after) : Bad();
                 case "rewardFilter":
                     return ParseRewards(value, out var rf)
-                        ? Set(() => s.RewardFilter = rf.Where(r => r != Ei.RewardType.EggsOfProphecy && r != Ei.RewardType.UnknownReward).ToList())
+                        ? Set(() => s.RewardFilter = rf.Where(r => r != Ei.RewardType.UnknownReward).ToList())
                         : Bad();
                 default:
                     return new ContractSettingResult(ContractSettingApplyStatus.UnknownField);

--- a/EGG9000.Common/Contracts/Assignment/RewardMatch.cs
+++ b/EGG9000.Common/Contracts/Assignment/RewardMatch.cs
@@ -3,6 +3,22 @@ using System.Linq;
 
 namespace EGG9000.Common.Contracts.Assignment {
     public static class RewardMatch {
+        // The effective reward filter for a contract: PE is ignored on seasonal contracts (seasonal PE
+        // is governed by SeasonalContractsRule; its RewardFilterAfter=true path falls through to the
+        // Include tier). Stripping PE can leave the filter empty (PE-only filter): empty means match
+        // all, consistent with Matches. Only allocates when PE is actually present and must go.
+        public static IReadOnlyList<Ei.RewardType> EffectiveFilter(IReadOnlyList<Ei.RewardType> filter, ContractFacts c) =>
+            c.IsSeasonal && filter is { Count: > 0 } && filter.Contains(Ei.RewardType.EggsOfProphecy)
+                ? filter.Where(r => r != Ei.RewardType.EggsOfProphecy).ToList()
+                : filter;
+
+        // Normalizes a stored/parsed reward filter: strips the "any reward" sentinel, and optionally PE
+        // (the V1 new-contract filter never carried PE; the legacy filter did).
+        public static List<Ei.RewardType> Sanitize(IEnumerable<Ei.RewardType> source, bool stripPe = false) =>
+            (source ?? Enumerable.Empty<Ei.RewardType>())
+                .Where(r => r != Ei.RewardType.UnknownReward && (!stripPe || r != Ei.RewardType.EggsOfProphecy))
+                .ToList();
+
         public static bool Matches(GradeRewardFacts grade, IReadOnlyList<Ei.RewardType> filter, int completedGoals) {
             if(filter is null || filter.Count == 0) return true;
             var remaining = grade.GoalRewards.Skip(completedGoals).ToList();

--- a/EGG9000.Common/Contracts/Assignment/Rules/IncludeRules.cs
+++ b/EGG9000.Common/Contracts/Assignment/Rules/IncludeRules.cs
@@ -1,7 +1,5 @@
 using EGG9000.Common.Helpers;
 
-using System.Linq;
-
 namespace EGG9000.Common.Contracts.Assignment {
     internal static class IncludeRuleHelpers {
         public static GradeRewardFacts GradeOrNull(ContractFacts c, Ei.Contract.Types.PlayerGrade grade) =>
@@ -10,10 +8,8 @@ namespace EGG9000.Common.Contracts.Assignment {
 
     // One reward filter for all contracts (the new/legacy split is gone). Empty filter = match all.
     // PE may be in the filter; in practice only leggacy contracts still carry a PE goal reward
-    // (modern contracts grant PE via season progress instead). Seasonal PE is governed by
-    // SeasonalContractsRule (Force tier); its RewardFilterAfter=true path falls through to this rule,
-    // so the PE entry is explicitly ignored for seasonal contracts. Stripping PE can leave the filter
-    // empty (PE-only filter) — empty means match all, consistent with the rule's contract.
+    // (modern contracts grant PE via season progress instead). PE handling for seasonal contracts is
+    // centralized in RewardMatch.EffectiveFilter.
     public sealed class RewardFilterRule : IAssignmentRule {
         public AssignmentRuleId Id => AssignmentRuleId.RewardFilter;
         public RuleTier Tier => RuleTier.Include;
@@ -21,10 +17,7 @@ namespace EGG9000.Common.Contracts.Assignment {
         public RuleOutcome Evaluate(AccountFacts f, ContractFacts c, AssignmentSettings s) {
             var grade = IncludeRuleHelpers.GradeOrNull(c, f.Grade);
             if(grade is null) return RuleOutcome.Exclude;
-            var filter = c.IsSeasonal && s.RewardFilter is not null
-                ? s.RewardFilter.Where(r => r != Ei.RewardType.EggsOfProphecy).ToList()
-                : s.RewardFilter;
-            return RewardMatch.Matches(grade, filter, f.CompletedGoalsOnThisContract)
+            return RewardMatch.Matches(grade, RewardMatch.EffectiveFilter(s.RewardFilter, c), f.CompletedGoalsOnThisContract)
                 ? RuleOutcome.Pass : RuleOutcome.Exclude;
         }
         public string Describe(RuleOutcome o) => "Rewards not selected";
@@ -53,8 +46,10 @@ namespace EGG9000.Common.Contracts.Assignment {
             var grade = IncludeRuleHelpers.GradeOrNull(c, f.Grade);
             if(c.HadTwoRewards && grade != null && grade.GoalRewards.Count == 3 && f.CompletedExactlyTwoGoals) {
                 if(!s.TwoToThree) return RuleOutcome.Exclude;
-                if(s.RewardFilter == null || s.RewardFilter.Count == 0) return RuleOutcome.Pass;
-                foreach(var r in s.RewardFilter)
+                // Same PE-on-seasonal handling as RewardFilterRule so PE is treated consistently.
+                var filter = RewardMatch.EffectiveFilter(s.RewardFilter, c);
+                if(filter == null || filter.Count == 0) return RuleOutcome.Pass;
+                foreach(var r in filter)
                     if(RewardMatch.MatchesLast(grade, r)) return RuleOutcome.Pass;
                 return RuleOutcome.Exclude;
             }

--- a/EGG9000.Common/Contracts/Assignment/Rules/IncludeRules.cs
+++ b/EGG9000.Common/Contracts/Assignment/Rules/IncludeRules.cs
@@ -1,5 +1,7 @@
 using EGG9000.Common.Helpers;
 
+using System.Linq;
+
 namespace EGG9000.Common.Contracts.Assignment {
     internal static class IncludeRuleHelpers {
         public static GradeRewardFacts GradeOrNull(ContractFacts c, Ei.Contract.Types.PlayerGrade grade) =>
@@ -7,7 +9,11 @@ namespace EGG9000.Common.Contracts.Assignment {
     }
 
     // One reward filter for all contracts (the new/legacy split is gone). Empty filter = match all.
-    // PE is never in the filter; seasonal PE is governed by SeasonalContractsRule.
+    // PE may be in the filter; in practice only leggacy contracts still carry a PE goal reward
+    // (modern contracts grant PE via season progress instead). Seasonal PE is governed by
+    // SeasonalContractsRule (Force tier); its RewardFilterAfter=true path falls through to this rule,
+    // so the PE entry is explicitly ignored for seasonal contracts. Stripping PE can leave the filter
+    // empty (PE-only filter) — empty means match all, consistent with the rule's contract.
     public sealed class RewardFilterRule : IAssignmentRule {
         public AssignmentRuleId Id => AssignmentRuleId.RewardFilter;
         public RuleTier Tier => RuleTier.Include;
@@ -15,7 +21,10 @@ namespace EGG9000.Common.Contracts.Assignment {
         public RuleOutcome Evaluate(AccountFacts f, ContractFacts c, AssignmentSettings s) {
             var grade = IncludeRuleHelpers.GradeOrNull(c, f.Grade);
             if(grade is null) return RuleOutcome.Exclude;
-            return RewardMatch.Matches(grade, s.RewardFilter, f.CompletedGoalsOnThisContract)
+            var filter = c.IsSeasonal && s.RewardFilter is not null
+                ? s.RewardFilter.Where(r => r != Ei.RewardType.EggsOfProphecy).ToList()
+                : s.RewardFilter;
+            return RewardMatch.Matches(grade, filter, f.CompletedGoalsOnThisContract)
                 ? RuleOutcome.Pass : RuleOutcome.Exclude;
         }
         public string Describe(RuleOutcome o) => "Rewards not selected";

--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -203,19 +203,20 @@ namespace EGG9000.Common.Database.Entities {
                                 // so blobs persisted before then deserialize with these as null.
                                 if(account.Assignment.Seasonal is null) { account.Assignment.Seasonal = new(); needsUpdate = true; }
                                 if(account.Assignment.RewardFilter is null) { account.Assignment.RewardFilter = new(); needsUpdate = true; }
-                                // One-shot repair: the original V2 migration wrongly stripped PE when it
-                                // migrated LeggacyAutoRegisterRewards. Re-add PE only (a full FromLegacyKeys
-                                // rebuild would clobber edits made through the new UI since V2), then remove
-                                // PE from the legacy key so this can never fire again — nothing writes that
-                                // key anymore, so it would otherwise resurrect PE forever after the user
-                                // unticks it in the new UI.
-                                if(account.LeggacyAutoRegisterRewards is { Count: > 0 }
-                                    && account.LeggacyAutoRegisterRewards.Contains(Ei.RewardType.EggsOfProphecy)) {
-                                    if(!account.Assignment.RewardFilter.Contains(Ei.RewardType.EggsOfProphecy))
-                                        account.Assignment.RewardFilter.Add(Ei.RewardType.EggsOfProphecy);
-                                    account.LeggacyAutoRegisterRewards.Remove(Ei.RewardType.EggsOfProphecy);
-                                    needsUpdate = true;
-                                }
+                            }
+                            // One-shot repair (must run after BOTH branches above, or the fresh-migration
+                            // path leaves PE in the legacy key and this fires later, resurrecting PE after
+                            // the user unticked it): the original V2 migration wrongly stripped PE when it
+                            // migrated LeggacyAutoRegisterRewards. Re-add PE only (a full FromLegacyKeys
+                            // rebuild would clobber edits made through the new UI since V2), then remove
+                            // PE from the legacy key so this can never fire again, nothing writes that
+                            // key anymore.
+                            if(account.LeggacyAutoRegisterRewards is { Count: > 0 }
+                                && account.LeggacyAutoRegisterRewards.Contains(Ei.RewardType.EggsOfProphecy)) {
+                                if(!account.Assignment.RewardFilter.Contains(Ei.RewardType.EggsOfProphecy))
+                                    account.Assignment.RewardFilter.Add(Ei.RewardType.EggsOfProphecy);
+                                account.LeggacyAutoRegisterRewards.Remove(Ei.RewardType.EggsOfProphecy);
+                                needsUpdate = true;
                             }
                         });
                         if(needsUpdate) {

--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -203,6 +203,19 @@ namespace EGG9000.Common.Database.Entities {
                                 // so blobs persisted before then deserialize with these as null.
                                 if(account.Assignment.Seasonal is null) { account.Assignment.Seasonal = new(); needsUpdate = true; }
                                 if(account.Assignment.RewardFilter is null) { account.Assignment.RewardFilter = new(); needsUpdate = true; }
+                                // One-shot repair: the original V2 migration wrongly stripped PE when it
+                                // migrated LeggacyAutoRegisterRewards. Re-add PE only (a full FromLegacyKeys
+                                // rebuild would clobber edits made through the new UI since V2), then remove
+                                // PE from the legacy key so this can never fire again — nothing writes that
+                                // key anymore, so it would otherwise resurrect PE forever after the user
+                                // unticks it in the new UI.
+                                if(account.LeggacyAutoRegisterRewards is { Count: > 0 }
+                                    && account.LeggacyAutoRegisterRewards.Contains(Ei.RewardType.EggsOfProphecy)) {
+                                    if(!account.Assignment.RewardFilter.Contains(Ei.RewardType.EggsOfProphecy))
+                                        account.Assignment.RewardFilter.Add(Ei.RewardType.EggsOfProphecy);
+                                    account.LeggacyAutoRegisterRewards.Remove(Ei.RewardType.EggsOfProphecy);
+                                    needsUpdate = true;
+                                }
                             }
                         });
                         if(needsUpdate) {

--- a/EGG9000.Site/Views/MyFarms/_ContractSettings.cshtml
+++ b/EGG9000.Site/Views/MyFarms/_ContractSettings.cshtml
@@ -22,8 +22,8 @@
     var redoMode = (int)s.Redo.Mode;
     var redoThreshold = s.Redo.ScoreThreshold;
 
-    // Reward types offered in the single filter. No Eggs Of Prophecy (PE is governed by the seasonal rule).
     var rewardLabels = new (Ei.RewardType Type, string Label)[] {
+        (Ei.RewardType.EggsOfProphecy, "Eggs of Prophecy"),
         (Ei.RewardType.Artifact, "Artifacts"),
         (Ei.RewardType.PiggyMultiplier, "Piggy Bank"),
         (Ei.RewardType.ShellScript, "Shell Tickets"),

--- a/EGG9000.Site/Views/MyFarms/_ContractSettings.cshtml
+++ b/EGG9000.Site/Views/MyFarms/_ContractSettings.cshtml
@@ -22,15 +22,11 @@
     var redoMode = (int)s.Redo.Mode;
     var redoThreshold = s.Redo.ScoreThreshold;
 
-    var rewardLabels = new (Ei.RewardType Type, string Label)[] {
-        (Ei.RewardType.EggsOfProphecy, "Eggs of Prophecy"),
-        (Ei.RewardType.Artifact, "Artifacts"),
-        (Ei.RewardType.PiggyMultiplier, "Piggy Bank"),
-        (Ei.RewardType.ShellScript, "Shell Tickets"),
-        (Ei.RewardType.Gold, "Golden Eggs"),
-        (Ei.RewardType.Boost, "Any Boost"),
-        (Ei.RewardType.EpicResearchItem, "Epic Research")
-    };
+    // Shared reward-label dictionary (same source as the bot menus). The "any reward" sentinel is a
+    // bot-menu concept; on the web, unchecking everything means "any".
+    var rewardLabels = ContractSettingsHelpers.GetRewardDictionary()
+        .Where(kv => kv.Key != Ei.RewardType.UnknownReward)
+        .Select(kv => (Type: kv.Key, Label: kv.Value));
 
     Func<int, int, string, IHtmlContent> opt = (val, current, label) =>
         new HtmlString($"<option value=\"{val}\"{(val == current ? " selected" : "")}>{System.Net.WebUtility.HtmlEncode(label)}</option>");

--- a/EGG9000.Test/Assignment/ContractSettingFieldTests.cs
+++ b/EGG9000.Test/Assignment/ContractSettingFieldTests.cs
@@ -106,12 +106,12 @@ namespace EGG9000.Test.Assignment {
 
         [TestMethod]
         [TestCategory("Unit")]
-        public void RewardFilter_CommaList_DropsPe() {
+        public void RewardFilter_CommaList_KeepsPe() {
             var s = new AssignmentSettings();
             var pe = (int)Ei.RewardType.EggsOfProphecy;
             var gold = (int)Ei.RewardType.Gold;
             Assert.AreEqual(ContractSettingApplyStatus.Ok, Apply(s, "rewardFilter", $"{pe},{gold}"));
-            CollectionAssert.DoesNotContain(s.RewardFilter, Ei.RewardType.EggsOfProphecy);
+            CollectionAssert.Contains(s.RewardFilter, Ei.RewardType.EggsOfProphecy);
             CollectionAssert.Contains(s.RewardFilter, Ei.RewardType.Gold);
         }
 

--- a/EGG9000.Test/Assignment/ContractSettingFieldTests.cs
+++ b/EGG9000.Test/Assignment/ContractSettingFieldTests.cs
@@ -14,8 +14,10 @@ namespace EGG9000.Test.Assignment {
         public void Apply_HealsNullSeasonalAndRedo_FromPartialV1Blob() {
             var s = new AssignmentSettings { Seasonal = null, Redo = null };
             Assert.AreEqual(ContractSettingApplyStatus.Ok, Apply(s, "seasonalMode", "0"));
+            Assert.IsNotNull(s.Seasonal);
             Assert.AreEqual(SeasonalMode.AlwaysAssign, s.Seasonal.Mode);
             Assert.AreEqual(ContractSettingApplyStatus.Ok, Apply(s, "excludeSeasonal", "true"));
+            Assert.IsNotNull(s.Redo);
             Assert.IsTrue(s.Redo.ExcludeSeasonal);
         }
 

--- a/EGG9000.Test/Assignment/IncludeRuleTests.cs
+++ b/EGG9000.Test/Assignment/IncludeRuleTests.cs
@@ -96,6 +96,28 @@ namespace EGG9000.Test.Assignment {
 
         [TestMethod]
         [TestCategory("Unit")]
+        public void RewardFilter_PeMatchesNonSeasonal_IgnoredOnSeasonal() {
+            var rule = new RewardFilterRule();
+            var facts = TestFactsBuilder.Account().Grade(G.GradeC).Build();
+            var peOnly = new AssignmentSettings { RewardFilter = new() { Ei.RewardType.EggsOfProphecy } };
+
+            // Leggacy (non-seasonal) contract with a PE goal: PE in the filter matches.
+            var leggacy = TestFactsBuilder.Contract().Seasonal(false).Grade(G.GradeC, Ei.RewardType.EggsOfProphecy).Build();
+            Assert.AreEqual(RuleOutcome.Pass, rule.Evaluate(facts, leggacy, peOnly));
+
+            // Seasonal contract: PE entry ignored even if a PE goal is present. PE-only filter
+            // strips to empty -> match all.
+            var seasonal = TestFactsBuilder.Contract().Seasonal(true).Grade(G.GradeC, Ei.RewardType.EggsOfProphecy).Build();
+            Assert.AreEqual(RuleOutcome.Pass, rule.Evaluate(facts, seasonal, peOnly));
+
+            // Mixed filter on a seasonal: PE ignored, remaining entries still filter.
+            var mixed = new AssignmentSettings { RewardFilter = new() { Ei.RewardType.EggsOfProphecy, Ei.RewardType.Artifact } };
+            var seasonalNoArtifact = TestFactsBuilder.Contract().Seasonal(true).Grade(G.GradeC, Ei.RewardType.EggsOfProphecy, Ei.RewardType.Gold).Build();
+            Assert.AreEqual(RuleOutcome.Exclude, rule.Evaluate(facts, seasonalNoArtifact, mixed));
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
         public void RewardFilter_MissingGradeRewards_Excludes() {
             var rule = new RewardFilterRule();
             // Contract only defines GradeC; account is GradeA -> no matching grade rewards.

--- a/EGG9000.Test/Assignment/IncludeRuleTests.cs
+++ b/EGG9000.Test/Assignment/IncludeRuleTests.cs
@@ -247,5 +247,27 @@ namespace EGG9000.Test.Assignment {
             var s = new AssignmentSettings { TwoToThree = true, RewardFilter = new() { Ei.RewardType.Cash } };
             Assert.AreEqual(RuleOutcome.Exclude, rule.Evaluate(TwoOfThree(), ThreeGoalContract(Ei.RewardType.Artifact), s));
         }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void TwoToThree_PeInFilter_IgnoredOnSeasonal_HonoredOtherwise() {
+            var rule = new PreviouslyCompletedRule();
+            var peOnly = new AssignmentSettings { TwoToThree = true, RewardFilter = new() { Ei.RewardType.EggsOfProphecy } };
+
+            // Non-seasonal 2->3 whose third reward is PE: PE in the filter matches the last goal.
+            var nonSeasonalPeLast = TestFactsBuilder.Contract().Seasonal(false).HadTwoRewards(true)
+                .Grade(G.GradeC, Ei.RewardType.Gold, Ei.RewardType.Cash, Ei.RewardType.EggsOfProphecy).Build();
+            Assert.AreEqual(RuleOutcome.Pass, rule.Evaluate(TwoOfThree(), nonSeasonalPeLast, peOnly));
+
+            // Seasonal 2->3: PE entry ignored (same EffectiveFilter as RewardFilterRule); PE-only
+            // filter strips to empty -> Pass even though the third reward isn't PE.
+            var seasonalGoldLast = TestFactsBuilder.Contract().Seasonal(true).HadTwoRewards(true)
+                .Grade(G.GradeC, Ei.RewardType.Gold, Ei.RewardType.Cash, Ei.RewardType.Gold).Build();
+            Assert.AreEqual(RuleOutcome.Pass, rule.Evaluate(TwoOfThree(), seasonalGoldLast, peOnly));
+
+            // Seasonal 2->3 with a mixed filter: PE ignored, remaining entries still checked.
+            var mixed = new AssignmentSettings { TwoToThree = true, RewardFilter = new() { Ei.RewardType.EggsOfProphecy, Ei.RewardType.Artifact } };
+            Assert.AreEqual(RuleOutcome.Exclude, rule.Evaluate(TwoOfThree(), seasonalGoldLast, mixed));
+        }
     }
 }

--- a/EGG9000.Test/Assignment/MigrationTests.cs
+++ b/EGG9000.Test/Assignment/MigrationTests.cs
@@ -5,19 +5,21 @@ using EGG9000.Common.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using System.Collections.Generic;
+using System.Linq;
 
 namespace EGG9000.Test.Assignment {
     [TestClass]
     public class MigrationTests {
         [TestMethod]
         [TestCategory("Unit")]
-        public void RewardFilter_LegacyWinsElseMain_NoPe() {
+        public void RewardFilter_LegacyWinsElseMain_KeepsPeFromLegacy() {
             var a = new EggIncAccount {
                 AutoRegisterRewards = new() { Ei.RewardType.EggsOfProphecy, Ei.RewardType.Gold },
                 LeggacyAutoRegisterRewards = new() { Ei.RewardType.Artifact, Ei.RewardType.EggsOfProphecy }
             };
             var s = AssignmentSettingsMigration.FromLegacyKeys(a);
-            CollectionAssert.AreEquivalent(new List<Ei.RewardType> { Ei.RewardType.Artifact }, s.RewardFilter);
+            // PE kept from legacy source (V1 kept it); PE still stripped when falling back to new-contract list
+            CollectionAssert.AreEquivalent(new List<Ei.RewardType> { Ei.RewardType.Artifact, Ei.RewardType.EggsOfProphecy }, s.RewardFilter);
 
             var b = new EggIncAccount { AutoRegisterRewards = new() { Ei.RewardType.Gold }, LeggacyAutoRegisterRewards = new() };
             CollectionAssert.AreEquivalent(new List<Ei.RewardType> { Ei.RewardType.Gold }, AssignmentSettingsMigration.FromLegacyKeys(b).RewardFilter);
@@ -58,6 +60,60 @@ namespace EGG9000.Test.Assignment {
 
             var off = AssignmentSettingsMigration.FromLegacyKeys(new EggIncAccount { DoUnfinishedCollegtibles = false });
             Assert.AreEqual(ForceMode.NotSet, off.Get(PermanentRewardKind.Colleggtible).Mode);
+        }
+
+        // PE re-migration heal in the EggIncAccounts getter (DBUser). Rebuilds the user from the
+        // persisted column so the getter's heal branch actually runs (an in-memory _accounts cache
+        // would short-circuit it).
+        private static DBUser Rehydrate(DBUser source) => new() {
+            _eggIncIds = source._eggIncIds,
+            _contractRegistrationByte = source._contractRegistrationByte
+        };
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void PeHeal_AddsPeOnly_PreservesPostV2Edits_StripsLegacyKey() {
+            var source = new DBUser {
+                EggIncAccounts = new List<EggIncAccount> {
+                    new() {
+                        Id = "EI1",
+                        LeggacyAutoRegisterRewards = new() { Ei.RewardType.Artifact, Ei.RewardType.EggsOfProphecy },
+                        // Post-V2 edit the heal must not clobber.
+                        Assignment = new AssignmentSettings { RewardFilter = new() { Ei.RewardType.Gold } }
+                    }
+                }
+            };
+            var healed = Rehydrate(source).EggIncAccounts.Single();
+
+            CollectionAssert.AreEquivalent(
+                new List<Ei.RewardType> { Ei.RewardType.Gold, Ei.RewardType.EggsOfProphecy },
+                healed.Assignment.RewardFilter);
+            // Legacy key stripped of PE so the heal is one-shot.
+            CollectionAssert.DoesNotContain(healed.LeggacyAutoRegisterRewards, Ei.RewardType.EggsOfProphecy);
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void PeHeal_DoesNotResurrectPeAfterUserRemovesIt() {
+            var source = new DBUser {
+                EggIncAccounts = new List<EggIncAccount> {
+                    new() {
+                        Id = "EI1",
+                        LeggacyAutoRegisterRewards = new() { Ei.RewardType.EggsOfProphecy },
+                        Assignment = new AssignmentSettings { RewardFilter = new() }
+                    }
+                }
+            };
+            var afterHeal = Rehydrate(source);
+            var account = afterHeal.EggIncAccounts.Single();
+            CollectionAssert.Contains(account.Assignment.RewardFilter, Ei.RewardType.EggsOfProphecy);
+
+            // User unticks PE in the new UI; the heal must not re-add it on the next load.
+            account.Assignment.RewardFilter.Remove(Ei.RewardType.EggsOfProphecy);
+            afterHeal.UpdateAccounts();
+
+            var reloaded = Rehydrate(afterHeal).EggIncAccounts.Single();
+            CollectionAssert.DoesNotContain(reloaded.Assignment.RewardFilter, Ei.RewardType.EggsOfProphecy);
         }
 
         [TestMethod]

--- a/EGG9000.Test/Assignment/MigrationTests.cs
+++ b/EGG9000.Test/Assignment/MigrationTests.cs
@@ -94,6 +94,35 @@ namespace EGG9000.Test.Assignment {
 
         [TestMethod]
         [TestCategory("Unit")]
+        public void PeHeal_FreshMigrationBranch_AlsoStripsLegacyKey_NoLaterResurrection() {
+            // Account still on the V1 blob (Assignment == null): FromLegacyKeys keeps PE, and the
+            // one-shot strip must ALSO run on this branch — otherwise the legacy key keeps PE and the
+            // heal fires on a later load, resurrecting PE after the user unticks it.
+            var source = new DBUser {
+                EggIncAccounts = new List<EggIncAccount> {
+                    new() {
+                        Id = "EI1",
+                        LeggacyAutoRegisterRewards = new() { Ei.RewardType.Artifact, Ei.RewardType.EggsOfProphecy },
+                        Assignment = null
+                    }
+                }
+            };
+            var migratedUser = Rehydrate(source);
+            var migrated = migratedUser.EggIncAccounts.Single();
+            CollectionAssert.AreEquivalent(
+                new List<Ei.RewardType> { Ei.RewardType.Artifact, Ei.RewardType.EggsOfProphecy },
+                migrated.Assignment.RewardFilter);
+            CollectionAssert.DoesNotContain(migrated.LeggacyAutoRegisterRewards, Ei.RewardType.EggsOfProphecy);
+
+            // User unticks PE after the fresh migration; it must stay gone on the next load.
+            migrated.Assignment.RewardFilter.Remove(Ei.RewardType.EggsOfProphecy);
+            migratedUser.UpdateAccounts();
+            var reloaded = Rehydrate(migratedUser).EggIncAccounts.Single();
+            CollectionAssert.DoesNotContain(reloaded.Assignment.RewardFilter, Ei.RewardType.EggsOfProphecy);
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
         public void PeHeal_DoesNotResurrectPeAfterUserRemovesIt() {
             var source = new DBUser {
                 EggIncAccounts = new List<EggIncAccount> {


### PR DESCRIPTION
PE filter was removed in the assignment V2 engine, this pr adds it back but only applies it to leggacy contracts. 
The old PE setting every user had set should be auto healed 

Seasonal contracts ignore PE filter completely