### PR TITLE
fix: attempt to fix left users showing as active

### DIFF
--- a/EGG9000.Bot/Automated/ManageOverflow.cs
+++ b/EGG9000.Bot/Automated/ManageOverflow.cs
@@ -58,14 +58,25 @@ namespace EGG9000.Bot.Automated {
                 }
 
                 // Re-associate any registered user who is present in this server but whose GuildId is unset.
-                // Presence is reliable even on a partial cache (only absence is not), so this is safe to run
-                // unconditionally. Covers both LastGuild-trail returns and the no-trail users that earlier
-                // zeroing left with GuildId = 0 and no record of their original guild.
-                var returned = users.Where(x => x.GuildId == 0 && mainServer.GetUser(x.DiscordId) is not null).Select(x => x.Id).ToList();
-                var membersReturn = await _db.DBUsers.Where(x => returned.Contains(x.Id)).ToListAsync(CancellationToken.None);
+                // The gateway cache can be wrong in this direction too (a stale add that never got
+                // evicted by a missed/delayed remove), so, same as the departure check above, each
+                // candidate is confirmed with a live REST lookup before being written back, instead of
+                // trusting the cache snapshot on its own. Covers both LastGuild-trail returns and the
+                // no-trail users that earlier zeroing left with GuildId = 0 and no record of their
+                // original guild.
+                var returnCandidates = users.Where(x => x.GuildId == 0 && mainServer.GetUser(x.DiscordId) is not null).ToList();
+                var confirmedReturned = new List<Guid>();
+                foreach(var candidate in returnCandidates) {
+                    var restUser = await _client.Rest.GetGuildUserAsync(guild.DiscordSeverId, candidate.DiscordId);
+                    if(restUser is not null)
+                        confirmedReturned.Add(candidate.Id);
+                    StillAlive();
+                }
+
+                var membersReturn = await _db.DBUsers.Where(x => confirmedReturned.Contains(x.Id)).ToListAsync(CancellationToken.None);
                 membersReturn.ForEach(x => {
                     x.GuildId = guild.Id;
-                    _logger.LogInformation("Re-associating member {name} to guild {guild} (present in server, GuildId was unset)", x.DiscordUsername, guild.Name);
+                    _logger.LogInformation("Re-associating member {name} to guild {guild} (present in server, GuildId was unset, REST-confirmed)", x.DiscordUsername, guild.Name);
                     StillAlive();
                 });
 

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -1395,29 +1395,19 @@ music
 
         public async Task<IActionResult> NonServerUsers() {
             var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
-            var guild = _discord.Guilds.First(x => x.Id == guildId);
-            await guild.DownloadUsersAsync();
-
-            // A partial roster cannot tell "left" from "not yet downloaded"; refuse to list
-            // so staff never unassign a real member during an incomplete cache.
-            if(!guild.HasAllMembers) {
-                return View((new List<DBUser>(), true));
-            }
-
-            var memberIds = guild.Users.Select(u => u.Id).ToHashSet();
 
             var candidates = await _db.DBUsers
                 .Where(u => u.GuildId == guildId)
                 .Select(u => new { u.Id, u.DiscordId, u.DiscordUsername, u._eggIncIds, u._contractRegistrationByte })
                 .ToListAsync();
 
+            // The gateway member cache (both the WS cache and this Site's own separate client) can be
+            // wrong in either direction, stale-present after a missed departure, or stale-absent right
+            // after a join, so it's not consulted at all here. REST is authoritative and bypasses both
+            // caches; every candidate is decided by it directly instead of only falling back to it when
+            // the cache claims someone is already gone.
             var rows = new List<DBUser>();
             foreach(var u in candidates) {
-                if(memberIds.Contains(u.DiscordId)) continue;
-
-                // Gateway member cache can lag or miss a departure (Site runs its own
-                // long-lived client independent of the bot). Confirm via REST, which
-                // bypasses the cache, before treating someone as gone.
                 var restUser = await _discord.Rest.GetGuildUserAsync(guildId, u.DiscordId);
                 if(restUser != null) continue;
 


### PR DESCRIPTION
added in REST checks to confirm a user has joined before changing the guild id in db. 
Without the logs to confirm, this is just a guess fix 