### PR TITLE
fix: DB threading, command registration regressions

### DIFF
--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -200,6 +200,12 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 timings.Set("GetStatus");
 
+                // GetStatus and the EggIncApi calls further below (join/kick retry, creator-still-in
+                // check) are network-only stretches with no _db access in between. Release the pooled
+                // connection for their duration instead of holding it open-but-idle; EF reopens it
+                // lazily on the next _db access (GetCustomEggsAsync below).
+                await _db.Database.CloseConnectionAsync();
+
                 var statusReponse = new StatusResponse();
                 try {
                     statusReponse = await GetStatus(coop, coopThread, cancellationToken);

--- a/EGG9000.Bot/Automated/EventUpdater.cs
+++ b/EGG9000.Bot/Automated/EventUpdater.cs
@@ -37,6 +37,9 @@ namespace EGG9000.Bot.Automated {
         public async override Task Run(object state, CancellationToken cancellationToken) {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
+            // CheckShells and GetPeriodicalsAsync are network-only; release the pooled connection while
+            // they're in flight instead of holding it open-but-idle. EF reopens it lazily on next _db access.
+            await _db.Database.CloseConnectionAsync();
             await CheckShells(_db);
 
             var response = await EggIncApi.GetPeriodicalsAsync();

--- a/EGG9000.Bot/Automated/HandleGradeChanges.cs
+++ b/EGG9000.Bot/Automated/HandleGradeChanges.cs
@@ -1,5 +1,6 @@
 ﻿using Cronos;
 using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
 using EGG9000.Common.EggIncAPI;
 using EGG9000.Common.Helpers;
 using Ei;
@@ -31,7 +32,7 @@ namespace EGG9000.Bot.Automated {
                 await Parallel.ForEachAsync(userchunk, new ParallelOptions { MaxDegreeOfParallelism = 3 }, async (user, token) => {
                     try {
                         var userMutated = false;
-                        foreach(var account in user.EggIncAccounts.Where(x => !string.IsNullOrEmpty(x.Id) && x.Id.StartsWith("EI") && x.LastGrade != Contract.Types.PlayerGrade.GradeUnset)) {
+                        foreach(var account in user.EggIncAccounts.Where(x => !string.IsNullOrEmpty(x.Id) && x.Id.StartsWith("EI") && x.LastGrade != Ei.Contract.Types.PlayerGrade.GradeUnset)) {
                             var r = await EggIncApi.Post<ContractPlayerInfo, BasicRequestInfo>(new BasicRequestInfo(), account.Id);
                             if(r is null) {
                                 _logger.LogWarning("Null response for {user} ({account})", user.DiscordUsername, account.Id);

--- a/EGG9000.Bot/Automated/HandleGradeChanges.cs
+++ b/EGG9000.Bot/Automated/HandleGradeChanges.cs
@@ -7,6 +7,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,14 +17,20 @@ namespace EGG9000.Bot.Automated {
     public class HandleGradeChanges(IServiceProvider provider) : _UpdaterBase<HandleGradeChanges>(CronExpression.Parse("30 10,18,23 * * 1,3,5"), provider) {
 
         public async override Task Run(object state, CancellationToken cancellationToken) {
-            var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            List<DBUser> users;
+            using(var lookupScope = _provider.CreateScope()) {
+                var lookupDb = lookupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                users = await lookupDb.DBUsers.AsNoTracking().Where(x => x.GuildId == 656455567858073601).ToListAsync(CancellationToken.None);
+            }
 
-            var users = await _db.DBUsers.Where(x => x.GuildId == 656455567858073601).ToListAsync(CancellationToken.None);
             var chunkedUsers = users.Chunk(25);
             foreach(var userchunk in chunkedUsers) {
                 StillAlive();
+                var mutatedUsers = new ConcurrentBag<DBUser>();
+                // Network calls only below - no DB scope held while awaiting EggIncApi.
                 await Parallel.ForEachAsync(userchunk, new ParallelOptions { MaxDegreeOfParallelism = 3 }, async (user, token) => {
                     try {
+                        var userMutated = false;
                         foreach(var account in user.EggIncAccounts.Where(x => !string.IsNullOrEmpty(x.Id) && x.Id.StartsWith("EI") && x.LastGrade != Contract.Types.PlayerGrade.GradeUnset)) {
                             var r = await EggIncApi.Post<ContractPlayerInfo, BasicRequestInfo>(new BasicRequestInfo(), account.Id);
                             if(r is null) {
@@ -30,14 +38,22 @@ namespace EGG9000.Bot.Automated {
                                 continue;
                             }
                             if(r.Status == ContractPlayerInfo.Types.Status.Complete)
-                                GradeSync.ApplyGradeChange(user, account, r.Grade, setPromotionTime: true, guardUnset: true, _logger);
+                                userMutated |= GradeSync.ApplyGradeChange(user, account, r.Grade, setPromotionTime: true, guardUnset: true, _logger);
                         }
+                        if(userMutated) mutatedUsers.Add(user);
                     } catch(Exception e) {
                         _bugSnag.Notify(e);
                         _logger.LogError(e, "Error checking for grade update for {user}", user.DiscordUsername);
                     }
                 });
-                await _db.SaveChangesAsync(CancellationToken.None);
+
+                if(mutatedUsers.IsEmpty) continue;
+                using var saveScope = _provider.CreateScope();
+                var saveDb = saveScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                foreach(var user in mutatedUsers) {
+                    await saveDb.DBUsers.Where(c => c.Id == user.Id).ExecuteUpdateAsync(s => s
+                        .SetProperty(c => c._contractRegistrationByte, user._contractRegistrationByte), CancellationToken.None);
+                }
             }
         }
     }

--- a/EGG9000.Bot/Automated/NewContracts.cs
+++ b/EGG9000.Bot/Automated/NewContracts.cs
@@ -40,6 +40,9 @@ namespace EGG9000.Bot.Automated {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var needsUpdate = false;
 
+            // GetPeriodicalsAsync is network-only; release the pooled connection while it's in flight
+            // instead of holding it open-but-idle. EF reopens it lazily on the next _db access below.
+            await _db.Database.CloseConnectionAsync();
             var contractsResponse = await EggIncApi.GetPeriodicalsAsync();
 
             if(contractsResponse == null) {
@@ -342,6 +345,9 @@ namespace EGG9000.Bot.Automated {
                 _logger.LogInformation("{guild} BG{bg}, Grade {grade}, Count {count} for Contract {contract}", guild.Name, group.bg, group.Grade, group.PotentialCoops.Count(x => x.Users.Count > 2), contract.Name);
                 var coopsToCreate = group.PotentialCoops.Where(x => x.Users.Count > 1);
 
+                // CreateCoopsV2.Start opens its own short-lived scope per coop; this outer _db is unused
+                // during the parallel batch, so release its pooled connection instead of holding it open.
+                await _db.Database.CloseConnectionAsync();
                 await Parallel.ForEachAsync(coopsToCreate, new ParallelOptions { MaxDegreeOfParallelism = 10 }, async (coop, token) => {
                     try {
                         await CreateCoopsV2.Start(coop.Users, contract, group.Grade, guild, _words, _provider, dbguild, (uint)skipbg + 1, contract.cc_only);

--- a/EGG9000.Bot/Automated/UpdateBackups.cs
+++ b/EGG9000.Bot/Automated/UpdateBackups.cs
@@ -41,6 +41,12 @@ namespace EGG9000.Bot.Automated {
             var discoveredContractDefs = new System.Collections.Concurrent.ConcurrentDictionary<string, Ei.Contract>();
             var knownContractIds = cachedContracts.Select(c => c.Identifier).ToHashSet();
 
+            // UpdateUser is network-only (EggIncApi calls, in-memory mutation of tracked entities) and
+            // never touches _db, so release the pooled connection for the whole parallel phase instead
+            // of holding it open-but-idle across up to 8 concurrent EggIncApi round-trips. EF reopens it
+            // lazily on the next _db access (SaveChangesAsync below).
+            await _db.Database.CloseConnectionAsync();
+
             foreach(var user in usersToCheck) {
                 await throttler.WaitAsync(cancellationToken);
                 tasks.Add(Task.Run(async () => {

--- a/EGG9000.Bot/Automated/UserCxpUpdater.cs
+++ b/EGG9000.Bot/Automated/UserCxpUpdater.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -20,27 +21,32 @@ namespace EGG9000.Bot.Automated {
             : CronExpression.Parse("0 9 * * MON,WED,FRI");
 
         public async override Task Run(object state, CancellationToken cancellationToken) {
-            var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            //Get a list of all users that are a part of a guild
-            var users = BuildConfig.IsDebug
-                ? await _db.DBUsers.AsQueryable().Where(x => x.DiscordId == 273621777119313921).ToListAsync(CancellationToken.None)
-                : await _db.DBUsers.AsQueryable().Where(x => x.GuildId > 0).ToListAsync(CancellationToken.None);
+            List<DBUser> users;
+            List<UserCsHistoryEntry> existingScores;
+            using(var lookupScope = _provider.CreateScope()) {
+                var lookupDb = lookupScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                //Get a list of all users that are a part of a guild
+                users = BuildConfig.IsDebug
+                    ? await lookupDb.DBUsers.AsNoTracking().Where(x => x.DiscordId == 273621777119313921).ToListAsync(CancellationToken.None)
+                    : await lookupDb.DBUsers.AsNoTracking().Where(x => x.GuildId > 0).ToListAsync(CancellationToken.None);
+
+                _logger.LogInformation("Getting scores");
+                existingScores = await lookupDb.UserCsHistoryEntries.AsNoTracking().ToListAsync(CancellationToken.None);
+                _logger.LogInformation("Finished Getting scores");
+            }
 
             //Loop through each user in the DB
             var chunkSize = 25;
             var count = 0;
             var userChunks = users.Chunk(chunkSize);
-            var random = new Random();
-            var userIDs = users.SelectMany(x => x.EggIncAccounts.Select(y => y.Id)).OrderBy(x => random.Next()).ToList();
-            _logger.LogInformation("Getting scores");
-            var existingScores = await _db.UserCsHistoryEntries.ToListAsync(CancellationToken.None);
-            _logger.LogInformation("Finished Getting scores");
             foreach(var userchunk in userChunks) {
                 await WaitOnCoopsBeingCreated(cancellationToken);
                 if(cancellationToken.IsCancellationRequested) break;
                 StillAlive();
-                var scoresToAdd = new List<UserCsHistoryEntry>();
+                var scoresToAdd = new ConcurrentBag<UserCsHistoryEntry>();
+                var scoresToUpdate = new ConcurrentBag<(string ContractIdentifier, string CoopIdentifier, string EggIncId, double Cxp)>();
                 var skipped = 0;
+                // Network calls only below - no DB scope held while awaiting EggIncApi.
                 await Parallel.ForEachAsync(userchunk, new ParallelOptions { MaxDegreeOfParallelism = 3, CancellationToken = cancellationToken }, async (user, cancellationToken) => {
                     //Loop through each account of the user
                     foreach(var account in user.EggIncAccounts.Where(x => x.LastGrade != Ei.Contract.Types.PlayerGrade.GradeUnset)) {
@@ -72,8 +78,7 @@ namespace EGG9000.Bot.Automated {
                                     //If it does, update the score and coop name, and bump Created so a
                                     //changed score (e.g. a later replay observed under the same coop
                                     //identifier) still sorts as the most recent play.
-                                    existingScore.Cxp = score.Evaluation.Cxp;
-                                    existingScore.Created = DateTimeOffset.UtcNow;
+                                    scoresToUpdate.Add((score.Contract.Identifier, coopIdentifier, account.Id, score.Evaluation.Cxp));
                                 }
                             }
                         } catch(Exception ex) {
@@ -82,11 +87,21 @@ namespace EGG9000.Bot.Automated {
                         }
                     }
                 });
-                _db.UserCsHistoryEntries.AddRange(scoresToAdd);
-                await _db.SaveChangesAsync(CancellationToken.None);
+
+                using(var saveScope = _provider.CreateScope()) {
+                    var saveDb = saveScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                    saveDb.UserCsHistoryEntries.AddRange(scoresToAdd);
+                    foreach(var update in scoresToUpdate) {
+                        await saveDb.UserCsHistoryEntries
+                            .Where(x => x.ContractIdentifier == update.ContractIdentifier && x.CoopIdentifier == update.CoopIdentifier && x.EggIncId == update.EggIncId)
+                            .ExecuteUpdateAsync(s => s
+                                .SetProperty(x => x.Cxp, update.Cxp)
+                                .SetProperty(x => x.Created, DateTimeOffset.UtcNow), CancellationToken.None);
+                    }
+                    await saveDb.SaveChangesAsync(CancellationToken.None);
+                }
                 _logger.LogInformation("Saving Changes {count}/{total}, skipped {skipped}", (++count * chunkSize), users.Count, skipped);
             }
-            await _db.SaveChangesAsync(CancellationToken.None);
         }
     }
 }

--- a/EGG9000.Bot/Automated/UserGrades.cs
+++ b/EGG9000.Bot/Automated/UserGrades.cs
@@ -31,12 +31,19 @@ namespace EGG9000.Bot.Automated {
                 tasks.Add(Task.Run(async () => {
                     foreach(var account in user.EggIncAccounts) {
                         try {
+                            // Network call first, with no DB scope held open across the round-trip.
+                            var info = await AccountRefresh.FetchExtrasAsync(user, account, _logger);
+
                             using var scope = _provider.CreateScope();
                             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
-                            if(await AccountRefresh.ApplyExtrasAsync(user, account, db, _logger, CancellationToken.None)) {
-                                await db.DBUsers.Where(c => c.Id == user.Id).ExecuteUpdateAsync(s => s
-                                    .SetProperty(c => c._contractRegistrationByte, user._contractRegistrationByte));
+                            if(info is not null) {
+                                var mutated = AccountRefresh.ApplyExtras(user, account, info, _logger);
+                                await AccountRefresh.UpsertSeasonProgress(account.Id, info.SeasonProgress, db, CancellationToken.None);
+                                if(mutated) {
+                                    await db.DBUsers.Where(c => c.Id == user.Id).ExecuteUpdateAsync(s => s
+                                        .SetProperty(c => c._contractRegistrationByte, user._contractRegistrationByte));
+                                }
                             }
                             await db.SaveChangesAsync(CancellationToken.None);
                         } catch(Exception ex) {

--- a/EGG9000.Bot/Commands/AdminStatusModule.cs
+++ b/EGG9000.Bot/Commands/AdminStatusModule.cs
@@ -245,7 +245,7 @@ namespace EGG9000.Bot.Commands {
         }
 
         [SlashCommand("sysload", "System load: runtime, Discord, DB, process (health-colored)")]
-        [StaffOnly(StaffTier.Admin)]
+        [StaffOnly(StaffTier.FarmHand)]
         public async Task SysLoad(
             [Summary("refreshseconds", "Auto-refresh every N seconds (1-30, stops after 30s total)")] int refreshseconds = 0,
             [Summary("showinchannel", "Post visibly in the channel instead of only to you")] bool showinchannel = false) {

--- a/EGG9000.Bot/Commands/BanCommands.cs
+++ b/EGG9000.Bot/Commands/BanCommands.cs
@@ -92,7 +92,12 @@ namespace EGG9000.Bot.Commands {
         }
     }
 
-    public partial class AdminGroupModule {
+    // Flat (non-grouped) command. Was a top-level /kick before the Discord.NET migration and was
+    // incorrectly nested under /admin in that migration - kept flat here to preserve the
+    // pre-migration command name.
+    public class KickModule(IDbContextFactory<ApplicationDbContext> dbFactory, DiscordHostedService client) : Interactions.E9KModuleBase(dbFactory) {
+        private readonly DiscordHostedService _client = client;
+
         [SlashCommand("kick", "Kick user(s) with DM")]
         [DefaultMemberPermissions(GuildPermission.Administrator | GuildPermission.ManageChannels | GuildPermission.ManageRoles)]
         [Interactions.StaffOnly(Interactions.StaffTier.Admin)]

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -1025,7 +1025,14 @@ namespace EGG9000.Bot.Commands {
         }
     }
 
-    public partial class AdminGroupModule {
+    // Flat (non-grouped) staff commands. These were top-level /commands before the Discord.NET
+    // migration and were incorrectly nested under /admin in that migration - kept flat here to
+    // preserve the pre-migration command names.
+    [DefaultMemberPermissions(GuildPermission.Administrator | GuildPermission.ManageChannels | GuildPermission.ManageRoles)]
+    [StaffOnly(StaffTier.Admin)]
+    public partial class ContractStaffModule(IDbContextFactory<ApplicationDbContext> dbFactory, ILogger<ContractStaffModule> logger, DiscordSocketClient gateway) : E9KModuleBase(dbFactory) {
+        private readonly ILogger<ContractStaffModule> _logger = logger;
+
         [SlashCommand("makeprivate", "Makes this co-op private")]
         public async Task MakePrivate() {
             await Context.Interaction.DeferAsync();

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -280,38 +280,6 @@ namespace EGG9000.Bot.Commands {
             await Context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Co-op renamed to {correctcoopname}");
         }
 
-        [SlashCommand("updatechannel", "Trigger an update for a co-op or contract channel")]
-        [DefaultMemberPermissions(GuildPermission.ManageChannels)]
-        [Interactions.StaffOnly(Interactions.StaffTier.CluckingCoordinator)]
-        public async Task UpdateChannel() {
-            var command = Context.Interaction;
-            await command.DeferAsync(ephemeral: true);
-            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
-            if(targetCoop != null) {
-                await command.ModifyOriginalResponseAsync(x => x.Content = "Updating coop...");
-                var guild = gateway.Guilds.First(x => x.Id == targetCoop.OverflowGuildId);
-                var users = await Db.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == targetCoop.Id)).ToListAsync();
-                var dbguild = await Db.Guilds.AsQueryable().FirstAsync(x => x.Id == targetCoop.GuildId);
-                var parentGuild = gateway.Guilds.First(x => x.Id == dbguild.Id);
-                await coopStatusUpdaterThreads.ProcessCoop(targetCoop.Id, guild, parentGuild, [.. users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x }))], dbguild, default);
-
-                await command.ModifyOriginalResponseAsync(m => m.Content = "Co-op Updated");
-                return;
-            }
-
-            var targetGuildContract = await Db.GuildContracts.Include(x => x.Contract).AsQueryable().FirstOrDefaultAsync(x => x.DiscordChannelId == command.Channel.Id);
-            if(targetGuildContract != null) {
-                await command.ModifyOriginalResponseAsync(x => x.Content = "Updating contract...");
-                var guild = gateway.Guilds.First(x => x.Id == targetGuildContract.GuildID);
-                var dbguild = await Db.Guilds.AsQueryable().FirstAsync(x => x.Id == guild.Id);
-                await contractUpdater.UpdateContractChannel(Db, targetGuildContract, guild, dbguild, command);
-                await command.ModifyOriginalResponseAsync(x => x.Content = "Content Updated");
-                return;
-            }
-
-            await command.ModifyOriginalResponseAsync(x => x.Embed = EmbedError($"Command only works in contract or co-op channels"));
-        }
-
         [SlashCommand("temprole", "Adds a temporary role for users that last a specific amount of time")]
         [DefaultMemberPermissions(GuildPermission.ManageChannels)]
         [Interactions.StaffOnly(Interactions.StaffTier.CluckingCoordinator)]
@@ -358,6 +326,43 @@ namespace EGG9000.Bot.Commands {
             await Db.SaveChangesAsync();
 
             await Context.Interaction.ModifyOriginalResponseAsync(m => m.Content = $"Added the role {role.Emoji} {role.Name} to the following {"user".ToQuantity(users.Length, ShowQuantityAs.None)} {string.Join(", ", users.Select(x => x.Mention))} until <t:{expireTime.ToUnixTimeSeconds()}:f> for the reason: {reason}");
+        }
+    }
+
+    // Flat (non-grouped) command. Was a top-level /updatechannel before the Discord.NET migration
+    // and was incorrectly nested under /a in that migration - kept flat here to preserve the
+    // pre-migration command name.
+    [DefaultMemberPermissions(GuildPermission.ManageChannels)]
+    [Interactions.StaffOnly(Interactions.StaffTier.CluckingCoordinator)]
+    public class UpdateChannelModule(IDbContextFactory<ApplicationDbContext> dbFactory, DiscordSocketClient gateway, ThreadsCoopStatusUpdater coopStatusUpdaterThreads, ContractUpdater contractUpdater) : Interactions.E9KModuleBase(dbFactory) {
+        [SlashCommand("updatechannel", "Trigger an update for a co-op or contract channel")]
+        public async Task UpdateChannel() {
+            var command = Context.Interaction;
+            await command.DeferAsync(ephemeral: true);
+            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
+            if(targetCoop != null) {
+                await command.ModifyOriginalResponseAsync(x => x.Content = "Updating coop...");
+                var guild = gateway.Guilds.First(x => x.Id == targetCoop.OverflowGuildId);
+                var users = await Db.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == targetCoop.Id)).ToListAsync();
+                var dbguild = await Db.Guilds.AsQueryable().FirstAsync(x => x.Id == targetCoop.GuildId);
+                var parentGuild = gateway.Guilds.First(x => x.Id == dbguild.Id);
+                await coopStatusUpdaterThreads.ProcessCoop(targetCoop.Id, guild, parentGuild, [.. users.SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x }))], dbguild, default);
+
+                await command.ModifyOriginalResponseAsync(m => m.Content = "Co-op Updated");
+                return;
+            }
+
+            var targetGuildContract = await Db.GuildContracts.Include(x => x.Contract).AsQueryable().FirstOrDefaultAsync(x => x.DiscordChannelId == command.Channel.Id);
+            if(targetGuildContract != null) {
+                await command.ModifyOriginalResponseAsync(x => x.Content = "Updating contract...");
+                var guild = gateway.Guilds.First(x => x.Id == targetGuildContract.GuildID);
+                var dbguild = await Db.Guilds.AsQueryable().FirstAsync(x => x.Id == guild.Id);
+                await contractUpdater.UpdateContractChannel(Db, targetGuildContract, guild, dbguild, command);
+                await command.ModifyOriginalResponseAsync(x => x.Content = "Content Updated");
+                return;
+            }
+
+            await command.ModifyOriginalResponseAsync(x => x.Embed = EmbedError($"Command only works in contract or co-op channels"));
         }
     }
 }

--- a/EGG9000.Bot/Commands/Ping.cs
+++ b/EGG9000.Bot/Commands/Ping.cs
@@ -23,8 +23,7 @@ namespace EGG9000.Bot.Commands {
 
             var gitVersion = string.Empty;
 
-            using(var stream = Assembly.GetExecutingAssembly()
-                    .GetManifestResourceStream("EGG9000.Bot.version.txt"))
+            using(var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("EGG9000.Bot.version.txt"))
             using(var reader = new StreamReader(stream)) {
                 gitVersion = reader.ReadToEnd();
             }
@@ -43,7 +42,7 @@ namespace EGG9000.Bot.Commands {
             if(emailStart > 0) author = author[..emailStart].Trim();
 
             var branchLine = string.IsNullOrEmpty(branch) ? string.Empty : $"\n**Branch:**\t{branch}";
-            var response = $"___Running commit:___\n**Hash:**\t[{commitHash}]({repoUrl}/commit/{commitHash}){branchLine}" +
+            var response = $"___Running commit:___\n**Hash:**\t[{commitHash}](<{repoUrl}/commit/{commitHash}>){branchLine}" +
                 $"\n**Author**:\t{author}\n**Message**:\t{commitMessage}\n**Timestamp:**\t<t:{commitTimestamp}:R>";
 
             _logger.LogInformation($"Responding to ping...");

--- a/EGG9000.Common/Helpers/AccountRefresh.cs
+++ b/EGG9000.Common/Helpers/AccountRefresh.cs
@@ -46,15 +46,33 @@ namespace EGG9000.Common.Helpers {
         // Caller persists the account blob and calls SaveChanges. Returns whether the account blob was
         // mutated (grade changed or PromotionTime re-stamped) and therefore needs persisting.
         public static async Task<bool> ApplyExtrasAsync(DBUser user, EggIncAccount account, ApplicationDbContext db, ILogger logger, CancellationToken cancellationToken = default) {
+            var info = await FetchExtrasAsync(user, account, logger);
+            if(info is null) return false;
+
+            var mutated = ApplyExtras(user, account, info, logger);
+            await UpsertSeasonProgress(account.Id, info.SeasonProgress, db, cancellationToken);
+            return mutated;
+        }
+
+        // Network-only half of ApplyExtrasAsync. Callers that need to avoid holding a DB connection
+        // open across the Egg Inc API call (e.g. batch jobs) can call this first, then ApplyExtras +
+        // UpsertSeasonProgress against a short-lived scope once the network round-trip is done.
+        public static async Task<Ei.ContractPlayerInfo> FetchExtrasAsync(DBUser user, EggIncAccount account, ILogger logger) {
             var (info, error) = await EggIncApi.GetContractPlayerInfo(account.Id);
             if(info is null) {
                 logger.LogWarning("No response getting grade for user {User} ({Account}): {Error}", user.DiscordUsername, account.Name, error);
-                return false;
+                return null;
             }
             if(info.Status != Ei.ContractPlayerInfo.Types.Status.Complete) {
                 logger.LogTrace("Skipping non-final grade ({Status}) for user {User} ({Account})", info.Status, user.DiscordUsername, account.Name);
-                return false;
+                return null;
             }
+            return info;
+        }
+
+        // DB-free half of ApplyExtrasAsync: applies grade + CS changes to the in-memory account blob.
+        // Caller still owes UpsertSeasonProgress(account.Id, info.SeasonProgress, db, ...) + persist.
+        public static bool ApplyExtras(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
             var csChanged = account.Backup is not null && (account.Backup.TotalCS != info.TotalCxp || account.Backup.SeasonCS != info.SeasonCxp);
             if(csChanged) {
                 account.Backup.TotalCS = info.TotalCxp;
@@ -85,11 +103,10 @@ namespace EGG9000.Common.Helpers {
                 }
             }
 
-            await UpsertSeasonProgress(account.Id, info.SeasonProgress, db, cancellationToken);
             return mutated;
         }
 
-        private static async Task UpsertSeasonProgress(string eggIncId, IEnumerable<Ei.ContractPlayerInfo.Types.SeasonProgress> seasonProgress, ApplicationDbContext db, CancellationToken cancellationToken) {
+        public static async Task UpsertSeasonProgress(string eggIncId, IEnumerable<Ei.ContractPlayerInfo.Types.SeasonProgress> seasonProgress, ApplicationDbContext db, CancellationToken cancellationToken) {
             var rows = seasonProgress.Where(sp => !string.IsNullOrEmpty(sp.SeasonId)).ToList();
             if(rows.Count == 0)
                 return;

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -242,8 +242,9 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
 
         // Trusted proxy subnet(s) come from TRUSTED_PROXY_NETWORKS (comma-separated CIDR). Forwarded
         // headers from any other source IP are ignored. Falls back to the prior hardcoded value when
-        // unset so an un-updated deploy keeps its old behavior instead of trusting nothing.
-        var trustedNetworks = Configuration["TRUSTED_PROXY_NETWORKS"] ?? "192.168.0.0/24";
+        // unset or blank so an un-updated deploy keeps its old behavior instead of trusting nothing.
+        var trustedNetworks = Configuration["TRUSTED_PROXY_NETWORKS"];
+        if(string.IsNullOrWhiteSpace(trustedNetworks)) trustedNetworks = "192.168.0.0/24";
         foreach(var cidr in trustedNetworks.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) {
             options.KnownIPNetworks.Add(System.Net.IPNetwork.Parse(cidr));
         }
@@ -267,7 +268,8 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
             options.EnableForHttps = true;
         });
 
-        var bugsnagConfig = new Bugsnag.Configuration(Configuration.GetConnectionString("BugSnagApiKey"));
+        var bugsnagKey = SecretsHelper.GetConfigOrSecret(Configuration, "ConnectionStrings:BugSnagApiKey", "bugsnag_api_key");
+        var bugsnagConfig = new Bugsnag.Configuration(bugsnagKey);
         var bs = new Bugsnag.Client(bugsnagConfig);
         services.AddSingleton<Bugsnag.IClient>(bs);
         // Test Bugsnag is working


### PR DESCRIPTION
- Fixed DB pooling on unused connections (no-write)
- Fixed incorrect command migrations