### PR TITLE
Fix: MyFarms Backup Freshness

### DIFF
--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -193,10 +193,6 @@ namespace EGG9000.Site.Controllers {
             return Json(new { imageB64 = Convert.ToBase64String(render.Jpeg), manifest = render.Manifest });
         }
 
-        // Lets the page poll whether RefreshBackupsInBackground has landed a newer backup than what was
-        // rendered, so it can reload once instead of showing stale data until the next manual refresh.
-        // Read-only, no side effects; same owner-or-staff gate as InventoryOverlay. Returns only a
-        // timestamp, never account content.
         [HttpGet]
         public async Task<IActionResult> BackupFreshness(ulong discordId) {
             var loginuser = await _userManager.GetUserAsync(User);

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -61,7 +61,24 @@ namespace EGG9000.Site.Controllers {
 
         [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin,GuildReadOnlyAdmin")]
         public async Task<IActionResult> ViewUser(ulong discordId) {
+            var model = await BuildViewUserModel(discordId);
+            return View("Index", model);
+        }
 
+        [HttpGet]
+        public async Task<IActionResult> RefreshContent(ulong discordId) {
+            var loginuser = await _userManager.GetUserAsync(User);
+            var logins = await _userManager.GetLoginsAsync(loginuser);
+            var loginUserId = ulong.Parse(logins.First().ProviderKey);
+
+            var isStaff = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
+            if(discordId != loginUserId && !isStaff) return Forbid();
+
+            var model = await BuildViewUserModel(discordId);
+            return PartialView("Index", model);
+        }
+
+        private async Task<MyFarmsModel> BuildViewUserModel(ulong discordId) {
 
             Console.WriteLine("ViewUser");
             var times = new TimingsFactory(_logger);
@@ -163,7 +180,7 @@ namespace EGG9000.Site.Controllers {
 
 
             Console.WriteLine(string.Join("\n", times.Finished().Select(y => $"{y.name}: {y.time.Humanize().ShortenTime()}")));
-            return View("Index", new MyFarmsModel(user, Contracts, Demerits, Merits, /*RawBackups,*/ Snapshots, xrefs, coops, erItems, scoring, DbGuild, uncompletedPes, dbCustomEggs, isSelf, cachedContracts, seasonPEByEggIncId, missingSeasonalPEByEggIncId));
+            return new MyFarmsModel(user, Contracts, Demerits, Merits, /*RawBackups,*/ Snapshots, xrefs, coops, erItems, scoring, DbGuild, uncompletedPes, dbCustomEggs, isSelf, cachedContracts, seasonPEByEggIncId, missingSeasonalPEByEggIncId);
         }
 
         // Lazily renders the artifact-inventory image plus its hover-target manifest for one account. The

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -193,6 +193,26 @@ namespace EGG9000.Site.Controllers {
             return Json(new { imageB64 = Convert.ToBase64String(render.Jpeg), manifest = render.Manifest });
         }
 
+        // Lets the page poll whether RefreshBackupsInBackground has landed a newer backup than what was
+        // rendered, so it can reload once instead of showing stale data until the next manual refresh.
+        // Read-only, no side effects; same owner-or-staff gate as InventoryOverlay. Returns only a
+        // timestamp, never account content.
+        [HttpGet]
+        public async Task<IActionResult> BackupFreshness(ulong discordId) {
+            var loginuser = await _userManager.GetUserAsync(User);
+            var logins = await _userManager.GetLoginsAsync(loginuser);
+            var loginUserId = ulong.Parse(logins.First().ProviderKey);
+
+            var isStaff = User.IsInRole("Admin") || User.IsInRole("GuildAdmin") || User.IsInRole("GuildLesserAdmin") || User.IsInRole("GuildReadOnlyAdmin");
+            if(discordId != loginUserId && !isStaff) return Forbid();
+
+            var user = await _db.DBUsers.AsNoTracking().FirstOrDefaultAsync(x => x.DiscordId == discordId);
+            if(user is null) return NotFound();
+
+            var latest = user.EggIncAccounts.Count == 0 ? 0 : user.EggIncAccounts.Max(a => a.Backup?.LastBackupTime ?? 0);
+            return Json(new { latest });
+        }
+
         private async Task GetScores(DBUser user, List<(string EggIncId, MyContracts MyContracts)> scoring) {
             // MyContracts scores per account (cached 1h, network-only on miss). Never touches _db, so it is safe
             // to run concurrently with the controller's DB queries.

--- a/EGG9000.Site/Views/MyFarms/-EarningsBoostCalculator.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EarningsBoostCalculator.cshtml
@@ -9,7 +9,18 @@
         max-height: 20px;
     }
 </style>
-<div x-data="earningsBoostCalc()">
+<div x-data="earningsBoostCalc()" data-earnings-boost-config="@Json.Serialize(new {
+    boostValue = Model.Event?.Multiplier ?? 1,
+    farms = Model.Backup.Farms.Where(x => x.FarmType != Ei.FarmType.Empty).Select(x => {
+        var farm = x.WithStats(Model.Backup, null, Model.CustomEggs);
+        var name = x.FarmType == Ei.FarmType.Home ? "Home" : $"{x.ContractId} ({x.CoopId})";
+        return new {
+            Name = name,
+            Income = farm.Income * (Model.Event?.Multiplier ?? 1),
+            IncomeRunning = farm.MaxRunningBonus * farm.Income * (Model.Event?.Multiplier ?? 1)
+        };
+    })
+})">
     <div class="d-flex align-items-center gap-2" style="padding-top:10px">
         <div class="form-group">
             <label style="margin-right:5px;">Farm</label>
@@ -109,7 +120,7 @@
 <script type="text/javascript">
     document.addEventListener('alpine:init', () => {
         Alpine.data('earningsBoostCalc', () => ({
-            boostValue: @(Model.Event?.Multiplier ?? 1),
+            boostValue: 1,
             farms: [],
             selectedFarm: null,
             selectedFarmIndex: 0,
@@ -121,20 +132,9 @@
             calculating: false,
 
             init() {
-                const _farmsRaw = @Html.Raw(
-                    Json.Serialize(
-                        Model.Backup.Farms.Where(x => x.FarmType != Ei.FarmType.Empty).Select(x => {
-                        var farm = x.WithStats(Model.Backup, null, Model.CustomEggs);
-                            var name = x.FarmType == Ei.FarmType.Home ? "Home" : $"{x.ContractId} ({x.CoopId})";
-                            return new {
-                                Name = name,
-                                Income = farm.Income * (Model.Event?.Multiplier ?? 1),
-                                IncomeRunning = farm.MaxRunningBonus * farm.Income * (Model.Event?.Multiplier ?? 1)
-                            };
-                        })
-                    )
-                );
-                this.farms = _farmsRaw;
+                const config = JSON.parse(this.$el.dataset.earningsBoostConfig);
+                this.boostValue = config.boostValue;
+                this.farms = config.farms;
                 this.selectedFarm = this.farms[0] || { name: '', income: 0, incomeRunning: 0 };
                 this.startCalculate();
             },

--- a/EGG9000.Site/Views/MyFarms/-EpicResearch.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EpicResearch.cshtml
@@ -16,7 +16,13 @@
 	var bankScalar = !Model.account.HasActiveSubscription() ? 1 : (Model.account.SubscriptionLevel == 0 ? 1.25 : 1.40);
 	var totalBankGE = (ulong)(Model.backup.TotalGEInPiggyBank * bankScalar);
 }
-<div class="card" style="margin-top:15px" x-data="epicResearchPage()">
+<div class="card" style="margin-top:15px" x-data="epicResearchPage()" data-epic-research-config="@Json.Serialize(new {
+	items = Model.epicResearchConfig,
+	currentGE = Model.backup.GoldenEggsEarned - Model.backup.GoldenEggsSpent,
+	rawGEInPiggyBank = Model.backup.TotalGEInPiggyBank,
+	totalBankGE = totalBankGE,
+	rawBankGE = rawBankGE
+})">
 	<h4 class="card-header mb-3 d-flex justify-content-between align-items-center" style="gap:12px;">
 		<span style="flex:0 1 auto;">Epic Research GE Calculator</span>
 		<select id="discount-select" class="form-select form-select-sm" x-model.number="Discount" style="width:auto; flex:0 0 auto; min-width:160px;">
@@ -154,15 +160,15 @@
 			Discount: 0,
 
 			init() {
-				const _rawConfig = @Html.Raw(Json.Serialize(Model.epicResearchConfig));
-				this.EpicResearchConfig = _rawConfig;
+				const config = JSON.parse(this.$el.dataset.epicResearchConfig);
+				this.EpicResearchConfig = config.items;
 				this.EpicResearchConfig.forEach(er => {
 					er.levelsToBuy = er.costs.length - er.mappedBackupResearch.level;
 				});
-				this.currentGE = @(Model.backup.GoldenEggsEarned - Model.backup.GoldenEggsSpent);
-				this.rawGEInPiggyBank = @Model.backup.TotalGEInPiggyBank;
-				this.totalBankGE = @totalBankGE;
-				this.rawBankGE = @rawBankGE;
+				this.currentGE = config.currentGE;
+				this.rawGEInPiggyBank = config.rawGEInPiggyBank;
+				this.totalBankGE = config.totalBankGE;
+				this.rawBankGE = config.rawBankGE;
 			},
 
 			getCostForLevels(epicResearch, single = false) {

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -34,6 +34,7 @@
 
     var inDB = Model.User.DiscordId > 0;
 
+    var latestBackupAtRender = Model.User.EggIncAccounts.Count == 0 ? 0 : Model.User.EggIncAccounts.Max(a => a.Backup?.LastBackupTime ?? 0);
 }
 
 <style>
@@ -997,5 +998,28 @@
             div.textContent = text;
             return div.innerHTML;
         }
+
+        (function() {
+            var discordId = @Model.User.DiscordId;
+            var since = @latestBackupAtRender;
+            var attempts = 0;
+            var maxAttempts = 6;
+            var poll = setInterval(function() {
+                attempts++;
+                if(attempts > maxAttempts) {
+                    clearInterval(poll);
+                    return;
+                }
+                fetch('/MyFarms/BackupFreshness?discordId=' + discordId)
+                    .then(function(r) { return r.ok ? r.json() : null; })
+                    .then(function(data) {
+                        if(data && data.latest > since) {
+                            clearInterval(poll);
+                            location.reload();
+                        }
+                    })
+                    .catch(function() {});
+            }, 4000);
+        })();
     </script>
 }

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -275,6 +275,7 @@
     </div>
 }
 
+<div id="myfarms-content">
 <div>
     @if (isLesserAdmin || isAdmin) {
         if (Model.User.TempDisabled) {
@@ -614,6 +615,7 @@
         </div>
     }
 </div>
+</div>
 
 @section Scripts {
     <script src="~/js/artifact-overlay.js" asp-append-version="true"></script>
@@ -651,10 +653,18 @@
             });
         }
 
