### PR TITLE
Feature: V2 of Artifact Cheater Detection

### DIFF
--- a/EGG9000.Bot/Automated/ArtifactCheaters.cs
+++ b/EGG9000.Bot/Automated/ArtifactCheaters.cs
@@ -2,10 +2,13 @@
 using EGG9000.Bot.Commands;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using EGG9000.Common.EggIncAPI;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.Helpers.Discord;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -17,10 +20,6 @@ namespace EGG9000.Bot.Automated {
     public class ArtifactCheaters(IServiceProvider provider) : _UpdaterBase<ArtifactCheaters>(interval, delay, provider) {
         private static readonly TimeSpan delay = TimeSpan.FromMinutes(0);
         private static readonly TimeSpan interval = BuildConfig.IsDebug ? TimeSpan.FromMinutes(1) : TimeSpan.FromMinutes(30);
-
-        public async override Task Run(object state, CancellationToken cancellationToken) {
-            await RunFairnessScores(sendMessages: true, returnScoreSet: false, cancellationToken);
-        }
 
         public async Task RunCraftingLevelCheck(CancellationToken cancellationToken, bool sendMessages = true, bool returnLevelSet = false) {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
@@ -39,7 +38,7 @@ namespace EGG9000.Bot.Automated {
             const double zScoreCutoff = 1.0;
 
             var sumXp = xpSet.Values.Sum();
-            var averageXp = sumXp / xpSet.Where(s => s.Value > 0).Count();
+            var averageXp = sumXp / xpSet.Count(s => s.Value > 0);
 
             xpSet = xpSet.Where(x => x.Value > averageXp).ToDictionary(pair => pair.Key, pair => pair.Value);
             sumXp = xpSet.Values.Sum();
@@ -92,23 +91,34 @@ namespace EGG9000.Bot.Automated {
             }
         }
 
-        public async Task<Dictionary<EggIncAccount, double>> RunFairnessScores(bool sendMessages, bool returnScoreSet, CancellationToken cancellationToken) {
+        // An account's legendary count vs. what its actual ship launches/crafts predict (LLC.LLCPercent)
+        // is the strongest single cheat signal since it's grounded in that account's own play history,
+        // not a population comparison. AFS (relative artifact-rarity stacking) is corroborating only -
+        // it catches inventory anomalies LLC doesn't model (e.g. hoarded rares with no legendary craft),
+        // but alone it flags legit whales with huge launch counts, so it never fires without LLC agreeing
+        // something is at least somewhat off too.
+        private const int LLCPercentHardCutoff = 50;
+        private const int LLCPercentSoftCutoff = 15;
+        private const double AFSZScoreCutoff = 1.0;
+
+        public async override Task Run(object state, CancellationToken cancellationToken) {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var _cache = _provider.CreateScope().ServiceProvider.GetRequiredService<IMemoryCache>();
             var dbguilds = await _db.Guilds.AsQueryable().ToListAsync(CancellationToken.None);
             var dbusers = await _db.DBUsers.AsQueryable().Where(u => !u.TempDisabled).ToListAsync(CancellationToken.None);
             var scoreSet = new Dictionary<EggIncAccount, double>();
+            var candidateAccounts = new List<EggIncAccount>();
 
             foreach(var user in dbusers) {
-                if(cancellationToken.IsCancellationRequested) return [];
+                if(cancellationToken.IsCancellationRequested) return;
                 foreach(var account in user.EggIncAccounts.ToList()) {
-                    var score = (double)ArtifactHelpers.GetArtifactFairnessScore(account.Backup?.ArtifactHall ?? null);
-                    if(account is null || score is 0) continue;
+                    if(account?.Backup?.ArtifactHall is null) continue;
+                    var score = ArtifactHelpers.GetArtifactFairnessScore(account.Backup.ArtifactHall);
+                    if(score is 0) continue;
                     scoreSet.Add(account, score);
+                    candidateAccounts.Add(account);
                 }
             }
-
-            //Change this to actually relate how far above the average someone has to be to get flagged
-            const double zScoreCutoff = 1.0;
 
             // Calculate the average score
             var sumScores = scoreSet.Values.Sum();
@@ -118,73 +128,107 @@ namespace EGG9000.Bot.Automated {
             var sumSquaredDeviations = scoreSet.Values.Sum(score => Math.Pow(score - averageScore, 2));
             var standardDeviation = Math.Sqrt(sumSquaredDeviations / scoreSet.Count);
 
-            // Calculate the Z-score for each account and find upper outliers
-            var upperThreshold = averageScore + (zScoreCutoff * standardDeviation);
+            var afsZScores = scoreSet.ToDictionary(pair => pair.Key, pair => (pair.Value - averageScore) / standardDeviation);
+
+            var shipCoefficientTable = await ArtifactHelpers.GetShipDataTable(_cache, _logger);
+            var llcResults = new Dictionary<EggIncAccount, ArtifactHelpers.LegendaryLuckResult>();
+            if(shipCoefficientTable is not null) {
+                // Mirror UpdateBackups' throttling - FirstContact is a live API call per account, so cap
+                // concurrency instead of firing one request per account at once.
+                var throttler = new SemaphoreSlim(8);
+                var tasks = candidateAccounts
+                    .Where(a => afsZScores.TryGetValue(a, out var z) && z > AFSZScoreCutoff / 2)
+                    .Select(async account => {
+                        await throttler.WaitAsync(cancellationToken);
+                        try {
+                            var firstContact = await EggIncApi.FirstContact(account.Id, _logger);
+                            if(firstContact?.Backup?.ArtifactsDb?.MissionArchive is null) return;
+                            var llc = ArtifactHelpers.GetLegendaryLuckCoefficient(account, firstContact.Backup, shipCoefficientTable);
+                            lock(llcResults) llcResults[account] = llc;
+                        } catch(Exception ex) {
+                            _logger.LogError(ex, "Error computing LLC for account {accountId}", account.Id);
+                        } finally {
+                            throttler.Release();
+                        }
+                    });
+                await Task.WhenAll(tasks);
+            }
+
+            // Informed combination: a lone-standing implausible legendary excess is damning on its own.
+            // A merely elevated one only counts alongside a corroborating AFS outlier, so a legit whale
+            // with a big launch history (which pushes AFS up too, but LLC stays near zero) never flags.
+            bool IsFlagged(EggIncAccount account) {
+                var hasLlc = llcResults.TryGetValue(account, out var llc);
+                var hasAfs = afsZScores.TryGetValue(account, out var afsZ);
+                if(hasLlc && llc.LLCPercent >= LLCPercentHardCutoff) return true;
+                if(hasLlc && hasAfs && llc.LLCPercent >= LLCPercentSoftCutoff && afsZ > AFSZScoreCutoff) return true;
+                return false;
+            }
+
             var upperOutliers = scoreSet
-                .Where(pair => dbguilds.Any(g => g.Id == dbusers.FirstOrDefault(d => d.EggIncAccounts.Any(a => a.Name == pair.Key.Name)).GuildId))
-                .Where(pair => !pair.Key.AFSMarkedClean)
-                .Where(pair => !pair.Key.AFSWarningSent)
-                .Where(pair => (pair.Value - averageScore) / standardDeviation > zScoreCutoff)
+                .Where(pair => !pair.Key.AFSMarkedClean
+                    && !pair.Key.AFSWarningSent
+                    && IsFlagged(pair.Key)
+                    && dbguilds.Any(g => g.Id == dbusers.FirstOrDefault(d => d.EggIncAccounts.Any(a => a.Name == pair.Key.Name)).GuildId))
                 .Select(pair => pair.Key)
                 .ToList();
 
-            if(sendMessages) {
-                foreach(var outlier in upperOutliers) {
-                    if(cancellationToken.IsCancellationRequested) return [];
-                    DBUser user;
-                    if(string.IsNullOrEmpty(outlier.Name)) user = dbusers.FirstOrDefault(u => u.EggIncAccounts.Any(a => a.Id == outlier.Id));
-                    else user = dbusers.FirstOrDefault(u => u.EggIncAccounts.Any(a => a.Name == outlier.Name));
-                    var outlierScore = scoreSet[outlier];
+            foreach(var outlier in upperOutliers) {
+                if(cancellationToken.IsCancellationRequested) return;
+                DBUser user;
+                if(string.IsNullOrEmpty(outlier.Name)) user = dbusers.FirstOrDefault(u => u.EggIncAccounts.Any(a => a.Id == outlier.Id));
+                else user = dbusers.FirstOrDefault(u => u.EggIncAccounts.Any(a => a.Name == outlier.Name));
+                var outlierScore = scoreSet[outlier];
 
-                    var clientGuild = _client.Guilds.FirstOrDefault(x => x.Id == user.GuildId);
-                    if(clientGuild is null) continue;
+                var clientGuild = _client.Guilds.FirstOrDefault(x => x.Id == user.GuildId);
+                if(clientGuild is null) continue;
 
-                    // GuildId can be stale when a user leaves Discord without being unassigned; skip the
-                    // ping when the roster is complete and the user is no longer a member.
-                    await clientGuild.DownloadUsersAsync();
-                    if(clientGuild.HasAllMembers && clientGuild.GetUser(user.DiscordId) is null) continue;
+                // GuildId can be stale when a user leaves Discord without being unassigned; skip the
+                // ping when the roster is complete and the user is no longer a member.
+                await clientGuild.DownloadUsersAsync();
+                if(clientGuild.HasAllMembers && clientGuild.GetUser(user.DiscordId) is null) continue;
 
-                    var dbGuild = dbguilds.FirstOrDefault(x => x.Id == clientGuild.Id);
-                    if(dbGuild is null) continue;
+                var dbGuild = dbguilds.FirstOrDefault(x => x.Id == clientGuild.Id);
+                if(dbGuild is null) continue;
 
-                    var doesCheaterChannelExist = ChannelHelper.DetermineChannelType(dbGuild, clientGuild, GuildChannelType.CheaterThread);
+                var doesCheaterChannelExist = ChannelHelper.DetermineChannelType(dbGuild, clientGuild, GuildChannelType.CheaterThread);
 
-                    //Only run through if the channel exists
-                    if(doesCheaterChannelExist is null) continue;
+                //Only run through if the channel exists
+                if(doesCheaterChannelExist is null) continue;
 
-                    var identifier = string.IsNullOrEmpty(outlier.Backup?.UserName) ? (string.IsNullOrEmpty(outlier.Name) ? outlier.Id : outlier.Name) : outlier.Backup.UserName;
-                    var message = BuildConfig.IsDev9002
-                        ? $"User `<@{user.DiscordId}>` may be using cheated artifacts - the account `{identifier}` has an AFS of `{outlierScore}` compared to the average of `{averageScore}`"
-                        : $"User <@{user.DiscordId}> may be using cheated artifacts - the account `{identifier}` has an AFS of `{outlierScore}` compared to the average of `{averageScore}`";
+                var identifier = string.IsNullOrEmpty(outlier.Backup?.UserName) ? (string.IsNullOrEmpty(outlier.Name) ? outlier.Id : outlier.Name) : outlier.Backup.UserName;
+                var llcSuffix = llcResults.TryGetValue(outlier, out var outlierLlc)
+                    ? $", LLC `{outlierLlc.LLC:f2}` (`{outlierLlc.LLCPercent}%` above expected legendaries)"
+                    : "";
+                var message = BuildConfig.IsDev9002
+                    ? $"User `<@{user.DiscordId}>` may be using cheated artifacts - the account `{identifier}` has an AFS of `{outlierScore}` compared to the average of `{averageScore}`{llcSuffix}"
+                    : $"User <@{user.DiscordId}> may be using cheated artifacts - the account `{identifier}` has an AFS of `{outlierScore}` compared to the average of `{averageScore}`{llcSuffix}";
 
-                    var (B64, Config) = await ArtifactHelpers.InventoryB64(outlier);
-                    if(string.IsNullOrEmpty(B64) || B64.StartsWith("$ERROR$:")) {
-                        var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
-                            Text = message
-                        });
-                    } else {
-                        var image = new FileAttachment(new MemoryStream(Convert.FromBase64String(B64)), "Inventory.jpeg", "Inventory Image");
-                        var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
-                            Text = message,
-                            Embed = ArtifactCommands._inventoryEmbed(user, outlier),
-                            File = image,
-                            SendFile = true,
-                        });
-                        var imageUrl = ArtifactCommands.TrimImageUrl(sendResponse.Embeds.First().Image.ToString());
+                var (B64, Config) = await ArtifactHelpers.InventoryB64(outlier);
+                if(string.IsNullOrEmpty(B64) || B64.StartsWith("$ERROR$:")) {
+                    var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
+                        Text = message
+                    });
+                } else {
+                    var image = new FileAttachment(new MemoryStream(Convert.FromBase64String(B64)), "Inventory.jpeg", "Inventory Image");
+                    var sendResponse = await ChannelHelper.DetermineAndSend(_client.Gateway, dbGuild, GuildChannelType.CheaterThread, new() {
+                        Text = message,
+                        Embed = ArtifactCommands._inventoryEmbed(user, outlier),
+                        File = image,
+                        SendFile = true,
+                    });
+                    var imageUrl = ArtifactCommands.TrimImageUrl(sendResponse.Embeds.First().Image.ToString());
 
-                        await sendResponse.ModifyAsync(x => {
-                            x.Content = message;
-                            x.Embed = ArtifactCommands._inventoryEmbed(user, outlier, imageUrl);
-                        });
-                    }
-
-                    outlier.AFSWarningSent = true;
-                    user.UpdateAccounts();
+                    await sendResponse.ModifyAsync(x => {
+                        x.Content = message;
+                        x.Embed = ArtifactCommands._inventoryEmbed(user, outlier, imageUrl);
+                    });
                 }
-                await _db.SaveChangesAsync(CancellationToken.None);
-            }
 
-            return returnScoreSet ? scoreSet : [];
+                outlier.AFSWarningSent = true;
+                user.UpdateAccounts();
+            }
+            await _db.SaveChangesAsync(CancellationToken.None);
         }
     }
 }

