### PR TITLE
Hotfix: seasonal filter, non server user and coop message

### DIFF
--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -455,12 +455,12 @@ namespace EGG9000.Bot.Automated.Coops {
                 if(!coop.FinalizedFinishedOrFailed()) {
                     await CheckHighestEBJoined(coop, usersWithStatus, coopDetails, coopThread, _db, usersNotJoined);
 
-                    if(!coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
+                    if(!status.Finished && !coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
                         coop.ProjectedToFinish = true;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!"));
                     }
 
-                    if(status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
+                    if(!status.Finished && status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
                         coop.ProjectedToFinish = false;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish."));
                     }

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -452,15 +452,16 @@ namespace EGG9000.Bot.Automated.Coops {
 
 
                 var waitingOn = usersWithStatus.Where(x => !x.Status?.Finalized ?? false);
+                var isFinished = coop.Finished || status.Finished();
                 if(!coop.FinalizedFinishedOrFailed()) {
                     await CheckHighestEBJoined(coop, usersWithStatus, coopDetails, coopThread, _db, usersNotJoined);
 
-                    if(!status.Finished && !coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
+                    if(!isFinished && !coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined >= 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
                         coop.ProjectedToFinish = true;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is now projected to finish!"));
                     }
 
-                    if(!status.Finished && status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
+                    if(!isFinished && status.SecondsRemaining > 1 && coop.ProjectedToFinish && coopDetails.PercentProjectedForJoined < 100 && coop.CoopEnds > DateTimeOffset.UtcNow) {
                         coop.ProjectedToFinish = false;
                         _queue.EnqueueLow(() => coopThread.SendMessageAsync($"Coop {coop.Name} is **no longer** projected to finish."));
                     }

--- a/EGG9000.Common/Contracts/Assignment/Rules/SeasonalRules.cs
+++ b/EGG9000.Common/Contracts/Assignment/Rules/SeasonalRules.cs
@@ -8,8 +8,13 @@ namespace EGG9000.Common.Contracts.Assignment {
         public bool AppliesTo(ContractFacts c) => c.IsSeasonal;
         public RuleOutcome Evaluate(AccountFacts f, ContractFacts c, AssignmentSettings s) {
             var r = s.Seasonal ?? new SeasonalRule();
+            var redo = s.Redo ?? new RedoRule();
             switch(r.Mode) {
                 case SeasonalMode.AlwaysAssign:
+                    // Skip-seasonal-replays carve-out: Force tier short-circuits before the Include tier's
+                    // PreviouslyCompletedRule ever runs, so that carve-out must be honored here too, else
+                    // AlwaysAssign force-includes previously-completed seasonal contracts unconditionally.
+                    if(redo.ExcludeSeasonal && (f.PreviouslyCompleted || f.CompletedExactlyTwoGoals)) return RuleOutcome.Exclude;
                     return RuleOutcome.ForceInclude;
                 case SeasonalMode.UntilPeEarned:
                     if(f.MissingSeasonalPe) return RuleOutcome.ForceInclude;
@@ -27,7 +32,7 @@ namespace EGG9000.Common.Contracts.Assignment {
             }
         }
         public string Describe(RuleOutcome o) => o == RuleOutcome.Exclude
-            ? "Seasonal goal met (not assigned)"
+            ? "Seasonal goal met or already completed (not assigned)"
             : "Seasonal contract (force assign)";
     }
 }

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -1395,28 +1395,39 @@ music
 
         public async Task<IActionResult> NonServerUsers() {
             var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
+            var guild = _discord.Guilds.First(x => x.Id == guildId);
+            await guild.DownloadUsersAsync();
+
+            // A partial roster cannot tell "left" from "not yet downloaded"; refuse to list so
+            // staff never unassign a real member during an incomplete cache.
+            if(!guild.HasAllMembers) {
+                return View((new List<DBUser>(), true));
+            }
+
+            var memberIds = guild.Users.Select(u => u.Id).ToHashSet();
 
             var candidates = await _db.DBUsers
                 .Where(u => u.GuildId == guildId)
                 .Select(u => new { u.Id, u.DiscordId, u.DiscordUsername, u._eggIncIds, u._contractRegistrationByte })
                 .ToListAsync();
 
-            // The gateway member cache (both the WS cache and this Site's own separate client) can be
-            // wrong in either direction, stale-present after a missed departure, or stale-absent right
-            // after a join, so it's not consulted at all here. REST is authoritative and bypasses both
-            // caches; every candidate is decided by it directly instead of only falling back to it when
-            // the cache claims someone is already gone.
-            var rows = new List<DBUser>();
-            foreach(var u in candidates) {
-                var restUser = await _discord.Rest.GetGuildUserAsync(guildId, u.DiscordId);
-                if(restUser != null) continue;
-
-                var row = DBUser.FromAccountColumns(u._eggIncIds, u._contractRegistrationByte);
-                row.Id = u.Id;
-                row.DiscordId = u.DiscordId;
-                row.DiscordUsername = u.DiscordUsername;
-                rows.Add(row);
-            }
+            // REST-authoritative reconciliation (bypassing gateway-cache staleness in either
+            // direction) already runs here every ~5.6min via ManageOverflow, which writes the
+            // confirmed GuildId back to the DB. So the cache only needs to be right within that
+            // window, not on every page load — checking ~3000 candidates against Discord's REST
+            // API one guild-member lookup apiece blew way past the reverse proxy's timeout
+            // (502/504). The in-memory cache check below is instant and self-heals on the next
+            // background pass.
+            var rows = candidates
+                .Where(u => !memberIds.Contains(u.DiscordId))
+                .Select(u => {
+                    var row = DBUser.FromAccountColumns(u._eggIncIds, u._contractRegistrationByte);
+                    row.Id = u.Id;
+                    row.DiscordId = u.DiscordId;
+                    row.DiscordUsername = u.DiscordUsername;
+                    return row;
+                })
+                .ToList();
 
             return View((rows, false));
         }

--- a/EGG9000.Test/Assignment/SeasonalRuleTests.cs
+++ b/EGG9000.Test/Assignment/SeasonalRuleTests.cs
@@ -1,4 +1,5 @@
 using EGG9000.Common.Contracts.Assignment;
+using EGG9000.Common.Helpers;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -21,6 +22,30 @@ namespace EGG9000.Test.Assignment {
             var c = TestFactsBuilder.Contract().Seasonal(true).Build();
             var f = TestFactsBuilder.Account().MissingSeasonalPe(false).Build();
             Assert.AreEqual(RuleOutcome.ForceInclude, new SeasonalContractsRule().Evaluate(f, c, With(SeasonalMode.AlwaysAssign)));
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void AlwaysAssign_ExcludeSeasonal_PreviouslyCompleted_Excludes() {
+            var c = TestFactsBuilder.Contract().Seasonal(true).Build();
+            var f = TestFactsBuilder.Account().PreviouslyCompleted(true).Build();
+            var s = new AssignmentSettings {
+                Seasonal = new SeasonalRule { Mode = SeasonalMode.AlwaysAssign },
+                Redo = new RedoRule { Mode = RedoLeggacyOption.No, ExcludeSeasonal = true }
+            };
+            Assert.AreEqual(RuleOutcome.Exclude, new SeasonalContractsRule().Evaluate(f, c, s));
+        }
+
+        [TestMethod]
+        [TestCategory("Unit")]
+        public void AlwaysAssign_ExcludeSeasonal_NotCompleted_StillForces() {
+            var c = TestFactsBuilder.Contract().Seasonal(true).Build();
+            var f = TestFactsBuilder.Account().PreviouslyCompleted(false).Build();
+            var s = new AssignmentSettings {
+                Seasonal = new SeasonalRule { Mode = SeasonalMode.AlwaysAssign },
+                Redo = new RedoRule { Mode = RedoLeggacyOption.No, ExcludeSeasonal = true }
+            };
+            Assert.AreEqual(RuleOutcome.ForceInclude, new SeasonalContractsRule().Evaluate(f, c, s));
         }
 
         [TestMethod]


### PR DESCRIPTION
reverted changes to the non server user page since ManageOverflow is now the authority on if someone is in a server. 
Check if coop status is finished before we send the projected to finish messages. 
exclude account based on skip seasonal replay setting since it was ignored when seasonal contract filter was "Always Assign" 