+        function hydrateMyFarmsContent() {
+            updateLastBackupTime();
+            wireContractSettings();
+            wireTestAssignment();
+            if (window.ArtifactOverlay) window.ArtifactOverlay.scan();
+        }
+        window.hydrateMyFarmsContent = hydrateMyFarmsContent;
+
         $(document).ready(() => {
             let url = location.href.replace(/\/$/, "");
 
-            updateLastBackupTime();
+            hydrateMyFarmsContent();
 
             if (location.hash) {
                 const hash = url.split("#");
@@ -676,7 +686,9 @@
 
             }
 
-            $('a[data-bs-toggle="tab"]').on("click", function () {
+            // Delegated on document, not the tab links themselves - survives a background content
+            // swap (BackupFreshness poll) without needing to be rebound.
+            $(document).on("click", 'a[data-bs-toggle="tab"]', function () {
                 let newUrl;
                 const hash = $(this).attr("href");
 
@@ -687,7 +699,7 @@
                 history.replaceState(null, null, newUrl);
             });
 
-            $("[id^='ArchivedFarmsSearch']").keyup(function () {
+            $(document).on("keyup", "[id^='ArchivedFarmsSearch']", function () {
                 var terms = $(this).val().split(" ");
                 var showAll = $(this).val().trim().length == 0;
                 var index = $(this).attr('id').replace("ArchivedFarmsSearch", "");
@@ -711,9 +723,6 @@
             });
 
             setInterval(updateLastBackupTime, 1000);
-
-            wireContractSettings();
-            wireTestAssignment();
         });
 
         function rewardGroupValue(group) {
@@ -999,6 +1008,30 @@
             return div.innerHTML;
         }
 
+        function swapMyFarmsContent(discordId) {
+            var current = document.getElementById('myfarms-content');
+            var activeOuterTab = current.querySelector('.nav-tabs > li > a.active');
+            var activeInnerTab = current.querySelector('.tab-pane.active .nav-tabs > li > a.active, .tab-pane.active .nav-link.active');
+
+            return fetch('/MyFarms/RefreshContent?discordId=' + discordId)
+                .then(function(r) { return r.ok ? r.text() : null; })
+                .then(function(html) {
+                    if(!html) return;
+                    var fresh = new DOMParser().parseFromString(html, 'text/html').getElementById('myfarms-content');
+                    if(!fresh) return;
+
+                    current.innerHTML = fresh.innerHTML;
+                    hydrateMyFarmsContent();
+
+                    [activeOuterTab, activeInnerTab].forEach(function(tab) {
+                        if(!tab) return;
+                        var href = tab.getAttribute('href');
+                        var replacement = href ? current.querySelector('a[href="' + href + '"]') : null;
+                        if(replacement) bootstrap.Tab.getOrCreateInstance(replacement).show();
+                    });
+                });
+        }
+
         (function() {
             var discordId = @Model.User.DiscordId;
             var since = @latestBackupAtRender;
@@ -1010,7 +1043,7 @@
                     .then(function(r) { return r.ok ? r.json() : null; })
                     .then(function(data) {
                         if(data && data.latest > since) {
-                            location.reload();
+                            swapMyFarmsContent(discordId);
                         } else {
                             setTimeout(function() { poll(attempt + 1); }, 4000);
                         }

--- a/EGG9000.Site/Views/MyFarms/Index.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Index.cshtml
@@ -1002,24 +1002,23 @@
         (function() {
             var discordId = @Model.User.DiscordId;
             var since = @latestBackupAtRender;
-            var attempts = 0;
             var maxAttempts = 6;
-            var poll = setInterval(function() {
-                attempts++;
-                if(attempts > maxAttempts) {
-                    clearInterval(poll);
-                    return;
-                }
+
+            function poll(attempt) {
+                if(attempt > maxAttempts) return;
                 fetch('/MyFarms/BackupFreshness?discordId=' + discordId)
                     .then(function(r) { return r.ok ? r.json() : null; })
                     .then(function(data) {
                         if(data && data.latest > since) {
-                            clearInterval(poll);
                             location.reload();
+                        } else {
+                            setTimeout(function() { poll(attempt + 1); }, 4000);
                         }
                     })
-                    .catch(function() {});
-            }, 4000);
+                    .catch(function() { setTimeout(function() { poll(attempt + 1); }, 4000); });
+            }
+
+            setTimeout(function() { poll(1); }, 4000);
         })();
     </script>
 }


### PR DESCRIPTION
Had attempted an implementation of the "use the cached data until we can load the new backup," however it had a very minimal/non-functional "callback," to the client, which in effect meant users needed to refresh again to see new data.

This PR changes the mechanism, so that:
- We load MyFarms "instantly," with the data that we have at the time
- New backup load happens in the background
- Page content 'refreshes' when the new backup loads
  - Works for both main data, and the partials