### PR TITLE
Fix: Re-Add Array Expansion for User Params

### DIFF
--- a/EGG9000.Bot/Commands/BanCommands.cs
+++ b/EGG9000.Bot/Commands/BanCommands.cs
@@ -102,18 +102,11 @@ namespace EGG9000.Bot.Commands {
         [DefaultMemberPermissions(GuildPermission.Administrator | GuildPermission.ManageChannels | GuildPermission.ManageRoles)]
         [Interactions.StaffOnly(Interactions.StaffTier.Admin)]
         public async Task Kick(
-            [Summary("users", "Mention one or more users (e.g. @a @b @c) or paste IDs")] string usersInput,
             [Summary("reason", "reason")] string reason,
+            [ComplexParameter] Interactions.UserSlots userSlots,
             [Summary("banaccount", "banaccount")] bool banaccount = false) {
             await Context.Interaction.DeferAsync();
-            var users = Interactions.UserParams.ParseUsers(usersInput, _client.Gateway, out var missing);
-            if(users.Length == 0) {
-                await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("No valid users parsed from input. Mention users like `@user1 @user2` or paste their IDs."); });
-                return;
-            }
-            if(missing.Count > 0) {
-                await Context.Interaction.FollowupAsync(embed: EmbedWarning($"Could not resolve: {string.Join(", ", missing.Select(id => $"`{id}`"))}"), ephemeral: true);
-            }
+            var users = userSlots.Users;
             var guild = _client.Guilds.FirstOrDefault(x => x.TextChannels.Any(y => y.Id == Context.Channel.Id));
             var dbGuild = await Db.Guilds.FirstOrDefaultAsync(g => g.Id == Context.Interaction.GuildId || g.OverflowServersJson.Contains(Context.Interaction.GuildId.ToString()));
 