--- a/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
+++ b/EGG9000.Bot/Commands/Informational/FormulaCommands.cs
@@ -90,30 +90,6 @@ namespace EGG9000.Bot.Commands.Informational {
             public double LegendaryDropRate { get; set; } = legendaryDropRate;
         }
 
-        private class ShipsSent {
-            public Dictionary<(Spaceship, DurationType, uint), int> ShipCounts { get; private set; }
-
-            public ShipsSent(Backup backup) {
-                ShipCounts = [];
-
-                if(backup?.ArtifactsDb?.MissionArchive is not null) {
-                    foreach(var mission in backup.ArtifactsDb.MissionArchive) {
-                        var key = (mission.Ship, mission.DurationType, mission.Level);
-                        if(ShipCounts.ContainsKey(key)) {
-                            ShipCounts[key]++;
-                        } else {
-                            ShipCounts[key] = 1;
-                        }
-                    }
-                }
-            }
-
-            public int GetShipsCount(Spaceship shipType, DurationType durationType, uint level) {
-                var key = (shipType, durationType, level);
-                return ShipCounts.TryGetValue(key, out var count) ? count : 0;
-            }
-        }
-
         [SlashCommand("llc", "Calculate your Legendary Luck Coefficient (LLC)")]
         public async Task Llc() {
             await Context.Interaction.DeferAsync();
@@ -138,30 +114,6 @@ namespace EGG9000.Bot.Commands.Informational {
             await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embeds = embeds.ToArray(); });
         }
 
