### PR TITLE
fix: sync redo sibling account to work with seasonal contracts

### DIFF
--- a/EGG9000.Bot/Commands/ContractSettings.cs
+++ b/EGG9000.Bot/Commands/ContractSettings.cs
@@ -275,11 +275,11 @@ namespace EGG9000.Bot.Commands {
                 RedoLeggacyOption.YesAll => "Yes (Will redo all contracts to help out others)",
                 RedoLeggacyOption.YesNoUltra => "Yes (Will not redo completed Ultra contracts)",
                 RedoLeggacyOption.YesThreshold => $"Yes (If previous score was under {account.Assignment.Redo.ScoreThreshold} score)",
-                RedoLeggacyOption.YesOtherAccountMatch => "Yes (If any other of your accounts get assigned)",
+                RedoLeggacyOption.YesOtherAccountMatch => "Yes (If any other of your accounts get assigned, also applies to seasonal contracts)",
                 RedoLeggacyOption.No => "No (Will still be assigned to incomplete leggacies)",
                 _ => "No (Will still be assigned to incomplete leggacies)"
             };
-            var content = "This option allows you to determine which Leggacy contracts you will redo, when they are offered in-game.\n\n**NOTE:** You will **always** be assigned to incomplete Leggacy contracts, so long as they match your rewards filter.";
+            var content = "This option allows you to determine which Leggacy contracts you will redo, when they are offered in-game. The \"other account matches\" option also applies to Seasonal contracts, forcing this account in whenever a sibling account is force-assigned by the seasonal filter.\n\n**NOTE:** You will **always** be assigned to incomplete Leggacy contracts, so long as they match your rewards filter.";
             return MenuEmbedTemplate("Redo Leggacies Menu", content, account, dbuser)
                 .AddField("Redo Completed Leggacies", redoText)
                 .AddField("Skip Seasonal Replays", account.Assignment.Redo.ExcludeSeasonal ? "ON" : "OFF");