--- a/EGG9000.Bot/Commands/MeritCommands.cs
+++ b/EGG9000.Bot/Commands/MeritCommands.cs
@@ -73,16 +73,9 @@ namespace EGG9000.Bot.Commands {
         [Interactions.StaffOnly(Interactions.StaffTier.ChickenTender)]
         public async Task AddMerit(
             [Summary("reason", "Merit Reason")] string reason,
-            [Summary("users", "Mention one or more users (e.g. @a @b) or paste IDs")] string usersInput) {
+            [ComplexParameter] Interactions.UserSlots userSlots) {
             await Context.Interaction.RespondAsyncGettingMessage("Adding Merits");
-            var users = Interactions.UserParams.ParseGuildUsers(usersInput, Context.Guild as SocketGuild, out var missing);
-            if(users.Length == 0) {
-                await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("No valid users parsed from input. Mention users like `@user1 @user2` or paste their IDs."); });
-                return;
-            }
-            if(missing.Count > 0) {
-                await Context.Interaction.FollowupAsync(embed: EmbedWarning($"Could not resolve: {string.Join(", ", missing.Select(id => $"`{id}`"))}"), ephemeral: true);
-            }
+            var users = userSlots.Users;
             var admin = await Db.DBUsers.AsQueryable().FirstOrDefaultAsync(x => x.DiscordId == Context.User.Id);
 
             var dbGuild = await Db.Guilds.FirstOrDefaultAsync(x => x.Id == Context.Interaction.GuildId || x.OverflowServersJson.IndexOf(Context.Interaction.GuildId.ToString()) > -1);

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -294,12 +294,8 @@ namespace EGG9000.Bot.Commands {
             [Summary("role")] SocketRole role,
             [Summary("timespan")] string timespan,
             [Summary("reason")] string reason,
-            [Summary("users", "Mention one or more users (e.g. @a @b) or paste IDs")] string usersInput) {
-            var users = Interactions.UserParams.ParseGuildUsers(usersInput, Context.Guild as SocketGuild, out var missing);
-            if(users.Length == 0) {
-                await Context.Interaction.RespondAsyncGettingMessage("No valid users parsed from input. Mention users like `@user1 @user2` or paste their IDs.");
-                return;
-            }
+            [ComplexParameter] Interactions.UserSlots userSlots) {
+            var users = userSlots.Users;
             DateTimeOffset expireTime;
             try {
                 expireTime = timespan.AddTimeSpanString(DateTimeOffset.UtcNow);

--- a/EGG9000.Bot/Interactions/UserParams.cs
+++ b/EGG9000.Bot/Interactions/UserParams.cs
@@ -1,51 +1,28 @@
+using Discord.Interactions;
 using Discord.WebSocket;
 
-using System.Collections.Generic;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace EGG9000.Bot.Interactions {
-    public static partial class UserParams {
-        public static SocketGuildUser[] CoalesceGuildUsers(params SocketGuildUser[] users) =>
-            [.. users.Where(u => u is not null)];
-        public static SocketUser[] CoalesceUsers(params SocketUser[] users) =>
-            [.. users.Where(u => u is not null)];
+    // Discord's slash command schema has no array option type, so a real "tag several users"
+    // param has to be several individual User-type options under the hood (each gets Discord's
+    // own full-guild user search, unlike a free-text field which only autocompletes users visible
+    // in the current channel). [ComplexParameter] lets every command declare this once as a single
+    // `[ComplexParameter] UserSlots users` parameter instead of repeating 8 ctor params each time.
+    public class UserSlots {
+        public SocketGuildUser[] Users { get; }
 
-        private static readonly Regex MentionRx = MyRegex();
-
-        // Parses "<@123> <@456> 789" (mentions or raw IDs, separated by anything) into resolved
-        // SocketUser[]. Unknown IDs (not in cache) become null entries in `missing`. Use this to
-        // restore the pre-migration "free-form list of users" UX in a single text option, since
-        // the Discord slash schema has no array option type.
-        public static SocketUser[] ParseUsers(string input, DiscordSocketClient gateway, out List<ulong> missing) {
-            missing = [];
-            if(string.IsNullOrWhiteSpace(input)) return [];
-            var seen = new HashSet<ulong>();
-            var result = new List<SocketUser>();
-            foreach(Match m in MentionRx.Matches(input)) {
-                var raw = m.Groups["id"].Success ? m.Groups["id"].Value : m.Groups["id2"].Value;
-                if(!ulong.TryParse(raw, out var id) || !seen.Add(id)) continue;
-                var u = (SocketUser)gateway.GetUser(id);
-                if(u is null) missing.Add(id); else result.Add(u);
-            }
-            return [.. result];
+        [ComplexParameterCtor]
+        public UserSlots(
+            [Summary("user1")] SocketGuildUser user1,
+            [Summary("user2")] SocketGuildUser user2 = null,
+            [Summary("user3")] SocketGuildUser user3 = null,
+            [Summary("user4")] SocketGuildUser user4 = null,
+            [Summary("user5")] SocketGuildUser user5 = null,
+            [Summary("user6")] SocketGuildUser user6 = null,
+            [Summary("user7")] SocketGuildUser user7 = null,
+            [Summary("user8")] SocketGuildUser user8 = null) {
+            Users = new[] { user1, user2, user3, user4, user5, user6, user7, user8 }.Where(u => u is not null).ToArray();
         }
-
-        public static SocketGuildUser[] ParseGuildUsers(string input, SocketGuild guild, out List<ulong> missing) {
-            missing = [];
-            if(string.IsNullOrWhiteSpace(input) || guild is null) return [];
-            var seen = new HashSet<ulong>();
-            var result = new List<SocketGuildUser>();
-            foreach(Match m in MentionRx.Matches(input)) {
-                var raw = m.Groups["id"].Success ? m.Groups["id"].Value : m.Groups["id2"].Value;
-                if(!ulong.TryParse(raw, out var id) || !seen.Add(id)) continue;
-                var u = guild.GetUser(id);
-                if(u is null) missing.Add(id); else result.Add(u);
-            }
-            return [.. result];
-        }
-
-        [GeneratedRegex(@"<@!?(?<id>\d{15,21})>|\b(?<id2>\d{15,21})\b", RegexOptions.Compiled)]
-        private static partial Regex MyRegex();
     }
 }


### PR DESCRIPTION
During the Discord.NET migration, what had been `User[]` params - which E9K's `CommandService` would then "convert" into multiple distinct user param boxes; were changed to singular `Summary("users")`, calls, however this hit the same bug we originally had:

Being that the "multi-user" only lets you tag users that are currently in the channel.
This re-adds a parameter for setting multi-slot user params, which can then be expanded within the function.

```csharp
        public async Task Kick(
            [Summary("reason", "reason")] string reason,
            [ComplexParameter] Interactions.UserSlots userSlots,
            [Summary("banaccount", "banaccount")] bool banaccount = false) {
            await Context.Interaction.DeferAsync();
            SocketGuild[] users = userSlots.Users;
```