### PR TITLE
Chore: Remove V1/Channel Fields from Coop

### DIFF
--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -46,7 +46,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
         public async override Task Run(object state, CancellationToken cancellationToken) {
             using var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            var coops = await _db.Coops.AsQueryable().Where(x => x.ThreadID != 0 && x.DiscordChannelId == 0 && !x.ThreadArchived && x.CoopEnds.HasValue && x.CoopEnds.Value.AddDays(7) > DateTimeOffset.UtcNow).ToListAsync(CancellationToken.None);
+            var coops = await _db.Coops.AsQueryable().Where(x => x.ThreadID != 0 && !x.ThreadArchived && x.CoopEnds.HasValue && x.CoopEnds.Value.AddDays(7) > DateTimeOffset.UtcNow).ToListAsync(CancellationToken.None);
 
             // Users who leave their server have GuildId reset to 0, which would drop them from the
             // GuildId > 0 set below even while they are still in an active coop. Without their backup

--- a/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
+++ b/EGG9000.Bot/Commands/CommonTypes/AutoCompleteHandlers.cs
@@ -310,7 +310,7 @@ namespace EGG9000.Bot.Commands.CommonTypes {
                         .Take(25).Select(x => new CoopMin { Name = x.Name, Id = x.Id, Contract = x.Contract?.Name, League = x.League })];
                 } else {
                     coops = [.. activeCoops
-                        .Where(x => x.Name?.Contains(filter, StringComparison.OrdinalIgnoreCase) == true && !x.ThreadArchived && x.GuildId == guild.Id && !x.DeletedChannel)
+                        .Where(x => x.Name?.Contains(filter, StringComparison.OrdinalIgnoreCase) == true && !x.ThreadArchived && x.GuildId == guild.Id)
                         .Take(25).Select(x => new CoopMin { Name = x.Name, Id = x.Id, Contract = x.Contract?.Name, League = x.League })];
                 }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -127,7 +127,7 @@ namespace EGG9000.Bot.Commands {
             if(contract.cc_only && !account.HasActiveSubscription()) {
                 return new() { Response = PotentialCoopCode.NonUltra };
             } else if(existingCoop is not null) {
-                return new() { Response = PotentialCoopCode.AlreadyAssigned, ReturnArgs = [existingCoop.Coop.ThreadID != 0 ? existingCoop.Coop.ThreadID.ToString() : existingCoop.Coop.DiscordChannelId.ToString()] };
+                return new() { Response = PotentialCoopCode.AlreadyAssigned, ReturnArgs = [existingCoop.Coop.ThreadID.ToString()] };
             } else if(account.GetGrade() is PlayerGrade.GradeUnset) {
                 return new() { Response = PotentialCoopCode.NoGrade };
             }
@@ -194,7 +194,7 @@ namespace EGG9000.Bot.Commands {
         [SlashCommand("fixfullcooperror", "Fix for getting full co-op error")]
         public async Task FixFullCoopError() {
             await Context.Interaction.DeferAsync();
-            var coop = await Db.Coops.Include(x => x.Contract).Include(x => x.UserCoopsXrefs).ThenInclude(x => x.User).FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.Include(x => x.Contract).Include(x => x.UserCoopsXrefs).ThenInclude(x => x.User).FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in a co-op channel."); });
                 return;
@@ -214,7 +214,7 @@ namespace EGG9000.Bot.Commands {
         [StaffOnly(StaffTier.CluckingCoordinator)]
         public async Task MakePublic() {
             await Context.Interaction.DeferAsync();
-            var coop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find coop for channel {Context.Channel.Name}"); });
                 return;
@@ -246,7 +246,7 @@ namespace EGG9000.Bot.Commands {
         public async Task MoveGrade([Summary("useraccount")][Autocomplete(typeof(UserAccountChannelSpecificAutoComplete))] string useraccount,
             [Summary("newgrade")][Autocomplete(typeof(MoveGradeAutoComplete))] uint newgrade) {
             await Context.Interaction.DeferAsync();
-            var targetCoop = await Db.Coops.Include(x => x.Contract).AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var targetCoop = await Db.Coops.Include(x => x.Contract).AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(targetCoop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in a co-op channel."); });
                 return;
@@ -332,7 +332,7 @@ namespace EGG9000.Bot.Commands {
                 }
             }
 
-            var coopChannel = newCoop.ThreadID != 0 ? _gateway.GetChannel(newCoop.ThreadID) : _gateway.GetChannel(newCoop.DiscordChannelId);
+            var coopChannel = _gateway.GetChannel(newCoop.ThreadID);
 
             var newxref = await CreateCoopsV2.MoveUser(newCoop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", Db, discordUser, dbuser, (SocketThreadChannel)coopChannel, (SocketTextChannel)Context.Channel);
             if(newxref == null) {
@@ -378,7 +378,7 @@ namespace EGG9000.Bot.Commands {
 
             var newCoop = newCoopResponse.FoundCoop;
             var discordUser = _gateway.GetUser(dbuser.DiscordId);
-            var coopChannel = newCoop.ThreadID != 0 ? _gateway.GetChannel(newCoop.ThreadID) : _gateway.GetChannel(newCoop.DiscordChannelId);
+            var coopChannel = _gateway.GetChannel(newCoop.ThreadID);
 
             var newxref = await CreateCoopsV2.MoveUser(newCoop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", Db, discordUser, dbuser, (SocketThreadChannel)coopChannel, (SocketTextChannel)Context.Channel);
             if(newxref == null) {
@@ -448,7 +448,7 @@ namespace EGG9000.Bot.Commands {
             [Summary("eggincname", "(Usually not required) Egg Inc Name, will match partial name")] string eggincname = "") {
             await Context.Interaction.DeferAsync();
 
-            var coop = await Db.Coops.Include(x => x.Contract).AsQueryable().FirstAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.Include(x => x.Contract).AsQueryable().FirstAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in co-op channels."); });
             }
@@ -461,11 +461,11 @@ namespace EGG9000.Bot.Commands {
             }
             var dbuser = await Db.DBUsers.FirstOrDefaultAsync(x => x.Id == userid);
             var account = dbuser.EggIncAccounts.OrderByDescending(x => x.Backup?.EarningsBonus).ToList()[int.Parse(useraccount.Split("|")[1])];
-            var xref = await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id || x.Coop.DiscordChannelId == Context.Channel.Id) && !x.JoinedCoop);
-            xref ??= await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id || x.Coop.DiscordChannelId == Context.Channel.Id));
+            var xref = await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id) && !x.JoinedCoop);
+            xref ??= await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id));
 
             var discordUser = _gateway.GetUser(dbuser.DiscordId);
-            var coopChannel = coop.ThreadID != 0 ? _gateway.GetChannel(coop.ThreadID) : _gateway.GetChannel(coop.DiscordChannelId);
+            var coopChannel = _gateway.GetChannel(coop.ThreadID);
             if(xref == null) {
                 var newxref = await CreateCoopsV2.MoveUser(coop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", Db, discordUser, dbuser, (SocketThreadChannel)coopChannel, (SocketTextChannel)Context.Channel, true);
 
@@ -477,8 +477,8 @@ namespace EGG9000.Bot.Commands {
                 await Db.SaveChangesAsync();
             }
 
-            xref = await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id || x.Coop.DiscordChannelId == Context.Channel.Id) && !x.JoinedCoop);
-            xref ??= await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id || x.Coop.DiscordChannelId == Context.Channel.Id));
+            xref = await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id) && !x.JoinedCoop);
+            xref ??= await Db.UserCoopXrefs.Include(x => x.Coop).FirstOrDefaultAsync(x => x.User.DiscordId == dbuser.DiscordId && (x.Coop.ThreadID == Context.Channel.Id));
 
             if(xref == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Even after a `MoveToCoop`, an Xref could not be found for this user. Try again?"); });
@@ -501,7 +501,7 @@ namespace EGG9000.Bot.Commands {
             xref.FixedUserName = t.UserName;
             await Db.SaveChangesAsync();
 
-            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             var guild = _gateway.Guilds.First(x => x.Id == targetCoop.OverflowGuildId);
             var users = await Db.DBUsers.AsQueryable().Where(x => x.UserCoopXrefs.Any(y => y.CoopId == targetCoop.Id)).ToListAsync();
             var dbguild = await Db.Guilds.AsQueryable().FirstAsync(x => x.Id == targetCoop.GuildId);
@@ -543,7 +543,7 @@ namespace EGG9000.Bot.Commands {
             var account = dbuser.EggIncAccounts.OrderByDescending(x => x.Backup?.EarningsBonus).ToList()[int.Parse(useraccount.Split("|")[1])];
 
             var discordUser = _gateway.GetUser(dbuser.DiscordId);
-            var coopChannel = coop.ThreadID != 0 ? _gateway.GetChannel(coop.ThreadID) : _gateway.GetChannel(coop.DiscordChannelId);
+            var coopChannel = _gateway.GetChannel(coop.ThreadID);
 
             var newxref = await CreateCoopsV2.MoveUser(coop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", Db, discordUser, dbuser, (SocketThreadChannel)coopChannel, (SocketTextChannel)Context.Channel, silent);
 
@@ -563,7 +563,7 @@ namespace EGG9000.Bot.Commands {
         [StaffOnly(StaffTier.FarmHand)]
         public async Task RemoveFromCoop([Summary("useraccount")][Autocomplete(typeof(RemoveFromCoopAutoComplete))] string useraccount) {
             await Context.Interaction.DeferAsync();
-            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(targetCoop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Please use in a co-op channel"); });
                 return;
@@ -625,7 +625,7 @@ namespace EGG9000.Bot.Commands {
                     var xref = existContractXrefs.First();
                     await Context.Interaction.ModifyOriginalResponseAsync(x => {
                         x.Content = ""; x.Embed = EmbedError($"You already have an assigned coop for <#{guildContract.DiscordChannelId}>. A new one was not created. Access your existing coop here: " +
-                        $"<#{(xref.Coop.ThreadID != 0 ? xref.Coop.ThreadID : xref.Coop.DiscordChannelId)}>");
+                        $"<#{xref.Coop.ThreadID}>");
                     });
                     return;
                 }
@@ -680,7 +680,7 @@ namespace EGG9000.Bot.Commands {
                              && x.Coop.ContractID == guildContract.ContractID
                              && (int)x.Coop.Status > 2 && (int)x.Coop.Status < 13
                              && x.Coop.CoopEnds > DateTimeOffset.UtcNow && !x.Coop.PseudoExpired)
-                    .Select(x => new AssignedCoop(x.Coop.Id, x.Coop.ThreadID, x.Coop.DiscordChannelId, x.Coop.Name, x.Coop.ContractID))
+                    .Select(x => new AssignedCoop(x.Coop.Id, x.Coop.ThreadID, x.Coop.Name, x.Coop.ContractID))
                     .ToListAsync())
                     .GroupBy(c => c.CoopId).Select(g => g.First())];
 
@@ -694,7 +694,7 @@ namespace EGG9000.Bot.Commands {
 
             var sb = new StringBuilder();
             foreach(var coop in found) {
-                var channelId = coop.ThreadId != 0 ? coop.ThreadId : coop.DiscordChannelId;
+                var channelId = coop.ThreadId;
                 sb.AppendLine($"Thread: <#{channelId}>");
                 sb.AppendLine($"Co-op code: `{coop.ContractId}` / `{coop.Name}`");
                 sb.AppendLine();
@@ -736,7 +736,7 @@ namespace EGG9000.Bot.Commands {
                 var xref = existingXrefs.First();
                 await component.UpdateAsync(x => {
                     x.Content = ""; x.Embed = EmbedError($"You already have an assigned coop for <#{guildContract.DiscordChannelId}>. A new one was not created. Access your existing coop here: " +
-                    $"<#{(xref.Coop.ThreadID != 0 ? xref.Coop.ThreadID : xref.Coop.DiscordChannelId)}>");
+                    $"<#{xref.Coop.ThreadID}>");
                 });
                 return;
             }
@@ -897,7 +897,7 @@ namespace EGG9000.Bot.Commands {
             var coop = await Db.Coops.FirstOrDefaultAsync(c => c.GuildId == dbuser.GuildId && c.Name == coopId);
             if(coop is null) return;
 
-            var coopChannel = coop.ThreadID != 0 ? _gateway.GetChannel(coop.ThreadID) : _gateway.GetChannel(coop.DiscordChannelId);
+            var coopChannel = _gateway.GetChannel(coop.ThreadID);
 
             var newxref = await CreateCoopsV2.MoveUser(coop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", Db, discordUser, dbuser, (SocketThreadChannel)coopChannel, null); //The "commandChannel" here is intentionally nulled to prevent sending messages in Contract channels
 
@@ -940,7 +940,7 @@ namespace EGG9000.Bot.Commands {
                 var xref = existingXrefs.First();
                 await component.ModifyOriginalResponseAsync(x => {
                     x.Content = ""; x.Components = null; x.Embed = EmbedError($"You already have an assigned coop for <#{guildContract.DiscordChannelId}>. A new one was not created. Access your existing coop here: " +
-                    $"<#{(xref.Coop.ThreadID != 0 ? xref.Coop.ThreadID : xref.Coop.DiscordChannelId)}>");
+                    $"<#{xref.Coop.ThreadID}>");
                 });
                 return;
             }
@@ -960,7 +960,7 @@ namespace EGG9000.Bot.Commands {
         [StaffOnly(StaffTier.FarmHand)]
         public async Task LeaveCoop([Summary("useraccount")][Autocomplete(typeof(UserAccountChannelSpecificAutoComplete))] string useraccount) {
             await Context.Interaction.DeferAsync();
-            var coop = await Db.Coops.FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in a co-op channel"); });
                 return;
@@ -1014,7 +1014,7 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var coop = await Db.Coops.Include(x => x.Contract).Include(x => x.UserCoopsXrefs).ThenInclude(x => x.User).FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.Include(x => x.Contract).Include(x => x.UserCoopsXrefs).ThenInclude(x => x.User).FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in a co-op channel."); });
                 return;
@@ -1036,7 +1036,7 @@ namespace EGG9000.Bot.Commands {
         public async Task MakePrivate() {
             await Context.Interaction.DeferAsync();
             var name = MyRegex().Match(Context.Channel.Name.ToLower()).Value;
-            var coop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Unable to find coop for this channel {Context.Channel.Name}"); });
                 return;

--- a/EGG9000.Bot/Commands/CoopSettings.cs
+++ b/EGG9000.Bot/Commands/CoopSettings.cs
@@ -25,7 +25,7 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            var inCoopChannel = await Db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && (x.Coop.ThreadID == Context.Interaction.ChannelId || x.Coop.DiscordChannelId == Context.Interaction.ChannelId));
+            var inCoopChannel = await Db.UserCoopXrefs.AnyAsync(x => x.UserId == dbuser.Id && x.Coop.ThreadID == Context.Interaction.ChannelId);
 
 
             if(inCoopChannel) {
@@ -106,7 +106,7 @@ namespace EGG9000.Bot.Commands {
             var dbuser = await Db.DBUsers.FirstOrDefaultAsync(x => x.DiscordId == (bypassUserId != 0 ? bypassUserId : component.User.Id));
             var dbGuild = Db.CachedGuilds.FirstOrDefault(g => g.Id == dbuser.GuildId);
 
-            var xref = await Db.UserCoopXrefs.FirstAsync(x => x.UserId == dbuser.Id && (x.Coop.ThreadID == component.ChannelId || x.Coop.DiscordChannelId == component.ChannelId));
+            var xref = await Db.UserCoopXrefs.FirstAsync(x => x.UserId == dbuser.Id && x.Coop.ThreadID == component.ChannelId);
             var props = MainMenu(xref.CoopSetting ?? new CoopSetting(xref, dbuser, dbGuild), "CSCoopOnly", "This Co-op", true, false, Db, dbuser);
             await component.ModifyOriginalResponseAsync(x => { x.Content = props.Content.GetValueOrDefault(null); x.Components = props.Components.GetValueOrDefault(null); x.Embed = props.Embed.GetValueOrDefault(null); });
         }
@@ -126,7 +126,7 @@ namespace EGG9000.Bot.Commands {
             dbuser.CoopSetting[settingName] = !dbuser.CoopSetting[settingName];
             dbuser.CoopSetting = dbuser.CoopSetting;
 
-            var xref = await Db.UserCoopXrefs.FirstOrDefaultAsync(x => x.UserId == dbuser.Id && (x.Coop.ThreadID == component.ChannelId || x.Coop.DiscordChannelId == component.ChannelId));
+            var xref = await Db.UserCoopXrefs.FirstOrDefaultAsync(x => x.UserId == dbuser.Id && x.Coop.ThreadID == component.ChannelId);
             if(xref is not null) {
                 var setting = xref.CoopSetting ?? new CoopSetting(xref, dbuser, dbGuild);
                 setting[settingName] = dbuser.CoopSetting[settingName];
@@ -150,7 +150,7 @@ namespace EGG9000.Bot.Commands {
 
             var settingName = data.Split(",")[0];
 
-            var xref = await Db.UserCoopXrefs.FirstOrDefaultAsync(x => x.UserId == dbuser.Id && (x.Coop.ThreadID == component.ChannelId || x.Coop.DiscordChannelId == component.ChannelId));
+            var xref = await Db.UserCoopXrefs.FirstOrDefaultAsync(x => x.UserId == dbuser.Id && x.Coop.ThreadID == component.ChannelId);
             var setting = xref.CoopSetting ?? new CoopSetting(xref, dbuser, dbGuild);
             setting[settingName] = !setting[settingName];
             xref.CoopSetting = setting;

--- a/EGG9000.Bot/Commands/DemeritCommands.cs
+++ b/EGG9000.Bot/Commands/DemeritCommands.cs
@@ -146,7 +146,7 @@ namespace EGG9000.Bot.Commands {
         public async Task NoDemerit([Summary("user")] SocketGuildUser user) {
             await Context.Interaction.DeferAsync();
             List<UserCoopXref> xref;
-            var targetCoop = await Db.Coops.AsQueryable().FirstAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var targetCoop = await Db.Coops.AsQueryable().FirstAsync(x => x.ThreadID == Context.Channel.Id);
 
             if(targetCoop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => x.Embed = EmbedError("This command can only be used in a co-op channel"));

--- a/EGG9000.Bot/Commands/MiscCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/MiscCommandsSlash.cs
@@ -279,7 +279,7 @@ namespace EGG9000.Bot.Commands {
         [Interactions.StaffOnly(Interactions.StaffTier.FarmHand)]
         public async Task RenameCoop([Summary("correctcoopname")] string correctcoopname) {
             await Context.Interaction.DeferAsync();
-            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(targetCoop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => x.Embed = EmbedError($"Command only works in co-op channels"));
                 return;
@@ -346,7 +346,7 @@ namespace EGG9000.Bot.Commands {
         public async Task UpdateChannel() {
             var command = Context.Interaction;
             await command.DeferAsync(ephemeral: true);
-            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id || x.DiscordChannelId == command.Channel.Id);
+            var targetCoop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == command.Channel.Id);
             if(targetCoop != null) {
                 await command.ModifyOriginalResponseAsync(x => x.Content = "Updating coop...");
                 var guild = gateway.Guilds.First(x => x.Id == targetCoop.OverflowGuildId);

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -473,7 +473,7 @@ namespace EGG9000.Bot.Commands {
         public async Task CoopStats() {
             var command = Context.Interaction;
             await command.DeferAsync();
-            var coops = await Db.Coops.Where(x => !x.Finished && x.Status != CoopStatusEnum.Failed && x.GuildId == command.GuildId && !x.DeletedChannel && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
+            var coops = await Db.Coops.Where(x => !x.Finished && x.Status != CoopStatusEnum.Failed && x.GuildId == command.GuildId && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
             var stats = new StringBuilder();
             stats.AppendLine($"**Coop Threads Last Updated**");
             var coopGroups = coops.Where(x => x.LastUpdateToChannel is not null).GroupBy(x => Math.Ceiling((DateTimeOffset.UtcNow - x.LastUpdateToChannel.Value).TotalHours));

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -198,7 +198,7 @@ namespace EGG9000.Bot.Commands {
         public async Task FixJoinIssue([Autocomplete(typeof(UserAccountChannelSpecificAutoComplete))][Summary("useraccount")] string useraccount) {
             await Context.Interaction.DeferAsync(ephemeral: true);
 
-            var coop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id || x.DiscordChannelId == Context.Channel.Id);
+            var coop = await Db.Coops.AsQueryable().FirstOrDefaultAsync(x => x.ThreadID == Context.Channel.Id);
             if(coop == null) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError("Command can only be used in a co-op channel"); });
                 return;

--- a/EGG9000.Bot/Commands/UserStatusCommands.cs
+++ b/EGG9000.Bot/Commands/UserStatusCommands.cs
@@ -183,7 +183,7 @@ namespace EGG9000.Bot.Commands {
                     xrefsShortened = true;
                 }
 
-                var coopsString = $"{string.Join("\n", xrefs.Select(x => $"<#{(x.Coop.ThreadID != 0 ? x.Coop.ThreadID : x.Coop.DiscordChannelId)}> {(user.EggIncAccounts.Count > 1 ? $"({user.EggIncAccounts.FirstOrDefault(y => y.Id == x.EggIncId)?.Backup?.UserName ?? "(No name)"})" : "")}"))}";
+                var coopsString = $"{string.Join("\n", xrefs.Select(x => $"<#{x.Coop.ThreadID}> {(user.EggIncAccounts.Count > 1 ? $"({user.EggIncAccounts.FirstOrDefault(y => y.Id == x.EggIncId)?.Backup?.UserName ?? "(No name)"})" : "")}"))}";
                 if(coopsString != "") {
                     AddInfoSeparatorIfNeeded();
                     lastBuilder.AddField($"Coops {(xrefsShortened ? "(Shortened List)" : "")}", coopsString);

--- a/EGG9000.Bot/Commands/UserStatusCommands.cs
+++ b/EGG9000.Bot/Commands/UserStatusCommands.cs
@@ -176,7 +176,7 @@ namespace EGG9000.Bot.Commands {
                     infoSeparatorAdded = true;
                 }
 
-                var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.UserId == user.Id && !x.Coop.ThreadArchived && !x.Coop.DeletedChannel).ToListAsync();
+                var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.UserId == user.Id && !x.Coop.ThreadArchived).ToListAsync();
                 var xrefsShortened = false;
                 if(xrefs.Count > 4) {
                     xrefs = [.. xrefs.OrderByDescending(x => x.CreatedOn).Take(4)];

--- a/EGG9000.Bot/Services/DiscordUserService.cs
+++ b/EGG9000.Bot/Services/DiscordUserService.cs
@@ -48,7 +48,7 @@ namespace EGG9000.Bot.Services {
 
         private async Task HandleThreadDeleted(SocketThreadChannel arg) {
             var db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id || x.DiscordChannelId == arg.Id);
+            var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id);
             if(coop is not null && coop.ThreadID != 0) {
                 _logger.LogInformation($"Marking thread archived due to thread deletion for {coop.Name}");
                 coop.ThreadArchived = true;
@@ -68,13 +68,10 @@ namespace EGG9000.Bot.Services {
                     await db.SaveChangesAsync();
                     return;
                 }
-                var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id || x.DiscordChannelId == arg.Id);
+                var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == arg.Id);
                 if(coop is not null && coop.ThreadID != 0) {
                     _logger.LogInformation($"Marking thread archived due to channel deletion for {coop.Name}");
                     coop.ThreadArchived = true;
-                    await db.SaveChangesAsync();
-                } else if(coop is not null && coop.DiscordChannelId != 0) {
-                    coop.DeletedChannel = true;
                     await db.SaveChangesAsync();
                 }
             } catch(Exception e) {
@@ -136,7 +133,7 @@ namespace EGG9000.Bot.Services {
                     try {
                         var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User.DiscordId == user.Id && x.Coop.OverflowGuildId == user.Guild.Id && !x.Coop.ThreadArchived && !x.AddedToChannel).ToListAsync();
                         foreach(var xref in xrefs) {
-                            var coopChannel = xref.Coop.ThreadID != 0 ? (SocketThreadChannel)_discord.GetChannel(xref.Coop.ThreadID) : (SocketTextChannel)_discord.GetChannel(xref.Coop.DiscordChannelId);
+                            var coopChannel = (SocketThreadChannel)_discord.GetChannel(xref.Coop.ThreadID);
                             if(coopChannel is null) continue;
                             await coopChannel.AddPermissionOverwriteAsync(user, new OverwritePermissions(viewChannel: PermValue.Allow));
                             xref.AddedToChannel = true;

--- a/EGG9000.Bot/Services/MessageHandlerService.cs
+++ b/EGG9000.Bot/Services/MessageHandlerService.cs
@@ -211,7 +211,7 @@ namespace EGG9000.Bot.Services {
 
                 if(!message.Author.IsBot && message.Type != MessageType.ChannelNameChange && message.Interaction == null) {
                     db ??= await _dbContextFactory.CreateDbContextAsync();
-                    var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == message.Channel.Id || x.DiscordChannelId == message.Channel.Id);
+                    var coop = await db.Coops.FirstOrDefaultAsync(x => x.ThreadID == message.Channel.Id);
                     if(coop is not null) {
                         var xrefs = await db.UserCoopXrefs.Include(x => x.User).Where(x => x.CoopId == coop.Id && x.User.DiscordId != message.Author.Id).ToListAsync();
                         foreach(var xref in xrefs.Where(x => x.User.DiscordId != message.Author.Id)) {
@@ -219,7 +219,7 @@ namespace EGG9000.Bot.Services {
                                 var discordUser = _discord.Guilds.First(x => x.Id == coop.GuildId).GetUser(xref.User.DiscordId);
                                 var author = _discord.Guilds.First(x => x.Id == coop.GuildId).GetUser(message.Author.Id);
                                 if(discordUser is null) continue; //Another null check
-                                var dmResult = await DiscordHelpersExt.BoolSendDm(discordUser, $"Message from <#{(coop.ThreadID != 0 ? coop.ThreadID : coop.DiscordChannelId)}>, **{author.GetCleanName()}:** {message.Content}", db);
+                                var dmResult = await DiscordHelpersExt.BoolSendDm(discordUser, $"Message from <#{coop.ThreadID}>, **{author.GetCleanName()}:** {message.Content}", db);
                             }
                         }
                     }

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -299,7 +299,7 @@ namespace EGG9000.Common.Database {
             builder.Entity<GuildContract>().HasIndex(x => x.DiscordChannelId);
 
             builder.Entity<Coop>().HasIndex(x => new { x.GuildId, x.ContractID, x.League })
-                .HasFilter("NOT \"Finished\" AND NOT \"DeletedChannel\" AND NOT \"ThreadArchived\"");
+                .HasFilter("NOT \"Finished\" AND NOT \"ThreadArchived\"");
 
             // DEV test-harness coops are excluded from every Coop query by default so they can never
             // trigger real thread/API creation or status polling. The harness opts back in where it

--- a/EGG9000.Common/Database/CoopAssignmentLookup.cs
+++ b/EGG9000.Common/Database/CoopAssignmentLookup.cs
@@ -8,9 +8,9 @@ using System.Linq;
 using System.Threading.Tasks;
 
 namespace EGG9000.Common.Database {
-    public sealed record AssignedCoop(Guid CoopId, ulong ThreadId, ulong DiscordChannelId, string Name, string ContractId);
+    public sealed record AssignedCoop(Guid CoopId, ulong ThreadId, string Name, string ContractId);
 
-    public readonly record struct CoopAssignmentRow(Guid UserId, Guid CoopId, string ContractId, ulong ThreadId, ulong DiscordChannelId, string Name);
+    public readonly record struct CoopAssignmentRow(Guid UserId, Guid CoopId, string ContractId, ulong ThreadId, string Name);
 
     /// <summary>
     /// Fast user -> assigned-but-not-yet-joined coop lookup, so the "Find my Coop" button
@@ -40,7 +40,7 @@ namespace EGG9000.Common.Database {
                 map[group.Key] = [.. group
                     .GroupBy(r => r.CoopId)
                     .Select(c => c.First())
-                    .Select(c => new AssignedCoop(c.CoopId, c.ThreadId, c.DiscordChannelId, c.Name, c.ContractId))];
+                    .Select(c => new AssignedCoop(c.CoopId, c.ThreadId, c.Name, c.ContractId))];
             }
             return map;
         }
@@ -55,7 +55,7 @@ namespace EGG9000.Common.Database {
                     .Where(x => !x.JoinedCoop
                              && (int)x.Coop.Status > 2 && (int)x.Coop.Status < 13
                              && x.Coop.CoopEnds > now && !x.Coop.PseudoExpired)
-                    .Select(x => new CoopAssignmentRow(x.UserId, x.Coop.Id, x.Coop.ContractID, x.Coop.ThreadID, x.Coop.DiscordChannelId, x.Coop.Name))
+                    .Select(x => new CoopAssignmentRow(x.UserId, x.Coop.Id, x.Coop.ContractID, x.Coop.ThreadID, x.Coop.Name))
                     .ToListAsync();
 
                 _map = Build(rows);

--- a/EGG9000.Common/Database/DatabaseCache.cs
+++ b/EGG9000.Common/Database/DatabaseCache.cs
@@ -23,7 +23,7 @@ namespace EGG9000.Common.Database {
             _lastCacheUpdateUser = DateTimeOffset.UtcNow;
             _cachedUsers = [.. db.DBUsers.AsNoTracking()];
 
-            _cachedActiveCoops = [.. db.Coops.AsNoTracking().Include(x => x.Contract).Where(c => !c.Finished && !c.DeletedChannel && !c.ThreadArchived)];
+            _cachedActiveCoops = [.. db.Coops.AsNoTracking().Include(x => x.Contract).Where(c => !c.Finished && !c.ThreadArchived)];
         }
 
         private volatile List<DBUser> _cachedUsers;
@@ -65,7 +65,7 @@ namespace EGG9000.Common.Database {
             try {
                 var db = await _dbContextFactory.CreateDbContextAsync();
                 _logger.LogInformation("Refreshing active coops cache");
-                var coops = await db.Coops.AsNoTracking().Include(x => x.Contract).Where(c => !c.Finished && !c.DeletedChannel && !c.ThreadArchived).ToListAsync();
+                var coops = await db.Coops.AsNoTracking().Include(x => x.Contract).Where(c => !c.Finished && !c.ThreadArchived).ToListAsync();
                 _cachedActiveCoops = coops;
             } catch(Exception e) {
                 _logger.LogError(e, "Error refreshing active coops cache");

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -50,7 +50,6 @@ namespace EGG9000.Common.Database.Entities {
         public string CreatorID { get; set; }
         public DateTimeOffset? LastUpdateToChannel { get; set; }
         public DateTimeOffset? WarningForDeleteChannel { get; set; }
-        public uint FindChannelErrors { get; set; } = 0; // V2 - Comment out
         public ulong Group { get; set; }
         public bool AddedFromBackup { get; set; } = false;
 

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -13,7 +13,7 @@ using System.Text;
 
 namespace EGG9000.Common.Database.Entities {
     [Index(nameof(Status))]
-    [Index(nameof(DiscordChannelId), nameof(ThreadArchived), nameof(CoopEnds), nameof(ThreadID))]
+    [Index(nameof(ThreadArchived), nameof(CoopEnds), nameof(ThreadID))]
     [Index(nameof(ThreadID), nameof(Created))]
     [Index(nameof(ThreadID))]
     public class Coop {
@@ -43,7 +43,6 @@ namespace EGG9000.Common.Database.Entities {
         public bool AnyLeague { get; set; }
         public bool SuccessfullyStarted { get; set; }
 
-        public ulong DiscordChannelId { get; set; } // V2 - Comment out
         public ulong GuildId { get; set; }
         public ulong OverflowGuildId { get; set; }
         public string UpdateMessagesId { get; set; }

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -50,7 +50,6 @@ namespace EGG9000.Common.Database.Entities {
         public string CreatorID { get; set; }
         public DateTimeOffset? LastUpdateToChannel { get; set; }
         public DateTimeOffset? WarningForDeleteChannel { get; set; }
-        public bool DeletedChannel { get; set; } // V2 - Comment out
         public uint FindChannelErrors { get; set; } = 0; // V2 - Comment out
         public ulong Group { get; set; }
         public bool AddedFromBackup { get; set; } = false;

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -285,7 +285,7 @@ namespace EGG9000.Common.Helpers {
             }
 
             if(extraRoles.Count > 0) {
-                var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.UserId == dbuser.Id && !x.Coop.ThreadArchived && !x.Coop.DeletedChannel).ToListAsync();
+                var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.UserId == dbuser.Id && !x.Coop.ThreadArchived).ToListAsync();
 
                 //Handle the case where users rank up, and need to still see existing coops
                 var lostXrefs = xrefs.Where(x => extraGrades.Any(eg => eg.grade == (Ei.Contract.Types.PlayerGrade)x.Coop.League));

--- a/EGG9000.Common/Migrations/20260715192527_DropV1CoopColumns.Designer.cs
+++ b/EGG9000.Common/Migrations/20260715192527_DropV1CoopColumns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EGG9000.Common.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace EGG9000.Common.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715192527_DropV1CoopColumns")]
+    partial class DropV1CoopColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EGG9000.Common/Migrations/20260715192527_DropV1CoopColumns.cs
+++ b/EGG9000.Common/Migrations/20260715192527_DropV1CoopColumns.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EGG9000.Common.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropV1CoopColumns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Coops_DiscordChannelId_ThreadArchived_CoopEnds_ThreadID",
+                table: "Coops");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Coops_GuildId_ContractID_League",
+                table: "Coops");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedChannel",
+                table: "Coops");
+
+            migrationBuilder.DropColumn(
+                name: "DiscordChannelId",
+                table: "Coops");
+
+            migrationBuilder.DropColumn(
+                name: "FindChannelErrors",
+                table: "Coops");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Coops_GuildId_ContractID_League",
+                table: "Coops",
+                columns: new[] { "GuildId", "ContractID", "League" },
+                filter: "NOT \"Finished\" AND NOT \"ThreadArchived\"");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Coops_ThreadArchived_CoopEnds_ThreadID",
+                table: "Coops",
+                columns: new[] { "ThreadArchived", "CoopEnds", "ThreadID" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Coops_GuildId_ContractID_League",
+                table: "Coops");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Coops_ThreadArchived_CoopEnds_ThreadID",
+                table: "Coops");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "DeletedChannel",
+                table: "Coops",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "DiscordChannelId",
+                table: "Coops",
+                type: "numeric(20,0)",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<long>(
+                name: "FindChannelErrors",
+                table: "Coops",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Coops_DiscordChannelId_ThreadArchived_CoopEnds_ThreadID",
+                table: "Coops",
+                columns: new[] { "DiscordChannelId", "ThreadArchived", "CoopEnds", "ThreadID" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Coops_GuildId_ContractID_League",
+                table: "Coops",
+                columns: new[] { "GuildId", "ContractID", "League" },
+                filter: "NOT \"Finished\" AND NOT \"DeletedChannel\" AND NOT \"ThreadArchived\"");
+        }
+    }
+}

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -505,8 +505,7 @@ namespace EGG9000.Site.Controllers {
             var coopsToFix = coops.Where(x => x.UserCoopsXrefs.Any(y => y.OutsideCoop));
 
             foreach(var coop in coopsToFix) {
-                var channel = coop.ThreadID != 0 ? _discord.Guilds.First(x => x.Id == coop.OverflowGuildId).GetTextChannel(coop.ThreadID) :
-                    _discord.Guilds.First(x => x.Id == coop.OverflowGuildId).GetTextChannel(coop.DiscordChannelId);
+                var channel = _discord.Guilds.First(x => x.Id == coop.OverflowGuildId).GetTextChannel(coop.ThreadID);
                 var messages = await channel.GetMessagesAsync().FlattenAsync();
                 foreach(var message in messages.Where(x => x.Content.Contains("has joined another co-op named . Please use the command"))) {
                     Console.WriteLine($"Deleting message from {coop.Name}");
@@ -672,7 +671,7 @@ namespace EGG9000.Site.Controllers {
                 TotalCoopSleep = x.TotalHoursSleeping,
                 CoopName = x.Coop.Name,
                 ContractName = x.Coop.Contract.Name,
-                DiscordChannelId = x.Coop.ThreadID != 0 ? x.Coop.ThreadID : x.Coop.DiscordChannelId,
+                DiscordChannelId = x.Coop.ThreadID,
                 GuildId = guildId,
                 Demerits = x.User.Demerits.Where(y => y.When > demeritExpires).ToList(),
                 FreshEgg = x.User.Registered > DateTimeOffset.UtcNow.AddDays(-7)
@@ -716,7 +715,7 @@ namespace EGG9000.Site.Controllers {
                 var xrefs = await _db.UserCoopXrefs.AsQueryable().Where(x => !x.Coop.DeletedChannel && !x.Coop.ThreadArchived && x.Coop.OverflowGuildId == overflowGuildId && !x.JoinedCoop).Select(x => new Ghost {
                     Coop = x.Coop.Name,
                     DiscordId = x.User.DiscordId,
-                    CoopChannel = x.Coop.ThreadID != 0 ? x.Coop.ThreadID : x.Coop.DiscordChannelId,
+                    CoopChannel = x.Coop.ThreadID,
                     UserName = x.User.DiscordUsername,
                     CoopId = x.CoopId,
                     UserId = x.UserId,
@@ -916,8 +915,8 @@ namespace EGG9000.Site.Controllers {
             var coopChannels = _discord.Guilds.SelectMany(x => x.TextChannels);
 
             var coopsWithChannels = coops.Select(c => new CoopWithChannels {
-                Coop = c, MainChannel = coopChannels.FirstOrDefault(x => (x.Id == c.ThreadID && c.ThreadID != 0) || (x.Id == c.DiscordChannelId && c.DiscordChannelId != 0)),
-                ExtraChannels = [.. coopChannels.Where(x => x.Id != c.ThreadID && x.Id != c.DiscordChannelId && StripEmoji(x.Name).Equals(c.Name, StringComparison.CurrentCultureIgnoreCase))]
+                Coop = c, MainChannel = coopChannels.FirstOrDefault(x => x.Id == c.ThreadID && c.ThreadID != 0),
+                ExtraChannels = [.. coopChannels.Where(x => x.Id != c.ThreadID && StripEmoji(x.Name).Equals(c.Name, StringComparison.CurrentCultureIgnoreCase))]
             }).ToList();
 
             return View(coopsWithChannels.Where(x => x.ExtraChannels.Any()).ToList());
@@ -939,8 +938,8 @@ namespace EGG9000.Site.Controllers {
             var coopChannels = _discord.Guilds.Where(x => x.Id == guildId || dbguild.OverflowServers.Any(y => y == x.Id)).SelectMany(x => x.TextChannels);
 
             var coopsWithChannels = coops.Select(c => new CoopWithChannels {
-                Coop = c, MainChannel = coopChannels.FirstOrDefault(x => (x.Id == c.ThreadID && c.ThreadID != 0) || (x.Id == c.DiscordChannelId && c.DiscordChannelId != 0)),
-                ExtraChannels = [.. coopChannels.Where(x => x.Id != c.ThreadID && x.Id != c.DiscordChannelId && StripEmoji(x.Name).Equals(c.Name, StringComparison.CurrentCultureIgnoreCase))]
+                Coop = c, MainChannel = coopChannels.FirstOrDefault(x => x.Id == c.ThreadID && c.ThreadID != 0),
+                ExtraChannels = [.. coopChannels.Where(x => x.Id != c.ThreadID && StripEmoji(x.Name).Equals(c.Name, StringComparison.CurrentCultureIgnoreCase))]
             }).ToList();
 
             foreach(var channel in coopsWithChannels.Where(x => x.ExtraChannels.Any()).SelectMany(x => x.ExtraChannels)) {

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -184,7 +184,7 @@ namespace EGG9000.Site.Controllers {
                 })],
                 Guild = guild,
                 ContractsToScore = contractsToScore,
-                CoopsWithoutThreads = await _db.Coops.CountAsync(x => x.ThreadID == 0 && (x.Status == CoopStatusEnum.WaitingOnThread || x.Status == CoopStatusEnum.WaitingOnCreation) && !x.DeletedChannel && x.CoopEnds > DateTimeOffset.UtcNow)
+                CoopsWithoutThreads = await _db.Coops.CountAsync(x => x.ThreadID == 0 && (x.Status == CoopStatusEnum.WaitingOnThread || x.Status == CoopStatusEnum.WaitingOnCreation) && x.CoopEnds > DateTimeOffset.UtcNow)
             });
         }
 
@@ -500,7 +500,7 @@ namespace EGG9000.Site.Controllers {
 
         public async Task<IActionResult> DeleteOutsideCoopMessage() {
             var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
-            var coops = await _db.Coops.AsQueryable().Include(x => x.UserCoopsXrefs).Where(x => x.GuildId == guildId && !x.DeletedChannel && !x.ThreadArchived).ToListAsync();
+            var coops = await _db.Coops.AsQueryable().Include(x => x.UserCoopsXrefs).Where(x => x.GuildId == guildId && !x.ThreadArchived).ToListAsync();
 
             var coopsToFix = coops.Where(x => x.UserCoopsXrefs.Any(y => y.OutsideCoop));
 
@@ -665,7 +665,7 @@ namespace EGG9000.Site.Controllers {
         public async Task<IActionResult> Sleepers() {
             var guildId = ulong.Parse(((ClaimsIdentity)User.Identity).Claims.First(x => x.Type == "GuildId").Value);
             var demeritExpires = DateTimeOffset.UtcNow.AddDays(-2);
-            var sleepers = await _db.UserCoopXrefs.AsQueryable().Where(x => x.User.GuildId == guildId && !x.Coop.DeletedChannel && !x.Coop.ThreadArchived).Select(x => new SleeperDetail {
+            var sleepers = await _db.UserCoopXrefs.AsQueryable().Where(x => x.User.GuildId == guildId && !x.Coop.ThreadArchived).Select(x => new SleeperDetail {
                 DiscordName = x.User.DiscordUsername,
                 CurrentSleep = x.HoursSleeping - (x.SiloTimeHours ?? 0),
                 TotalCoopSleep = x.TotalHoursSleeping,
@@ -712,7 +712,7 @@ namespace EGG9000.Site.Controllers {
                 var overflowGuild = _discord.Guilds.First(x => x.Id == overflowGuildId);
                 await overflowGuild.DownloadUsersAsync();
                 var oneWeekAgo = DateTimeOffset.UtcNow.AddDays(-7);
-                var xrefs = await _db.UserCoopXrefs.AsQueryable().Where(x => !x.Coop.DeletedChannel && !x.Coop.ThreadArchived && x.Coop.OverflowGuildId == overflowGuildId && !x.JoinedCoop).Select(x => new Ghost {
+                var xrefs = await _db.UserCoopXrefs.AsQueryable().Where(x => !x.Coop.ThreadArchived && x.Coop.OverflowGuildId == overflowGuildId && !x.JoinedCoop).Select(x => new Ghost {
                     Coop = x.Coop.Name,
                     DiscordId = x.User.DiscordId,
                     CoopChannel = x.Coop.ThreadID,
@@ -910,7 +910,7 @@ namespace EGG9000.Site.Controllers {
         public async Task<ActionResult> DuplicateChannels() {
 
 
-            var coops = await _db.Coops.AsQueryable().Where(x => !x.ThreadArchived && !x.DeletedChannel).ToListAsync();
+            var coops = await _db.Coops.AsQueryable().Where(x => !x.ThreadArchived).ToListAsync();
 
             var coopChannels = _discord.Guilds.SelectMany(x => x.TextChannels);
 
@@ -933,7 +933,7 @@ namespace EGG9000.Site.Controllers {
             var dbguild = await _db.Guilds.FirstAsync(x => x.Id == guildId);
 
 
-            var coops = await _db.Coops.AsQueryable().Where(x => !x.ThreadArchived && !x.DeletedChannel).ToListAsync();
+            var coops = await _db.Coops.AsQueryable().Where(x => !x.ThreadArchived).ToListAsync();
 
             var coopChannels = _discord.Guilds.Where(x => x.Id == guildId || dbguild.OverflowServers.Any(y => y == x.Id)).SelectMany(x => x.TextChannels);
 

--- a/EGG9000.Site/Controllers/ContractController.cs
+++ b/EGG9000.Site/Controllers/ContractController.cs
@@ -245,7 +245,7 @@ namespace EGG9000.Site.Controllers {
             var discordUser = guild.Users.First(x => x.Id == dbuser.DiscordId);
             var guildId = targetCoop.OverflowGuildId > 0 ? targetCoop.OverflowGuildId : targetCoop.GuildId;
 
-            var channel = targetCoop.ThreadID != 0 ? (SocketThreadChannel)_discord.GetChannel(targetCoop.ThreadID) : (SocketTextChannel)_discord.GetChannel(targetCoop.DiscordChannelId);
+            var channel = (SocketThreadChannel)_discord.GetChannel(targetCoop.ThreadID);
             var eggIncName = dbuser.EggIncAccounts.First(x => x.Id == EggIncId).Name;
             var xref = await CreateCoopsV2.MoveUser(targetCoop, UserId, EggIncId, eggIncName, _db, discordUser, dbuser, channel, null);
 

--- a/EGG9000.Site/Controllers/HomeController.cs
+++ b/EGG9000.Site/Controllers/HomeController.cs
@@ -121,7 +121,7 @@ namespace EGG9000.Site.Controllers {
 
                 foreach(var coop in guildGroup.OrderBy(x => rnd.Next())) {
                     var UpdateMessageIDs = JsonConvert.DeserializeObject<List<ulong>>(coop.UpdateMessagesId ?? "[]");
-                    var channel = coop.ThreadID != 0 ? guild.GetThreadChannel(coop.ThreadID) : guild.GetTextChannel(coop.DiscordChannelId);
+                    var channel = guild.GetThreadChannel(coop.ThreadID);
                     if(channel == null) {
                         continue;
                     }

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -48,7 +48,7 @@
         CoopId = (isAdmin || c.CoopParticipants.Any(u => u.DiscordUser?.Id.ToString() == discordId)) ? c.Coop.Id : Guid.Empty,
         HoursToFinish = c.TimeRemaining.TotalHours,
         DiscordChannelId = c.Coop.ThreadID.ToString(),
-        DeletedChannel = (c.Coop.ThreadID != 0 ? c.Coop.ThreadArchived : c.Coop.DeletedChannel),
+        DeletedChannel = c.Coop.ThreadArchived,
         OverflowGuildId = c.Coop.OverflowGuildId.ToString()
     });
 

--- a/EGG9000.Site/Views/Contract/Details.cshtml
+++ b/EGG9000.Site/Views/Contract/Details.cshtml
@@ -47,7 +47,7 @@
         Percent = (c.CoopParticipants.Sum(x => x.Projected) / targetAmount).ToString("P0"),
         CoopId = (isAdmin || c.CoopParticipants.Any(u => u.DiscordUser?.Id.ToString() == discordId)) ? c.Coop.Id : Guid.Empty,
         HoursToFinish = c.TimeRemaining.TotalHours,
-        DiscordChannelId = (c.Coop.ThreadID != 0 ? c.Coop.ThreadID.ToString() : c.Coop.DiscordChannelId.ToString()),
+        DiscordChannelId = c.Coop.ThreadID.ToString(),
         DeletedChannel = (c.Coop.ThreadID != 0 ? c.Coop.ThreadArchived : c.Coop.DeletedChannel),
         OverflowGuildId = c.Coop.OverflowGuildId.ToString()
     });

--- a/EGG9000.Site/Views/Home/Coop.cshtml
+++ b/EGG9000.Site/Views/Home/Coop.cshtml
@@ -54,7 +54,6 @@
 			if (!discordChannelDeleted) {
 				var discordGuildID = Model.CoopDetails.Coop?.OverflowGuildId != default ? Model.CoopDetails.Coop.OverflowGuildId : Model.CoopDetails.Coop.GuildId;
 				var discordChannelID = Model.CoopDetails.Coop?.ThreadID;
-				if (discordChannelID == 0) discordChannelID = Model.CoopDetails.Coop?.DiscordChannelId;
 				var discordLink = "discord://discordapp.com/channels/" + discordGuildID + "/" + discordChannelID + "/";
 				<a href="@discordLink" alt="Discord channel link" target="_self"><img style="max-height: 1em;" src="/images/discordicon.png" /> @Model.CoopStatus.CoopIdentifier</a>
 			}

--- a/EGG9000.Site/Views/Home/Coop.cshtml
+++ b/EGG9000.Site/Views/Home/Coop.cshtml
@@ -27,7 +27,7 @@
 	var projectPercentEveryone = Model.CoopDetails.CoopParticipants.Sum(x => x.Projected) / targetAmount * 100;
 	var projectPercentEveryoneStr = PercentString(projectPercentEveryone);
 
-	var discordChannelDeleted = ((Model.CoopDetails.Coop?.ThreadID != 0 ? Model.CoopDetails.Coop?.ThreadArchived : Model.CoopDetails.Coop?.DeletedChannel)) ?? true;
+	var discordChannelDeleted = (Model.CoopDetails.Coop?.ThreadArchived) ?? true;
 
 
 	var projectPercentWidth = Math.Min(projectPercent, 100) - percent;

--- a/EGG9000.Test/CoopAssignmentLookup.cs
+++ b/EGG9000.Test/CoopAssignmentLookup.cs
@@ -18,8 +18,8 @@ namespace EGG9000.Test {
         [TestMethod]
         public void Build_GroupsMultipleCoopsUnderOneUserContractKey() {
             var rows = new List<CoopAssignmentRow> {
-                new(UserA, Coop1, "c1", 100, 0, "alpha"),
-                new(UserA, Coop2, "c1", 200, 0, "beta"),
+                new(UserA, Coop1, "c1", 100, "alpha"),
+                new(UserA, Coop2, "c1", 200, "beta"),
             };
 
             var map = CoopAssignmentLookup.Build(rows);
@@ -31,8 +31,8 @@ namespace EGG9000.Test {
         [TestMethod]
         public void Build_DeduplicatesSameCoopId() {
             var rows = new List<CoopAssignmentRow> {
-                new(UserA, Coop1, "c1", 100, 0, "alpha"),
-                new(UserA, Coop1, "c1", 100, 0, "alpha"),
+                new(UserA, Coop1, "c1", 100, "alpha"),
+                new(UserA, Coop1, "c1", 100, "alpha"),
             };
 
             var map = CoopAssignmentLookup.Build(rows);
@@ -43,9 +43,9 @@ namespace EGG9000.Test {
         [TestMethod]
         public void Build_SeparatesByUserAndContract() {
             var rows = new List<CoopAssignmentRow> {
-                new(UserA, Coop1, "c1", 100, 0, "alpha"),
-                new(UserB, Coop1, "c1", 100, 0, "alpha"),
-                new(UserA, Coop2, "c2", 200, 0, "beta"),
+                new(UserA, Coop1, "c1", 100, "alpha"),
+                new(UserB, Coop1, "c1", 100, "alpha"),
+                new(UserA, Coop2, "c2", 200, "beta"),
             };
 
             var map = CoopAssignmentLookup.Build(rows);
@@ -58,13 +58,12 @@ namespace EGG9000.Test {
 
         [TestMethod]
         public void Build_PreservesCoopFields() {
-            var rows = new List<CoopAssignmentRow> { new(UserA, Coop1, "c1", 555, 777, "gamma") };
+            var rows = new List<CoopAssignmentRow> { new(UserA, Coop1, "c1", 555, "gamma") };
 
             var coop = CoopAssignmentLookup.Build(rows)[(UserA, "c1")].Single();
 
             Assert.AreEqual(Coop1, coop.CoopId);
             Assert.AreEqual(555ul, coop.ThreadId);
-            Assert.AreEqual(777ul, coop.DiscordChannelId);
             Assert.AreEqual("gamma", coop.Name);
             Assert.AreEqual("c1", coop.ContractId);
         }


### PR DESCRIPTION
Since we're cutover to Threads entirely now, removes the DB columns associated with Discord Channel, and adds a migration to drop them.