--- a/EGG9000.Common/Contracts/Assignment/Rules/SeasonalRules.cs
+++ b/EGG9000.Common/Contracts/Assignment/Rules/SeasonalRules.cs
@@ -13,12 +13,14 @@ namespace EGG9000.Common.Contracts.Assignment {
                     return RuleOutcome.ForceInclude;
                 case SeasonalMode.UntilPeEarned:
                     if(f.MissingSeasonalPe) return RuleOutcome.ForceInclude;
+                    if(f.SiblingMatchProvisionalInclude) return RuleOutcome.ForceInclude;
                     return r.RewardFilterAfter ? RuleOutcome.NotApplicable : RuleOutcome.Exclude;
                 case SeasonalMode.UntilCsGoal:
                     // Force-assign until the user's CS goal, never below the grade floor, and never below
                     // the season's PE-CS goal (so a goal under the PE threshold cannot skip earning the PE).
                     var goal = System.Math.Max(r.EffectiveCsGoal(f.Grade), f.SeasonalPeCsGoal);
                     if((f.PreviousScoreOnThisContract ?? 0) < goal) return RuleOutcome.ForceInclude;
+                    if(f.SiblingMatchProvisionalInclude) return RuleOutcome.ForceInclude;
                     return r.RewardFilterAfter ? RuleOutcome.NotApplicable : RuleOutcome.Exclude;
                 default:
                     return RuleOutcome.NotApplicable;

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -365,6 +365,9 @@ namespace EGG9000.Site.Controllers {
         public record TestAssignmentModel {
             public int AccountIndex { get; set; }
             public string ContractId { get; set; }
+            // Simulates a sibling account being assigned, for previewing RedoLeggacyOption.YesOtherAccountMatch
+            // (normally only resolved by AssignmentEvaluator.EvaluateUser's two-pass, multi-account run).
+            public bool SimulateSiblingAssigned { get; set; }
         }
 
         [HttpPost]
@@ -389,6 +392,11 @@ namespace EGG9000.Site.Controllers {
             var contractFacts = Common.Contracts.Assignment.ContractFactsBuilder.Build(contract, season);
             var accountFacts = Common.Contracts.Assignment.AccountFactsBuilder.Build(dbuser, account, contract, new List<Coop>(), latest, season, seasonProgresses);
 
+            // Only means anything under YesOtherAccountMatch; on any other redo mode nothing reads the flag.
+            var siblingMatchApplies = m.SimulateSiblingAssigned
+                && (account.Assignment?.Redo?.Mode ?? Common.Helpers.RedoLeggacyOption.NotSet) == Common.Helpers.RedoLeggacyOption.YesOtherAccountMatch;
+            if(siblingMatchApplies) accountFacts.SiblingMatchProvisionalInclude = true;
+
             var dbGuild = _db.CachedGuilds.FirstOrDefault(g => g.Id == dbuser.GuildId);
             var decision = Common.Contracts.Assignment.AssignmentEvaluator.Evaluate(accountFacts, contractFacts, account.Assignment, dbGuild?.RuleOverrides, dbGuild?.DisableBG ?? false, verbose: true);
 
@@ -403,7 +411,8 @@ namespace EGG9000.Site.Controllers {
                     missingColleggtible = accountFacts.MissingColleggtible,
                     previouslyCompleted = accountFacts.PreviouslyCompleted,
                     previousScore = accountFacts.PreviousScoreOnThisContract,
-                    filtersDisabled = dbGuild?.DisableBG ?? false
+                    filtersDisabled = dbGuild?.DisableBG ?? false,
+                    siblingMatchSimulated = siblingMatchApplies
                 },
                 results = decision.Results.Select(r => new {
                     rule = r.Rule.ToString(),

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -831,6 +831,8 @@
                         if (field === 'redoMode') {
                             const wrap = container.querySelector('.cs-redothreshold-wrap-' + accountIndex);
                             if (wrap) wrap.style.display = (value === '2') ? '' : 'none';
+                            const otherMatchWrap = container.querySelector('.cs-redoothermatch-wrap-' + accountIndex);
+                            if (otherMatchWrap) otherMatchWrap.style.display = (value === '4') ? '' : 'none';
                         }
                         saveContractSetting(container, accountIndex, field, value, () => {
                             if (el.type === 'checkbox') el.checked = (before === 'true');
@@ -900,6 +902,7 @@
                     const index = parseInt(btn.dataset.index);
                     const select = document.getElementById('ta-contract-' + index);
                     const result = document.getElementById('ta-result-' + index);
+                    const siblingCheckbox = document.getElementById('ta-sibling-' + index);
                     if (!select || !result) return;
                     // The picker value is "Name (contractId)"; pull the id from the trailing parens.
                     // Fall back to the raw text so a directly-typed id still works.
@@ -912,7 +915,7 @@
                     fetch('/MyFarms/TestAssignment', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ accountIndex: index, contractId: contractId })
+                        body: JSON.stringify({ accountIndex: index, contractId: contractId, simulateSiblingAssigned: !!(siblingCheckbox && siblingCheckbox.checked) })
                     }).then(res => {
                         if (!res.ok) {
                             result.innerHTML = '<span style="color:red;">Test failed (' + res.status + ').</span>';
@@ -945,6 +948,7 @@
             ];
             if (d.previousScore != null) diagParts.push('Prev score: ' + Math.round(d.previousScore).toLocaleString());
             if (d.filtersDisabled) diagParts.push('Filters OFF (server uses roles)');
+            if (d.siblingMatchSimulated) diagParts.push('Sibling match simulated');
             const diag = '<div style="margin:8px 0; font-size:.85em; color:#9aa0a6; line-height:1.6;">' + escapeHtml(diagParts.join('  ·  ')) + '</div>';
 
             const outMeta = {

--- a/EGG9000.Site/Views/MyFarms/_ContractSettings.cshtml
+++ b/EGG9000.Site/Views/MyFarms/_ContractSettings.cshtml
@@ -131,6 +131,12 @@
                         <button type="button" class="btn btn-secondary cs-num-step" data-step="1000" tabindex="-1" @dis>+</button>
                     </div>
                 </div>
+
+                <div class="cs-dependent cs-redoothermatch-wrap-@index" style="margin-top:6px; @(redoMode == (int)RedoLeggacyOption.YesOtherAccountMatch ? "" : "display:none;")">
+                    <p style="font-size:0.82em; color:grey; margin:2px 0 0;">
+                        Also applies to Seasonal contracts: forces this account in whenever a sibling account (same boarding group) is force-assigned by the Seasonal Contracts filter above.
+                    </p>
+                </div>
             </div>
 
             <div class="form-check cs-check" style="margin-top:18px;">

--- a/EGG9000.Site/Views/MyFarms/_TestAssignment.cshtml
+++ b/EGG9000.Site/Views/MyFarms/_TestAssignment.cshtml
@@ -22,6 +22,13 @@
                     }
                 </datalist>
             </div>
+            <div class="form-check" style="margin-top:8px;">
+                <input class="form-check-input ta-sibling-assigned" type="checkbox" id="ta-sibling-@index" />
+                <label class="form-check-label" for="ta-sibling-@index">Simulate a sibling account being assigned</label>
+                <p style="font-size:0.82em; color:grey; margin:2px 0 0;">
+                    Only matters if "Redo leggacies" is set to "if other account matches" — previews whether a sibling getting assigned would pull this account in too (Leggacy redo or Seasonal force-assign).
+                </p>
+            </div>
             <p style="font-size:0.85em; color:grey; margin-top:8px;">Ignores current-round assignment (whether you are already in a co-op).</p>
             <div class="ta-result" id="ta-result-@index" style="margin-top:12px;"></div>
         </div>

--- a/EGG9000.Test/Assignment/TwoPassTests.cs
+++ b/EGG9000.Test/Assignment/TwoPassTests.cs
@@ -57,5 +57,39 @@ namespace EGG9000.Test.Assignment {
             Assert.IsTrue(siblingDecision.Assigned);
             Assert.IsFalse(replayDecision.Assigned, "different boarding group means no sibling match");
         }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void YesOtherAccountMatch_IncludedWhenSiblingForcedBySeasonal() {
+            var contract = TestFactsBuilder.Contract().Seasonal(true).Grade(G.GradeC, Ei.RewardType.Gold).Build();
+
+            // The replay account: seasonal goal already met (Force tier would Exclude it outright),
+            // group 1, opted into YesOtherAccountMatch.
+            var replay = TestFactsBuilder.Account().AccountId("replay").Grade(G.GradeC).BoardingGroup(1)
+                .MissingSeasonalPe(false).Build();
+            var replaySettings = new AssignmentSettings {
+                Redo = new RedoRule { Mode = RedoLeggacyOption.YesOtherAccountMatch },
+                Seasonal = new SeasonalRule { Mode = SeasonalMode.UntilPeEarned, RewardFilterAfter = false }
+            };
+
+            // The sibling: still missing seasonal PE -> force-assigned in pass 1, same grade + group.
+            var sibling = TestFactsBuilder.Account().AccountId("sibling").Grade(G.GradeC).BoardingGroup(1)
+                .MissingSeasonalPe(true).Build();
+            var siblingSettings = new AssignmentSettings {
+                Seasonal = new SeasonalRule { Mode = SeasonalMode.UntilPeEarned }
+            };
+
+            var inputs = new List<(AccountFacts, AssignmentSettings)> {
+                (replay, replaySettings),
+                (sibling, siblingSettings)
+            };
+
+            var results = AssignmentEvaluator.EvaluateUser(inputs, contract);
+            var replayDecision = results.First(r => r.facts.AccountId == "replay").decision;
+            var siblingDecision = results.First(r => r.facts.AccountId == "sibling").decision;
+
+            Assert.IsTrue(siblingDecision.Assigned, "sibling should be force-assigned by the seasonal rule");
+            Assert.IsTrue(replayDecision.Assigned, "replay should be pulled in by the seasonal-forced sibling");
+        }
     }
 }


### PR DESCRIPTION
Other account match option now force assigns account if option is selected and a sibling account gets assigned. 
Added in the option to test this directly on the site