-        public static (int, int) GetCompledShipsOfDuration(EggIncAccount account, DurationType duration) {
-            var maxShipLevels = MissionHelpers.MaxShipLevels.ToList();
-            var lastShipType = maxShipLevels[^1].Key;
-            var secondToLastShipType = maxShipLevels[^2].Key;
-
-            var shipsForLastType = account.Backup.ShipsSent
-                .Where(x => x.ship == lastShipType && x.type == duration)
-                .Sum(x => x.count);
-            var exploringShipsLastType = account.Backup.SpaceMissions
-                .Where(x => x.Ship == lastShipType && x.Status == Status.Exploring && x.Duration == duration)
-                .Count();
-            var resultLastType = shipsForLastType - exploringShipsLastType;
-
-            var shipsForSecondToLastType = account.Backup.ShipsSent
-                .Where(x => x.ship == secondToLastShipType && x.type == duration)
-                .Sum(x => x.count);
-            var exploringShipsSecondToLastType = account.Backup.SpaceMissions
-                .Where(x => x.Ship == secondToLastShipType && x.Status == Status.Exploring && x.Duration == duration)
-                .Count();
-            var resultSecondToLastType = shipsForSecondToLastType - exploringShipsSecondToLastType;
-
-            return (resultLastType, resultSecondToLastType);
-        }
-
         private static async Task<Embed> LLCCalculate(EggIncAccount account, string userName, IMemoryCache _cache, ILogger _logger) {
             var backup = await EggIncApi.FirstContact(account.Id);
 
@@ -170,77 +122,26 @@ namespace EGG9000.Bot.Commands.Informational {
             }
 
             var shipCoefficientTable = await GetShipDataTable(_cache, _logger);
-            var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
 
             //Catch the case where the cache is invalidated, and the API returns an error
             if(shipCoefficientTable is null) {
                 return EmbedError($"Ship coefficients were not cached, and Menno's API did not respond to refresh them. Please try again later.");
             }
 
-            var shipsSent = new ShipsSent(backup.Backup);
+            var llc = GetLegendaryLuckCoefficient(account, backup.Backup, shipCoefficientTable);
 
-            var sumOfRatios = 0.0;
-            foreach(var (ship, type, dropRates) in shipCoefficientTable) {
-                var rateIndex = 0;
-                foreach(var rate in dropRates) {
-                    if(rate == 0.0) {
-                        rateIndex++;
-                        continue;
-                    }
-                    sumOfRatios += shipsSent.GetShipsCount(ship, type, (uint)rateIndex) / rate;
-                    rateIndex++;
-                }
-            }
+            var (linerEpicCount, henEpicCount) = GetCompletedShipsOfDuration(account, DurationType.Epic);
+            var (linerLongCount, henLongCount) = GetCompletedShipsOfDuration(account, DurationType.Long);
+            var (linerShortCount, henShortCount) = GetCompletedShipsOfDuration(account, DurationType.Short);
 
-            var afHall = account.Backup.ArtifactHall;
-            var newLLCSum = 0.0;
-            foreach(var craftType in baseCraftingCoefficients.Where(c => c.Value[2] != 0)) {
-
-                //Don't account for Lunar totems in LLC calc, re: sync with Menno data
-                if(craftType.Key.Artifact == "Lunar Totem" && craftType.Key.Tier == 4) continue;
-
-                //Get the number of crafts that have been performed for this artifact
-                var numCrafted = (double)(afHall.Where(a => a.NumberCrafted > 0).FirstOrDefault(a => a.Artifact.Tier == craftType.Key.Tier && a.Artifact.Artifact == craftType.Key.Artifact)?.NumberCrafted ?? 0.0);
-                if(numCrafted == 0) continue;
-                var assumedXpPerCraft = account.Backup.CraftingXP / numCrafted;
-                for(var i = 0; i < numCrafted; i++) {
-
-                    var craftingCountCoefficient = Math.Min(1.0, (double)(i / 400.0));
-                    var fixedCraftingCountCoefficient = 1.0 - craftingCountCoefficient * 0.3; //Where these numbers come from, I have no idea
-
-                    var baseLegRate = craftType.Value[2];
-
-                    var simulatedCraftingLevel = GetCraftingLevel(assumedXpPerCraft * i);
-                    var simulatedMultiplier = Root.Get().craftingLevelMultipliers[(int)simulatedCraftingLevel - 1];
-
-                    var simulatedRate = Math.Max(10.0, baseLegRate / simulatedMultiplier);
-                    var simulatedRatio = 1.0 / simulatedRate;
-
-                    var simulatedThreshold = Math.Pow(simulatedRatio, fixedCraftingCountCoefficient);
-                    var ceilingedThreshold = Math.Min(0.1, simulatedThreshold);
-
-                    newLLCSum += ceilingedThreshold;
-                }
-            }
-
-            var (linerEpicCount, henEpicCount) = GetCompledShipsOfDuration(account, DurationType.Epic);
-            var (linerLongCount, henLongCount) = GetCompledShipsOfDuration(account, DurationType.Long);
-            var (linerShortCount, henShortCount) = GetCompledShipsOfDuration(account, DurationType.Short);
-
-            var craftCount = GetTotalCraftWithLegendaryPossibility(account.Backup.ArtifactHall);
-            var legCount = GetLegendaryArtifactCount(account.Backup.ArtifactHall, llcCount: true);
-
-            var newExpectedLeggies = newLLCSum + sumOfRatios;
-            var newLLC = Math.Round(legCount - newExpectedLeggies, 2);
-            var newLLCPercent = newExpectedLeggies != 0 ? (int)Math.Round((legCount * 100 / newExpectedLeggies) - 100) : 0;
-            var newDisplayPercent = newLLCPercent == int.MinValue ? "-∞" : $"{newLLCPercent}%";
-            var description = $"\n:tools: **Possible <:leggy:1113516502516248636> crafts** `{craftCount}`" +
+            var newDisplayPercent = llc.LLCPercent == int.MinValue ? "-∞" : $"{llc.LLCPercent}%";
+            var description = $"\n:tools: **Possible <:leggy:1113516502516248636> crafts** `{llc.PossibleCraftCount}`" +
                 $"\n<:Henerprise:801748924146384906> **Henerprises** `{henEpicCount}` extended / `{henLongCount}` standard / `{henShortCount}` short" +
                 $"\n<:Atreggies:1215022229826314380> **Atreggies** `{linerEpicCount}` extended / `{linerLongCount}` standard / `{linerShortCount}` short" +
-                $"\n<:leggy:1113516502516248636> **Legendaries** `{Math.Round(newExpectedLeggies, 2)}` expected / `{legCount}` acquired";
+                $"\n<:leggy:1113516502516248636> **Legendaries** `{Math.Round(llc.ExpectedLeggies, 2)}` expected / `{llc.LegCount}` acquired";
 
             return new EmbedBuilder()
-                .WithTitle($"`{newLLC:f2}` (`{newDisplayPercent}`)")
+                .WithTitle($"`{llc.LLC:f2}` (`{newDisplayPercent}`)")
                 .WithColor(Color.DarkBlue)
                 .WithDescription(description)
                 .WithAuthor(new EmbedAuthorBuilder()

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -25,6 +25,9 @@ namespace EGG9000.Bot.Commands {
         private readonly ContractUpdater _contractUpdater = contractUpdater;
         private readonly ILogger<MiscModule> _logger = logger;
 
+#if !RELEASE
+        // EID screenshot recognition is undecided (keep it around, but dev-only) until we settle on
+        // whether to continue down this path - see HandleTestOCR in MessageHandlerService.
         [SlashCommand("starttestprocess", "Start EID screenshot recognition process.")]
         [CommandContextType(InteractionContextType.Guild, InteractionContextType.BotDm)]
         public async Task StartTestProcess() {
@@ -41,6 +44,7 @@ namespace EGG9000.Bot.Commands {
                 embed: EmbedSuccess("Please reply (a real Discord Reply - hit the Reply button) to this message with an **uncropped screenshot of your Privacy & Data tab**.")
             );
         }
+#endif
 
         [SlashCommand("trackeb", "Track your EB since the last time you ran this command")]
         [CommandContextType(InteractionContextType.Guild, InteractionContextType.BotDm)]

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -19,15 +19,12 @@ using static EGG9000.Common.Helpers.DiscordHelpersExt;
 using static EGG9000.Common.Helpers.Prefarm;
 
 namespace EGG9000.Bot.Commands {
-    public class MiscModule(IDbContextFactory<ApplicationDbContext> dbFactory, DiscordSocketClient client, ThreadsCoopStatusUpdater coopStatusUpdaterThreads, ContractUpdater contractUpdater, ILogger<MiscModule> logger) : Interactions.E9KModuleBase(dbFactory) {
-        private readonly DiscordSocketClient _client = client;
-        private readonly ThreadsCoopStatusUpdater _coopStatusUpdaterThreads = coopStatusUpdaterThreads;
-        private readonly ContractUpdater _contractUpdater = contractUpdater;
-        private readonly ILogger<MiscModule> _logger = logger;
-
-#if !RELEASE
-        // EID screenshot recognition is undecided (keep it around, but dev-only) until we settle on
-        // whether to continue down this path - see HandleTestOCR in MessageHandlerService.
+    // EID screenshot recognition is undecided - kept around, dev-only, until we settle on whether
+    // to continue down this path. See HandleTestOCR in MessageHandlerService for the DM-reply handler
+    // this command's prompt matches against. Own module so BuildConfigOnly can gate just this command
+    // (the attribute is class-level; MiscModule's other commands are prod-eligible).
+    [Interactions.BuildConfigOnly(BuildConfiguration.Debug, BuildConfiguration.Dev9001, BuildConfiguration.Dev9002)]
+    public class TestOCRModule(IDbContextFactory<ApplicationDbContext> dbFactory) : Interactions.E9KModuleBase(dbFactory) {
         [SlashCommand("starttestprocess", "Start EID screenshot recognition process.")]
         [CommandContextType(InteractionContextType.Guild, InteractionContextType.BotDm)]
         public async Task StartTestProcess() {
@@ -44,7 +41,13 @@ namespace EGG9000.Bot.Commands {
                 embed: EmbedSuccess("Please reply (a real Discord Reply - hit the Reply button) to this message with an **uncropped screenshot of your Privacy & Data tab**.")
             );
         }
-#endif
+    }
+
+    public class MiscModule(IDbContextFactory<ApplicationDbContext> dbFactory, DiscordSocketClient client, ThreadsCoopStatusUpdater coopStatusUpdaterThreads, ContractUpdater contractUpdater, ILogger<MiscModule> logger) : Interactions.E9KModuleBase(dbFactory) {
+        private readonly DiscordSocketClient _client = client;
+        private readonly ThreadsCoopStatusUpdater _coopStatusUpdaterThreads = coopStatusUpdaterThreads;
+        private readonly ContractUpdater _contractUpdater = contractUpdater;
+        private readonly ILogger<MiscModule> _logger = logger;
 
         [SlashCommand("trackeb", "Track your EB since the last time you ran this command")]
         [CommandContextType(InteractionContextType.Guild, InteractionContextType.BotDm)]

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -51,18 +51,6 @@ namespace EGG9000.Bot.Commands {
             public DBUser User { get; set; }
         }
 
-        static async internal Task _afs(SocketInteraction command, ApplicationDbContext db, SocketGuildUser discUser, bool showInChannel) {
-            await command.DeferAsync(ephemeral: !showInChannel);
-            var user = await db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == discUser.Id);
-
-            var sb = new StringBuilder();
-
-            foreach(var account in user.EggIncAccounts.Where(a => a.Backup is not null).ToList()) {
-                sb.Append($"For {account.Backup?.UserName ?? "(No Name)"}: {ArtifactHelpers.GetArtifactFairnessScoreString(account.Backup.ArtifactHall)}\n");
-            }
-
-            await command.RespondAsyncGettingMessage(sb.ToString(), ephemeral: !showInChannel);
-        }
     }
 
     public class StaffModule(IDbContextFactory<ApplicationDbContext> dbFactory, DiscordSocketClient client) : E9KModuleBase(dbFactory) {
@@ -146,11 +134,6 @@ namespace EGG9000.Bot.Commands {
     }
 
     public partial class AdminModule {
-
-        [SlashCommand("afs", "Determine a user's artifact fairness score")]
-        public Task AFS([Summary("user")] SocketGuildUser user, [Summary("showinchannel")] bool ShowInChannel = false) {
-            return StaffCommands._afs(Context.Interaction, Db, user, ShowInChannel);
-        }
 
         [SlashCommand("selectroleusers", "Select X random users with Y role")]
         [StaffOnly(StaffTier.FarmHand)]

--- a/EGG9000.Bot/Commands/TestSuiteCommands.cs
+++ b/EGG9000.Bot/Commands/TestSuiteCommands.cs
@@ -1,4 +1,3 @@
-#if !RELEASE
 using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
@@ -7,6 +6,7 @@ using EGG9000.Bot.Automated;
 using EGG9000.Bot.Interactions;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
 
 using Microsoft.EntityFrameworkCore;
@@ -22,10 +22,11 @@ using static EGG9000.Bot.Commands.CommonTypes.AutoCompleteHandlers;
 using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
 
 namespace EGG9000.Bot.Commands {
-    // DEV-only test harness. Whole file is `#if !RELEASE` so these never register on prod.
+    // DEV-only test harness - registration is skipped outside Debug/DEV9001/DEV9002 by InteractionRoutingService
     [Group("test", "DEV test harness")]
     [DefaultMemberPermissions(GuildPermission.Administrator)]
     [StaffOnly(StaffTier.Admin)]
+    [BuildConfigOnly(BuildConfiguration.Debug, BuildConfiguration.Dev9001, BuildConfiguration.Dev9002)]
     public class TestModule(IDbContextFactory<ApplicationDbContext> dbFactory, DiscordSocketClient client, CoopStatsCache stats, IServiceProvider serviceProvider) : E9KModuleBase(dbFactory) {
         public const string SeedPrefix = "TESTSEED-";
 
@@ -199,4 +200,3 @@ namespace EGG9000.Bot.Commands {
 
     }
 }
-#endif

--- a/EGG9000.Bot/GlobalSuppressions.cs
+++ b/EGG9000.Bot/GlobalSuppressions.cs
@@ -10,3 +10,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Performance", "CA1873:Avoid potentially expensive logging", Justification = "Stlyistic choice")]
 [assembly: SuppressMessage("Performance", "CA1873:Avoid potentially expensive logging", Justification = "Stlyistic choice")]
 [assembly: SuppressMessage("Style", "IDE0022:Use block body for method", Justification = "Stlyistic choice")]
+[assembly: SuppressMessage("Style", "IDE0025:Use block body for property", Justification = "Stlyistic choice")]

--- a/EGG9000.Bot/Interactions/BuildConfigGate.cs
+++ b/EGG9000.Bot/Interactions/BuildConfigGate.cs
@@ -1,0 +1,18 @@
+using Discord.Interactions;
+using EGG9000.Common.Helpers;
+using System;
+using System.Linq;
+
+namespace EGG9000.Bot.Interactions {
+    // Marks an InteractionModuleBase module as only registerable in specific BuildConfigurations.
+    // InteractionRoutingService reads this via reflection before RegisterCommandsGloballyAsync and
+    // removes disallowed modules from the InteractionService entirely, so the command never appears
+    // in Discord's slash picker outside the allowed configs - unlike a precondition (e.g. StaffOnly),
+    // which only blocks execution after the command is already visible and invoked.
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class BuildConfigOnlyAttribute(params BuildConfiguration[] allowed) : Attribute {
+        public BuildConfiguration[] Allowed { get; } = allowed;
+
+        public bool AllowsCurrent => Allowed.Contains(BuildConfig.Current);
+    }
+}

--- a/EGG9000.Bot/Services/InteractionRoutingService.cs
+++ b/EGG9000.Bot/Services/InteractionRoutingService.cs
@@ -2,6 +2,8 @@ using Discord;
 using Discord.Interactions;
 using Discord.Rest;
 using Discord.WebSocket;
+using EGG9000.Bot.Interactions;
+using EGG9000.Common.Helpers;
 using EGG9000.Common.Services;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -28,6 +30,7 @@ namespace EGG9000.Bot.Services {
 
         public async Task StartAsync(CancellationToken cancellationToken) {
             await _interactions.AddModulesAsync(Assembly.GetExecutingAssembly(), _provider);
+            await RemoveModulesDisallowedForCurrentBuildConfigAsync();
             _interactions.SlashCommandExecuted += (i, c, r) => OnExecuted(i, c, r);
             _interactions.ComponentCommandExecuted += (i, c, r) => OnExecuted(i, c, r);
             _interactions.ModalCommandExecuted += (i, c, r) => OnExecuted(i, c, r);
@@ -41,6 +44,19 @@ namespace EGG9000.Bot.Services {
             await _interactions.RegisterCommandsGloballyAsync();
 
             await PurgeStaleGuildCommandsAsync();
+        }
+
+        // [BuildConfigOnly] modules were just discovered/tracked in-memory by AddModulesAsync above;
+        // pull the disallowed ones back out before RegisterCommandsGloballyAsync so they never reach
+        // Discord's slash picker outside their allowed configs (no #if - see BuildConfig.cs).
+        private async Task RemoveModulesDisallowedForCurrentBuildConfigAsync() {
+            var disallowedTypes = Assembly.GetExecutingAssembly().GetTypes()
+                .Where(t => t.GetCustomAttribute<BuildConfigOnlyAttribute>() is { AllowsCurrent: false });
+
+            foreach(var type in disallowedTypes) {
+                var removed = await _interactions.RemoveModuleAsync(type);
+                if(removed) _logger.LogInformation("Skipping registration of {module} - not allowed in {config}", type.Name, BuildConfig.Current);
+            }
         }
 
         // This app only ever registers commands globally, so any guild-scoped command is a leftover

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Numerics;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -116,11 +115,120 @@ namespace EGG9000.Common.Helpers {
             }
         }
 
-        public static string GetArtifactFairnessScoreString(List<ArtifactCount> ArtifactHall) {
-            return (ArtifactHall is null || ArtifactHall.Count == 0) ? "0 (null artifact hall)" : GetArtifactFairnessScore(ArtifactHall).ToString("E");
+        private class ShipsSentByLevel {
+            public Dictionary<(Spaceship, DurationType, uint), int> ShipCounts { get; private set; }
+
+            public ShipsSentByLevel(Ei.Backup backup) {
+                ShipCounts = [];
+
+                if(backup?.ArtifactsDb?.MissionArchive is not null) {
+                    foreach(var mission in backup.ArtifactsDb.MissionArchive) {
+                        var key = (mission.Ship, mission.DurationType, mission.Level);
+                        if(ShipCounts.ContainsKey(key)) {
+                            ShipCounts[key]++;
+                        } else {
+                            ShipCounts[key] = 1;
+                        }
+                    }
+                }
+            }
+
+            public int GetShipsCount(Spaceship shipType, DurationType durationType, uint level) {
+                var key = (shipType, durationType, level);
+                return ShipCounts.TryGetValue(key, out var count) ? count : 0;
+            }
         }
 
-        public static BigInteger GetArtifactFairnessScore(List<ArtifactCount> ArtifactHall) {
+        public static (int lastShipTypeCount, int secondToLastShipTypeCount) GetCompletedShipsOfDuration(EggIncAccount account, DurationType duration) {
+            var maxShipLevels = MissionHelpers.MaxShipLevels.ToList();
+            var lastShipType = maxShipLevels[^1].Key;
+            var secondToLastShipType = maxShipLevels[^2].Key;
+
+            var shipsForLastType = account.Backup.ShipsSent
+                .Where(x => x.ship == lastShipType && x.type == duration)
+                .Sum(x => x.count);
+            var exploringShipsLastType = account.Backup.SpaceMissions
+                .Where(x => x.Ship == lastShipType && x.Status == Status.Exploring && x.Duration == duration)
+                .Count();
+            var resultLastType = shipsForLastType - exploringShipsLastType;
+
+            var shipsForSecondToLastType = account.Backup.ShipsSent
+                .Where(x => x.ship == secondToLastShipType && x.type == duration)
+                .Sum(x => x.count);
+            var exploringShipsSecondToLastType = account.Backup.SpaceMissions
+                .Where(x => x.Ship == secondToLastShipType && x.Status == Status.Exploring && x.Duration == duration)
+                .Count();
+            var resultSecondToLastType = shipsForSecondToLastType - exploringShipsSecondToLastType;
+
+            return (resultLastType, resultSecondToLastType);
+        }
+
+        public record LegendaryLuckResult(double ExpectedLeggies, int LegCount, uint PossibleCraftCount, double LLC, int LLCPercent);
+
+        // Legendary Luck Coefficient: how many legendaries an account "should" have given its actual
+        // ship launches (by ship/duration/level, weighted against Menno's crowd-sourced drop rates) and
+        // its crafting history (simulated per-craft odds from crafting XP/level at the time of each
+        // craft). LLC = owned - expected; large positive LLC without a matching launch/craft history is
+        // the cheat signal, unlike the raw fairness score which just measures rare-artifact ownership.
+        public static LegendaryLuckResult GetLegendaryLuckCoefficient(EggIncAccount account, Ei.Backup freshBackup, List<(Spaceship ship, DurationType type, List<double> legendaryDropRates)> shipCoefficientTable) {
+            var baseCraftingCoefficients = Root.Get().baseCraftingCoefficients;
+            var shipsSent = new ShipsSentByLevel(freshBackup);
+
+            var sumOfRatios = 0.0;
+            foreach(var (ship, type, dropRates) in shipCoefficientTable) {
+                var rateIndex = 0;
+                foreach(var rate in dropRates) {
+                    if(rate == 0.0) {
+                        rateIndex++;
+                        continue;
+                    }
+                    sumOfRatios += shipsSent.GetShipsCount(ship, type, (uint)rateIndex) / rate;
+                    rateIndex++;
+                }
+            }
+
+            var afHall = account.Backup.ArtifactHall;
+            var newLLCSum = 0.0;
+            foreach(var craftType in baseCraftingCoefficients.Where(c => c.Value[2] != 0)) {
+
+                //Don't account for Lunar totems in LLC calc, re: sync with Menno data
+                if(craftType.Key.Artifact == "Lunar Totem" && craftType.Key.Tier == 4) continue;
+
+                //Get the number of crafts that have been performed for this artifact
+                var numCrafted = (double)(afHall.Where(a => a.NumberCrafted > 0).FirstOrDefault(a => a.Artifact.Tier == craftType.Key.Tier && a.Artifact.Artifact == craftType.Key.Artifact)?.NumberCrafted ?? 0.0);
+                if(numCrafted == 0) continue;
+                var assumedXpPerCraft = account.Backup.CraftingXP / numCrafted;
+                for(var i = 0; i < numCrafted; i++) {
+
+                    var craftingCountCoefficient = Math.Min(1.0, (double)(i / 400.0));
+                    var fixedCraftingCountCoefficient = 1.0 - craftingCountCoefficient * 0.3; //Where these numbers come from, I have no idea
+
+                    var baseLegRate = craftType.Value[2];
+
+                    var simulatedCraftingLevel = GetCraftingLevel(assumedXpPerCraft * i);
+                    var simulatedMultiplier = Root.Get().craftingLevelMultipliers[(int)simulatedCraftingLevel - 1];
+
+                    var simulatedRate = Math.Max(10.0, baseLegRate / simulatedMultiplier);
+                    var simulatedRatio = 1.0 / simulatedRate;
+
+                    var simulatedThreshold = Math.Pow(simulatedRatio, fixedCraftingCountCoefficient);
+                    var ceilingedThreshold = Math.Min(0.1, simulatedThreshold);
+
+                    newLLCSum += ceilingedThreshold;
+                }
+            }
+
+            var craftCount = GetTotalCraftWithLegendaryPossibility(account.Backup.ArtifactHall);
+            var legCount = GetLegendaryArtifactCount(account.Backup.ArtifactHall, llcCount: true);
+
+            var newExpectedLeggies = newLLCSum + sumOfRatios;
+            var newLLC = Math.Round(legCount - newExpectedLeggies, 2);
+            var newLLCPercent = newExpectedLeggies != 0 ? (int)Math.Round((legCount * 100 / newExpectedLeggies) - 100) : 0;
+
+            return new LegendaryLuckResult(newExpectedLeggies, legCount, craftCount, newLLC, newLLCPercent);
+        }
+
+        public static double GetArtifactFairnessScore(List<ArtifactCount> ArtifactHall) {
             if(ArtifactHall is null || ArtifactHall.Count == 0) return 0;
             // Collapse duplicate rows for the same artifact instance before scoring. A real hall has one
             // row per distinct artifact; stray duplicates (from a corrupted/legacy backup) would otherwise
@@ -128,8 +236,13 @@ namespace EGG9000.Common.Helpers {
             var collapsed = ArtifactHall
                 .Where(a => a.Artifact is not null)
                 .GroupBy(a => a.Artifact)
-                .Select(g => (Artifact: g.Key, Count: g.Sum(x => x.Count)));
-            return (BigInteger)collapsed.Sum(a => Math.Pow(GetFairness(a.Artifact)[a.Artifact.Tier - 1], a.Artifact.Rarity + 1) * a.Count);
+                .Select(g => (Artifact: g.Key, Count: g.Sum(x => (long)x.Count)));
+            // Log-dampen the per-artifact cost and scale linearly (not exponentially) by rarity. The old
+            // Math.Pow(fairness, rarity+1) blew up on any T4/legendary stack - a single legit Book of Basan
+            // or Tachyon Deflector legendary craft could outweigh an entire common inventory, flagging
+            // endgame players who did nothing wrong. Log+linear keeps rarity ordering (legendary still
+            // scores higher than common) without the runaway magnitude.
+            return collapsed.Sum(a => Math.Log(GetFairness(a.Artifact)[a.Artifact.Tier - 1] + 1) * (a.Artifact.Rarity + 1) * a.Count);
         }
 
         public static int GetAFOrder(string AF) {


### PR DESCRIPTION
Artifact cheater detection now uses a combination of the following to calculate:
  - Ships Sent
  - LLC
  - Artifact score (both the game's and "ours")
  
Instead of solely relying on one calculation.

Other changes:
- Removed `/a afs` (it was never used by staff)
- Gated `/starttestprocess` behind DEV, for now
- Added `BuildConfig` decorator class, to  prevent registration of commands in non-DEV environments