### PR TITLE
Chore: new analyzer to detect EF Core-incompatible string.Equals usage in IQueryable LINQ expression

### DIFF
--- a/EGG9000.Analyzers.Test/LinqStringEqualsAnalyzerTests.cs
+++ b/EGG9000.Analyzers.Test/LinqStringEqualsAnalyzerTests.cs
@@ -17,14 +17,9 @@ namespace EGG9000.Analyzers.Test {
     [TestCategory("Unit")]
     public class LinqStringEqualsAnalyzerTests {
 
-        /// <summary>
-        /// Builds a compilation with all runtime + System.Linq references so that
-        /// IQueryable&lt;T&gt;, StringComparison, etc. resolve correctly in test sources.
-        /// </summary>
         private static async Task<Diagnostic[]> GetDiagnosticsAsync(string source) {
             var tree = CSharpSyntaxTree.ParseText(source);
 
-            // Collect the core runtime assemblies needed for IQueryable<T> and StringComparison.
             var refs = new List<MetadataReference> {
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(System.Linq.IQueryable<>).Assembly.Location),
@@ -32,8 +27,6 @@ namespace EGG9000.Analyzers.Test {
                 MetadataReference.CreateFromFile(typeof(System.StringComparison).Assembly.Location),
             };
 
-            // Add all assemblies from the current AppDomain's trusted platform assemblies
-            // so that netX.0 ref-pack types (System.Runtime, etc.) are resolvable.
             var trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
             foreach(var path in trustedAssemblies.Split(Path.PathSeparator)) {
                 refs.Add(MetadataReference.CreateFromFile(path));
@@ -49,10 +42,6 @@ namespace EGG9000.Analyzers.Test {
             var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync();
             return [.. diagnostics];
         }
-
-        // -------------------------------------------------------------------------
-        // Cases that SHOULD produce a diagnostic
-        // -------------------------------------------------------------------------
 
         [TestMethod]
         public async Task Equals_WithStringComparison_InWhereLambda_OnIQueryable_Warning() {
@@ -107,10 +96,6 @@ namespace EGG9000.Analyzers.Test {
             Assert.IsTrue(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
         }
 
-        // -------------------------------------------------------------------------
-        // Cases that should NOT produce a diagnostic
-        // -------------------------------------------------------------------------
-
         [TestMethod]
         public async Task Equals_WithStringComparison_OnIEnumerable_NoDiagnostic() {
             var diagnostics = await GetDiagnosticsAsync("""
@@ -161,7 +146,6 @@ namespace EGG9000.Analyzers.Test {
 
         [TestMethod]
         public async Task Equals_WithStringComparison_AfterAsEnumerable_NoDiagnostic() {
-            // AsEnumerable() switches to IEnumerable — subsequent operators run in-process.
             var diagnostics = await GetDiagnosticsAsync("""
                 using System;
                 using System.Linq;

--- a/EGG9000.Analyzers.Test/LinqStringEqualsAnalyzerTests.cs
+++ b/EGG9000.Analyzers.Test/LinqStringEqualsAnalyzerTests.cs
@@ -1,0 +1,175 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using EGG9000.Analyzers;
+
+namespace EGG9000.Analyzers.Test;
+
+using Verify = CSharpAnalyzerVerifier<LinqStringEqualsAnalyzer, DefaultVerifier>;
+
+public class LinqStringEqualsAnalyzerTests {
+
+    // -------------------------------------------------------------------------
+    // Cases that SHOULD produce a diagnostic
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Equals_WithStringComparison_InWhereLambda_OnIQueryable_Warning() {
+        var source = """
+            using System;
+            using System.Linq;
+
+            public class Test {
+                public void Run(IQueryable<string> query, string value) {
+                    var result = query.Where(s => s.{|#0:Equals(value, StringComparison.OrdinalIgnoreCase)|});
+                }
+            }
+            """;
+
+        var expected = Verify.Diagnostic(LinqStringEqualsAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithSeverity(DiagnosticSeverity.Warning);
+
+        await Verify.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task Equals_WithStringComparison_InJoinLambda_OnIQueryable_Warning() {
+        var source = """
+            using System;
+            using System.Linq;
+
+            public class Coop { public string Name { get; set; } }
+            public class User { public string CoopName { get; set; } }
+
+            public class Test {
+                public void Run(IQueryable<User> users, IQueryable<Coop> coops, string targetName) {
+                    var result = users.Join(
+                        coops,
+                        u => u.CoopName,
+                        c => c.Name,
+                        (u, c) => new { u, c })
+                        .Where(x => x.c.Name.{|#0:Equals(targetName, StringComparison.CurrentCultureIgnoreCase)|});
+                }
+            }
+            """;
+
+        var expected = Verify.Diagnostic(LinqStringEqualsAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithSeverity(DiagnosticSeverity.Warning);
+
+        await Verify.VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public async Task Equals_WithStringComparison_InSelectLambda_OnIQueryable_Warning() {
+        var source = """
+            using System;
+            using System.Linq;
+
+            public class Test {
+                public void Run(IQueryable<string> query, string value) {
+                    var result = query.Select(s => s.{|#0:Equals(value, StringComparison.InvariantCultureIgnoreCase)|});
+                }
+            }
+            """;
+
+        var expected = Verify.Diagnostic(LinqStringEqualsAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithSeverity(DiagnosticSeverity.Warning);
+
+        await Verify.VerifyAnalyzerAsync(source, expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cases that should NOT produce a diagnostic
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Equals_WithStringComparison_OnIEnumerable_NoDiagnostic() {
+        // IEnumerable is evaluated in-process; no SQL translation required.
+        var source = """
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+
+            public class Test {
+                public void Run(IEnumerable<string> list, string value) {
+                    var result = list.Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task Equals_WithStringComparison_OutsideLambda_NoDiagnostic() {
+        // Plain method body — not inside any LINQ lambda.
+        var source = """
+            using System;
+
+            public class Test {
+                public bool Run(string a, string b) {
+                    return a.Equals(b, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task Equals_OneArgOverload_InIQueryableLambda_NoDiagnostic() {
+        // Only the two-argument overload (with StringComparison) is non-translatable.
+        var source = """
+            using System;
+            using System.Linq;
+
+            public class Test {
+                public void Run(IQueryable<string> query, string value) {
+                    var result = query.Where(s => s.Equals(value));
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NonStringEquals_WithTwoArgs_InIQueryableLambda_NoDiagnostic() {
+        // Receiver is not a string — should not flag.
+        var source = """
+            using System;
+            using System.Linq;
+
+            public class MyObj { public bool Equals(object other, StringComparison c) => true; }
+
+            public class Test {
+                public void Run(IQueryable<MyObj> query, MyObj value) {
+                    var result = query.Where(s => s.Equals(value, StringComparison.Ordinal));
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task Equals_WithStringComparison_InAsEnumerableLambda_NoDiagnostic() {
+        // Once AsEnumerable() is called, the subsequent LINQ operators run in-process.
+        var source = """
+            using System;
+            using System.Linq;
+
+            public class Test {
+                public void Run(IQueryable<string> query, string value) {
+                    var result = query.AsEnumerable()
+                                      .Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                }
+            }
+            """;
+
+        await Verify.VerifyAnalyzerAsync(source);
+    }
+}

--- a/EGG9000.Analyzers.Test/LinqStringEqualsAnalyzerTests.cs
+++ b/EGG9000.Analyzers.Test/LinqStringEqualsAnalyzerTests.cs
@@ -1,175 +1,180 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing;
 using EGG9000.Analyzers;
 
-namespace EGG9000.Analyzers.Test;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 
-using Verify = CSharpAnalyzerVerifier<LinqStringEqualsAnalyzer, DefaultVerifier>;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-public class LinqStringEqualsAnalyzerTests {
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
-    // -------------------------------------------------------------------------
-    // Cases that SHOULD produce a diagnostic
-    // -------------------------------------------------------------------------
+namespace EGG9000.Analyzers.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class LinqStringEqualsAnalyzerTests {
 
-    [Fact]
-    public async Task Equals_WithStringComparison_InWhereLambda_OnIQueryable_Warning() {
-        var source = """
-            using System;
-            using System.Linq;
+        /// <summary>
+        /// Builds a compilation with all runtime + System.Linq references so that
+        /// IQueryable&lt;T&gt;, StringComparison, etc. resolve correctly in test sources.
+        /// </summary>
+        private static async Task<Diagnostic[]> GetDiagnosticsAsync(string source) {
+            var tree = CSharpSyntaxTree.ParseText(source);
 
-            public class Test {
-                public void Run(IQueryable<string> query, string value) {
-                    var result = query.Where(s => s.{|#0:Equals(value, StringComparison.OrdinalIgnoreCase)|});
-                }
+            // Collect the core runtime assemblies needed for IQueryable<T> and StringComparison.
+            var refs = new List<MetadataReference> {
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Linq.IQueryable<>).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location),
+                MetadataReference.CreateFromFile(typeof(System.StringComparison).Assembly.Location),
+            };
+
+            // Add all assemblies from the current AppDomain's trusted platform assemblies
+            // so that netX.0 ref-pack types (System.Runtime, etc.) are resolvable.
+            var trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
+            foreach(var path in trustedAssemblies.Split(Path.PathSeparator)) {
+                refs.Add(MetadataReference.CreateFromFile(path));
             }
-            """;
 
-        var expected = Verify.Diagnostic(LinqStringEqualsAnalyzer.DiagnosticId)
-            .WithLocation(0)
-            .WithSeverity(DiagnosticSeverity.Warning);
+            var compilation = CSharpCompilation.Create("Test",
+                [tree],
+                refs.DistinctBy(r => r.Display),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-        await Verify.VerifyAnalyzerAsync(source, expected);
-    }
+            var analyzer = new LinqStringEqualsAnalyzer();
+            var withAnalyzers = compilation.WithAnalyzers([analyzer]);
+            var diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync();
+            return [.. diagnostics];
+        }
 
-    [Fact]
-    public async Task Equals_WithStringComparison_InJoinLambda_OnIQueryable_Warning() {
-        var source = """
-            using System;
-            using System.Linq;
+        // -------------------------------------------------------------------------
+        // Cases that SHOULD produce a diagnostic
+        // -------------------------------------------------------------------------
 
-            public class Coop { public string Name { get; set; } }
-            public class User { public string CoopName { get; set; } }
+        [TestMethod]
+        public async Task Equals_WithStringComparison_InWhereLambda_OnIQueryable_Warning() {
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
+                using System.Linq;
 
-            public class Test {
-                public void Run(IQueryable<User> users, IQueryable<Coop> coops, string targetName) {
-                    var result = users.Join(
-                        coops,
-                        u => u.CoopName,
-                        c => c.Name,
-                        (u, c) => new { u, c })
-                        .Where(x => x.c.Name.{|#0:Equals(targetName, StringComparison.CurrentCultureIgnoreCase)|});
+                public class Test {
+                    public void Run(IQueryable<string> query, string value) {
+                        var result = query.Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                    }
                 }
-            }
-            """;
+                """);
 
-        var expected = Verify.Diagnostic(LinqStringEqualsAnalyzer.DiagnosticId)
-            .WithLocation(0)
-            .WithSeverity(DiagnosticSeverity.Warning);
+            Assert.IsTrue(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
 
-        await Verify.VerifyAnalyzerAsync(source, expected);
-    }
+        [TestMethod]
+        public async Task Equals_WithStringComparison_InJoinLambda_OnIQueryable_Warning() {
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
+                using System.Linq;
 
-    [Fact]
-    public async Task Equals_WithStringComparison_InSelectLambda_OnIQueryable_Warning() {
-        var source = """
-            using System;
-            using System.Linq;
+                public class Coop { public string Name { get; set; } }
+                public class User { public string CoopName { get; set; } }
 
-            public class Test {
-                public void Run(IQueryable<string> query, string value) {
-                    var result = query.Select(s => s.{|#0:Equals(value, StringComparison.InvariantCultureIgnoreCase)|});
+                public class Test {
+                    public void Run(IQueryable<User> users, IQueryable<Coop> coops, string targetName) {
+                        var result = users
+                            .Join(coops, u => u.CoopName, c => c.Name, (u, c) => new { u, c })
+                            .Where(x => x.c.Name.Equals(targetName, StringComparison.CurrentCultureIgnoreCase));
+                    }
                 }
-            }
-            """;
+                """);
 
-        var expected = Verify.Diagnostic(LinqStringEqualsAnalyzer.DiagnosticId)
-            .WithLocation(0)
-            .WithSeverity(DiagnosticSeverity.Warning);
+            Assert.IsTrue(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
 
-        await Verify.VerifyAnalyzerAsync(source, expected);
-    }
+        [TestMethod]
+        public async Task Equals_WithStringComparison_InSelectLambda_OnIQueryable_Warning() {
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
+                using System.Linq;
 
-    // -------------------------------------------------------------------------
-    // Cases that should NOT produce a diagnostic
-    // -------------------------------------------------------------------------
-
-    [Fact]
-    public async Task Equals_WithStringComparison_OnIEnumerable_NoDiagnostic() {
-        // IEnumerable is evaluated in-process; no SQL translation required.
-        var source = """
-            using System;
-            using System.Collections.Generic;
-            using System.Linq;
-
-            public class Test {
-                public void Run(IEnumerable<string> list, string value) {
-                    var result = list.Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                public class Test {
+                    public void Run(IQueryable<string> query, string value) {
+                        var result = query.Select(s => s.Equals(value, StringComparison.InvariantCultureIgnoreCase));
+                    }
                 }
-            }
-            """;
+                """);
 
-        await Verify.VerifyAnalyzerAsync(source);
-    }
+            Assert.IsTrue(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
 
-    [Fact]
-    public async Task Equals_WithStringComparison_OutsideLambda_NoDiagnostic() {
-        // Plain method body — not inside any LINQ lambda.
-        var source = """
-            using System;
+        // -------------------------------------------------------------------------
+        // Cases that should NOT produce a diagnostic
+        // -------------------------------------------------------------------------
 
-            public class Test {
-                public bool Run(string a, string b) {
-                    return a.Equals(b, StringComparison.OrdinalIgnoreCase);
+        [TestMethod]
+        public async Task Equals_WithStringComparison_OnIEnumerable_NoDiagnostic() {
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
+                using System.Collections.Generic;
+                using System.Linq;
+
+                public class Test {
+                    public void Run(IEnumerable<string> list, string value) {
+                        var result = list.Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                    }
                 }
-            }
-            """;
+                """);
 
-        await Verify.VerifyAnalyzerAsync(source);
-    }
+            Assert.IsFalse(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
 
-    [Fact]
-    public async Task Equals_OneArgOverload_InIQueryableLambda_NoDiagnostic() {
-        // Only the two-argument overload (with StringComparison) is non-translatable.
-        var source = """
-            using System;
-            using System.Linq;
+        [TestMethod]
+        public async Task Equals_WithStringComparison_OutsideLambda_NoDiagnostic() {
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
 
-            public class Test {
-                public void Run(IQueryable<string> query, string value) {
-                    var result = query.Where(s => s.Equals(value));
+                public class Test {
+                    public bool Run(string a, string b) {
+                        return a.Equals(b, StringComparison.OrdinalIgnoreCase);
+                    }
                 }
-            }
-            """;
+                """);
 
-        await Verify.VerifyAnalyzerAsync(source);
-    }
+            Assert.IsFalse(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
 
-    [Fact]
-    public async Task NonStringEquals_WithTwoArgs_InIQueryableLambda_NoDiagnostic() {
-        // Receiver is not a string — should not flag.
-        var source = """
-            using System;
-            using System.Linq;
+        [TestMethod]
+        public async Task Equals_OneArgOverload_InIQueryableLambda_NoDiagnostic() {
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
+                using System.Linq;
 
-            public class MyObj { public bool Equals(object other, StringComparison c) => true; }
-
-            public class Test {
-                public void Run(IQueryable<MyObj> query, MyObj value) {
-                    var result = query.Where(s => s.Equals(value, StringComparison.Ordinal));
+                public class Test {
+                    public void Run(IQueryable<string> query, string value) {
+                        var result = query.Where(s => s.Equals(value));
+                    }
                 }
-            }
-            """;
+                """);
 
-        await Verify.VerifyAnalyzerAsync(source);
-    }
+            Assert.IsFalse(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
 
-    [Fact]
-    public async Task Equals_WithStringComparison_InAsEnumerableLambda_NoDiagnostic() {
-        // Once AsEnumerable() is called, the subsequent LINQ operators run in-process.
-        var source = """
-            using System;
-            using System.Linq;
+        [TestMethod]
+        public async Task Equals_WithStringComparison_AfterAsEnumerable_NoDiagnostic() {
+            // AsEnumerable() switches to IEnumerable — subsequent operators run in-process.
+            var diagnostics = await GetDiagnosticsAsync("""
+                using System;
+                using System.Linq;
 
-            public class Test {
-                public void Run(IQueryable<string> query, string value) {
-                    var result = query.AsEnumerable()
-                                      .Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                public class Test {
+                    public void Run(IQueryable<string> query, string value) {
+                        var result = query.AsEnumerable()
+                                          .Where(s => s.Equals(value, StringComparison.OrdinalIgnoreCase));
+                    }
                 }
-            }
-            """;
+                """);
 
-        await Verify.VerifyAnalyzerAsync(source);
+            Assert.IsFalse(diagnostics.Any(d => d.Id == LinqStringEqualsAnalyzer.DiagnosticId));
+        }
     }
 }

--- a/EGG9000.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/EGG9000.Analyzers/AnalyzerReleases.Unshipped.md
@@ -3,7 +3,9 @@
 
 ### New Rules
 
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-EGG001  | Style    | Warning  | Banner/divider comment not allowed
-EGG002  | Style    | Warning  | Vertical alignment padding before comment not allowed
+Rule ID | Category        | Severity | Notes
+--------|-----------------|----------|--------------------
+EGG001  | Style           | Warning  | Banner/divider comment not allowed
+EGG002  | Style           | Warning  | Vertical alignment padding before comment not allowed
+EGG003  | EntityFramework | Warning  | Avoid string.Equals with StringComparison inside IQueryable LINQ lambdas
+

--- a/EGG9000.Analyzers/LinqStringEqualsAnalyzer.cs
+++ b/EGG9000.Analyzers/LinqStringEqualsAnalyzer.cs
@@ -4,171 +4,146 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace EGG9000.Analyzers;
+namespace EGG9000.Analyzers {
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class LinqStringEqualsAnalyzer : DiagnosticAnalyzer {
+        public const string DiagnosticId = "EGG003";
 
-/// <summary>
-/// Warns when <c>string.Equals(value, StringComparison)</c> is used inside a LINQ lambda
-/// that operates on an <see cref="System.Linq.IQueryable{T}"/> source, because EF Core cannot
-/// translate that overload to SQL.
-/// </summary>
-[DiagnosticAnalyzer(LanguageNames.CSharp)]
-public sealed class LinqStringEqualsAnalyzer : DiagnosticAnalyzer {
-    public const string DiagnosticId = "EGG003";
+        private static readonly DiagnosticDescriptor Rule = new(
+            id: DiagnosticId,
+            title: "Avoid string.Equals with StringComparison inside IQueryable LINQ lambdas",
+            messageFormat: "'{0}' uses string.Equals with a StringComparison parameter inside an IQueryable LINQ lambda, which EF Core cannot translate to SQL. Use ToLower() == or EF.Functions.ILike() instead.",
+            category: "EntityFramework",
+            defaultSeverity: DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            description: "EF Core cannot translate string.Equals overloads that accept a StringComparison parameter. " +
+                         "Replace with a translatable form such as `s.ToLower() == value.ToLower()`, or `EF.Functions.ILike(s, value)` for case-insensitive matching on Postgres (EF.Functions.Like is case-sensitive under Npgsql's default collation).");
 
-    private static readonly DiagnosticDescriptor Rule = new(
-        id: DiagnosticId,
-        title: "Avoid string.Equals with StringComparison inside IQueryable LINQ lambdas",
-        messageFormat: "'{0}' uses string.Equals with a StringComparison parameter inside an IQueryable LINQ lambda, which EF Core cannot translate to SQL. Use ToLower() == or EF.Functions.Like() instead.",
-        category: "EntityFramework",
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true,
-        description: "EF Core cannot translate string.Equals overloads that accept a StringComparison parameter. " +
-                     "Replace with a translatable form such as `s.ToLower() == value.ToLower()` or `EF.Functions.Like(s, value)`.");
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+        private static readonly ImmutableHashSet<string> LinqLambdaMethods = ImmutableHashSet.Create(
+            "Where", "Select", "SelectMany",
+            "Join", "GroupJoin",
+            "OrderBy", "OrderByDescending", "ThenBy", "ThenByDescending",
+            "GroupBy",
+            "Any", "All",
+            "First", "FirstOrDefault", "Last", "LastOrDefault",
+            "Single", "SingleOrDefault",
+            "Count", "LongCount",
+            "Sum", "Min", "Max", "Average",
+            "TakeWhile", "SkipWhile",
+            "Include",
+            "ThenInclude"
+        );
 
-    // LINQ operator method names that accept lambdas and can be applied to IQueryable.
-    private static readonly ImmutableHashSet<string> LinqLambdaMethods = ImmutableHashSet.Create(
-        "Where", "Select", "SelectMany",
-        "Join", "GroupJoin",
-        "OrderBy", "OrderByDescending", "ThenBy", "ThenByDescending",
-        "GroupBy",
-        "Any", "All",
-        "First", "FirstOrDefault", "Last", "LastOrDefault",
-        "Single", "SingleOrDefault",
-        "Count", "LongCount",
-        "Sum", "Min", "Max", "Average",
-        "TakeWhile", "SkipWhile",
-        "Include",  // EF Core navigation includes that accept expression lambdas
-        "ThenInclude"
-    );
-
-    public override void Initialize(AnalysisContext context) {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
-    }
-
-    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context) {
-        var invocation = (InvocationExpressionSyntax)context.Node;
-
-        // Must be a member access: <receiver>.Equals(...)
-        if(invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
-            return;
-
-        if(memberAccess.Name.Identifier.Text != "Equals")
-            return;
-
-        // Must have exactly 2 arguments: (value, StringComparison)
-        var args = invocation.ArgumentList.Arguments;
-        if(args.Count != 2)
-            return;
-
-        // Verify via semantic model that the second argument is System.StringComparison
-        var secondArgType = context.SemanticModel.GetTypeInfo(args[1].Expression, context.CancellationToken).Type;
-        if(secondArgType?.ToDisplayString() != "System.StringComparison")
-            return;
-
-        // Verify via semantic model that the receiver is a string
-        var receiverType = context.SemanticModel.GetTypeInfo(memberAccess.Expression, context.CancellationToken).Type;
-        if(receiverType?.SpecialType != SpecialType.System_String)
-            return;
-
-        // Walk up the syntax tree to find if this call lives inside a lambda
-        // whose parent LINQ method operates on an IQueryable source.
-        if(!IsInsideQueryableLambda(invocation, context.SemanticModel, context.CancellationToken))
-            return;
-
-        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), invocation.ToString()));
-    }
-
-    private static bool IsInsideQueryableLambda(
-        SyntaxNode node,
-        SemanticModel semanticModel,
-        System.Threading.CancellationToken cancellationToken) {
-
-        var current = node.Parent;
-
-        while(current is not null) {
-            if(current is LambdaExpressionSyntax) {
-                // This lambda must be a direct argument to a LINQ method call.
-                if(current.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outerCall } }) {
-                    if(IsQueryableLinqCall(outerCall, semanticModel, cancellationToken))
-                        return true;
-                }
-                // Lambda found but not in a qualifying position — stop walking
-                // (nested lambdas would need their own check; keep walking to cover nesting).
-            }
-            current = current.Parent;
+        public override void Initialize(AnalysisContext context) {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
         }
 
-        return false;
-    }
+        private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context) {
+            var invocation = (InvocationExpressionSyntax)context.Node;
 
-    private static bool IsQueryableLinqCall(
-        InvocationExpressionSyntax invocation,
-        SemanticModel semanticModel,
-        System.Threading.CancellationToken cancellationToken) {
+            if(invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                return;
 
-        // The method name must be a known LINQ operator.
-        var methodName = invocation.Expression switch {
-            MemberAccessExpressionSyntax ma => ma.Name.Identifier.Text,
-            _ => null
-        };
+            if(memberAccess.Name.Identifier.Text != "Equals")
+                return;
 
-        if(methodName is null || !LinqLambdaMethods.Contains(methodName))
+            var args = invocation.ArgumentList.Arguments;
+            if(args.Count != 2)
+                return;
+
+            var secondArgType = context.SemanticModel.GetTypeInfo(args[1].Expression, context.CancellationToken).Type;
+            if(secondArgType?.ToDisplayString() != "System.StringComparison")
+                return;
+
+            var receiverType = context.SemanticModel.GetTypeInfo(memberAccess.Expression, context.CancellationToken).Type;
+            if(receiverType?.SpecialType != SpecialType.System_String)
+                return;
+
+            if(!IsInsideQueryableLambda(invocation, context.SemanticModel, context.CancellationToken))
+                return;
+
+            context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), invocation.ToString()));
+        }
+
+        private static bool IsInsideQueryableLambda(
+            SyntaxNode node,
+            SemanticModel semanticModel,
+            System.Threading.CancellationToken cancellationToken) {
+
+            var current = node.Parent;
+
+            while(current is not null) {
+                if(current is LambdaExpressionSyntax) {
+                    if(current.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outerCall } }) {
+                        if(IsQueryableLinqCall(outerCall, semanticModel, cancellationToken))
+                            return true;
+                    }
+                }
+                current = current.Parent;
+            }
+
             return false;
+        }
 
-        // Use the semantic model to confirm the resolved symbol operates on IQueryable<T>.
-        var symbolInfo = semanticModel.GetSymbolInfo(invocation.Expression, cancellationToken);
-        var candidates = symbolInfo.Symbol is not null
-            ? ImmutableArray.Create(symbolInfo.Symbol)
-            : symbolInfo.CandidateSymbols;
+        private static bool IsQueryableLinqCall(
+            InvocationExpressionSyntax invocation,
+            SemanticModel semanticModel,
+            System.Threading.CancellationToken cancellationToken) {
 
-        foreach(var symbol in candidates) {
-            if(symbol is not IMethodSymbol method)
-                continue;
+            var methodName = invocation.Expression switch {
+                MemberAccessExpressionSyntax ma => ma.Name.Identifier.Text,
+                _ => null
+            };
 
-            // Extension method: first parameter type must be or implement IQueryable<T>
-            if(method.IsExtensionMethod && method.Parameters.Length > 0) {
-                if(ImplementsIQueryable(method.Parameters[0].Type))
+            if(methodName is null || !LinqLambdaMethods.Contains(methodName))
+                return false;
+
+            var symbolInfo = semanticModel.GetSymbolInfo(invocation.Expression, cancellationToken);
+            var candidates = symbolInfo.Symbol is not null
+                ? ImmutableArray.Create(symbolInfo.Symbol)
+                : symbolInfo.CandidateSymbols;
+
+            foreach(var symbol in candidates) {
+                if(symbol is not IMethodSymbol method)
+                    continue;
+
+                if(method.IsExtensionMethod && method.Parameters.Length > 0) {
+                    if(ImplementsIQueryable(method.Parameters[0].Type))
+                        return true;
+                }
+
+                if(ImplementsIQueryable(method.ContainingType))
                     return true;
             }
 
-            // Instance method: containing type must implement IQueryable<T>
-            if(ImplementsIQueryable(method.ContainingType))
-                return true;
+            if(invocation.Expression is MemberAccessExpressionSyntax memberAccess) {
+                var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression, cancellationToken).Type;
+                if(receiverType is not null && ImplementsIQueryable(receiverType))
+                    return true;
+            }
+
+            return false;
         }
 
-        // Semantic resolution failed or returned nothing — fall back to a syntax-level
-        // heuristic: check if the receiver's inferred type implements IQueryable<T>.
-        if(invocation.Expression is MemberAccessExpressionSyntax memberAccess) {
-            var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression, cancellationToken).Type;
-            if(receiverType is not null && ImplementsIQueryable(receiverType))
+        private static bool ImplementsIQueryable(ITypeSymbol type) {
+            if(IsIQueryableType(type))
                 return true;
+
+            foreach(var iface in type.AllInterfaces) {
+                if(IsIQueryableType(iface))
+                    return true;
+            }
+
+            return false;
         }
 
-        return false;
-    }
-
-    /// <summary>
-    /// Returns <see langword="true"/> when <paramref name="type"/> is, or implements / is assignable to,
-    /// <c>System.Linq.IQueryable&lt;T&gt;</c>.
-    /// </summary>
-    private static bool ImplementsIQueryable(ITypeSymbol type) {
-        if(IsIQueryableType(type))
-            return true;
-
-        foreach(var iface in type.AllInterfaces) {
-            if(IsIQueryableType(iface))
-                return true;
+        private static bool IsIQueryableType(ITypeSymbol type) {
+            var display = type.OriginalDefinition.ToDisplayString();
+            return display is "System.Linq.IQueryable<T>" or "System.Linq.IQueryable";
         }
-
-        return false;
-    }
-
-    private static bool IsIQueryableType(ITypeSymbol type) {
-        var display = type.OriginalDefinition.ToDisplayString();
-        return display is "System.Linq.IQueryable<T>" or "System.Linq.IQueryable";
     }
 }

--- a/EGG9000.Analyzers/LinqStringEqualsAnalyzer.cs
+++ b/EGG9000.Analyzers/LinqStringEqualsAnalyzer.cs
@@ -1,0 +1,174 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace EGG9000.Analyzers;
+
+/// <summary>
+/// Warns when <c>string.Equals(value, StringComparison)</c> is used inside a LINQ lambda
+/// that operates on an <see cref="System.Linq.IQueryable{T}"/> source, because EF Core cannot
+/// translate that overload to SQL.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class LinqStringEqualsAnalyzer : DiagnosticAnalyzer {
+    public const string DiagnosticId = "EGG003";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        id: DiagnosticId,
+        title: "Avoid string.Equals with StringComparison inside IQueryable LINQ lambdas",
+        messageFormat: "'{0}' uses string.Equals with a StringComparison parameter inside an IQueryable LINQ lambda, which EF Core cannot translate to SQL. Use ToLower() == or EF.Functions.Like() instead.",
+        category: "EntityFramework",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "EF Core cannot translate string.Equals overloads that accept a StringComparison parameter. " +
+                     "Replace with a translatable form such as `s.ToLower() == value.ToLower()` or `EF.Functions.Like(s, value)`.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    // LINQ operator method names that accept lambdas and can be applied to IQueryable.
+    private static readonly ImmutableHashSet<string> LinqLambdaMethods = ImmutableHashSet.Create(
+        "Where", "Select", "SelectMany",
+        "Join", "GroupJoin",
+        "OrderBy", "OrderByDescending", "ThenBy", "ThenByDescending",
+        "GroupBy",
+        "Any", "All",
+        "First", "FirstOrDefault", "Last", "LastOrDefault",
+        "Single", "SingleOrDefault",
+        "Count", "LongCount",
+        "Sum", "Min", "Max", "Average",
+        "TakeWhile", "SkipWhile",
+        "Include",  // EF Core navigation includes that accept expression lambdas
+        "ThenInclude"
+    );
+
+    public override void Initialize(AnalysisContext context) {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeInvocation, SyntaxKind.InvocationExpression);
+    }
+
+    private static void AnalyzeInvocation(SyntaxNodeAnalysisContext context) {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Must be a member access: <receiver>.Equals(...)
+        if(invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+            return;
+
+        if(memberAccess.Name.Identifier.Text != "Equals")
+            return;
+
+        // Must have exactly 2 arguments: (value, StringComparison)
+        var args = invocation.ArgumentList.Arguments;
+        if(args.Count != 2)
+            return;
+
+        // Verify via semantic model that the second argument is System.StringComparison
+        var secondArgType = context.SemanticModel.GetTypeInfo(args[1].Expression, context.CancellationToken).Type;
+        if(secondArgType?.ToDisplayString() != "System.StringComparison")
+            return;
+
+        // Verify via semantic model that the receiver is a string
+        var receiverType = context.SemanticModel.GetTypeInfo(memberAccess.Expression, context.CancellationToken).Type;
+        if(receiverType?.SpecialType != SpecialType.System_String)
+            return;
+
+        // Walk up the syntax tree to find if this call lives inside a lambda
+        // whose parent LINQ method operates on an IQueryable source.
+        if(!IsInsideQueryableLambda(invocation, context.SemanticModel, context.CancellationToken))
+            return;
+
+        context.ReportDiagnostic(Diagnostic.Create(Rule, invocation.GetLocation(), invocation.ToString()));
+    }
+
+    private static bool IsInsideQueryableLambda(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        System.Threading.CancellationToken cancellationToken) {
+
+        var current = node.Parent;
+
+        while(current is not null) {
+            if(current is LambdaExpressionSyntax) {
+                // This lambda must be a direct argument to a LINQ method call.
+                if(current.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax outerCall } }) {
+                    if(IsQueryableLinqCall(outerCall, semanticModel, cancellationToken))
+                        return true;
+                }
+                // Lambda found but not in a qualifying position — stop walking
+                // (nested lambdas would need their own check; keep walking to cover nesting).
+            }
+            current = current.Parent;
+        }
+
+        return false;
+    }
+
+    private static bool IsQueryableLinqCall(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        System.Threading.CancellationToken cancellationToken) {
+
+        // The method name must be a known LINQ operator.
+        var methodName = invocation.Expression switch {
+            MemberAccessExpressionSyntax ma => ma.Name.Identifier.Text,
+            _ => null
+        };
+
+        if(methodName is null || !LinqLambdaMethods.Contains(methodName))
+            return false;
+
+        // Use the semantic model to confirm the resolved symbol operates on IQueryable<T>.
+        var symbolInfo = semanticModel.GetSymbolInfo(invocation.Expression, cancellationToken);
+        var candidates = symbolInfo.Symbol is not null
+            ? ImmutableArray.Create(symbolInfo.Symbol)
+            : symbolInfo.CandidateSymbols;
+
+        foreach(var symbol in candidates) {
+            if(symbol is not IMethodSymbol method)
+                continue;
+
+            // Extension method: first parameter type must be or implement IQueryable<T>
+            if(method.IsExtensionMethod && method.Parameters.Length > 0) {
+                if(ImplementsIQueryable(method.Parameters[0].Type))
+                    return true;
+            }
+
+            // Instance method: containing type must implement IQueryable<T>
+            if(ImplementsIQueryable(method.ContainingType))
+                return true;
+        }
+
+        // Semantic resolution failed or returned nothing — fall back to a syntax-level
+        // heuristic: check if the receiver's inferred type implements IQueryable<T>.
+        if(invocation.Expression is MemberAccessExpressionSyntax memberAccess) {
+            var receiverType = semanticModel.GetTypeInfo(memberAccess.Expression, cancellationToken).Type;
+            if(receiverType is not null && ImplementsIQueryable(receiverType))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="type"/> is, or implements / is assignable to,
+    /// <c>System.Linq.IQueryable&lt;T&gt;</c>.
+    /// </summary>
+    private static bool ImplementsIQueryable(ITypeSymbol type) {
+        if(IsIQueryableType(type))
+            return true;
+
+        foreach(var iface in type.AllInterfaces) {
+            if(IsIQueryableType(iface))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsIQueryableType(ITypeSymbol type) {
+        var display = type.OriginalDefinition.ToDisplayString();
+        return display is "System.Linq.IQueryable<T>" or "System.Linq.IQueryable";
+    }
+}

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.cs
@@ -691,7 +691,7 @@ namespace EGG9000.Bot.Automated.Coops {
                                                 .ThenInclude(c => c.Contract)
                                             .FirstOrDefaultAsync(
                                                 x => x.User.DiscordId == discordUser.Id &&
-                                                EF.Functions.Like(farm.CoopId, x.Coop.Name),
+                                                EF.Functions.ILike(farm.CoopId, x.Coop.Name),
                                                 cancellationToken: CancellationToken.None
                                             );
                                         if(otherContractXref != null) {

--- a/EGG9000.Common/Helpers/EggIncStatics.cs
+++ b/EGG9000.Common/Helpers/EggIncStatics.cs
@@ -77,7 +77,7 @@ namespace EGG9000.Common.Helpers {
                 case Ei.RewardType.Gold:
                     return $"<:Egg_Golden:692439755798872075>  {goal.RewardAmount.ToEggString()}";
                 case Ei.RewardType.EpicResearchItem:
-                    var researchItem = (EiEpicResearch.Get().epicResearchItems.AsQueryable().FirstOrDefault(x => x.id.Equals(goal.RewardSubType, StringComparison.CurrentCultureIgnoreCase)));
+                    var researchItem = (EiEpicResearch.Get().epicResearchItems.FirstOrDefault(x => x.id.Equals(goal.RewardSubType, StringComparison.CurrentCultureIgnoreCase)));
                     var goldenEggRefund = (int)(researchItem?.Costs?.Last() * goal?.RewardAmount);
                     var goldenEggRefundString = $" (<:Golden_Egg_GE:692439755798872075> {(goldenEggRefund >= 1000 ? (goldenEggRefund / 1000).ToString() + 'K' : goldenEggRefund)})";
                     return $"{researchItem?.title ?? ToStartCase(goal.RewardSubType)} +{goal.RewardAmount}{(goldenEggRefund == default ? "" : goldenEggRefundString)}";


### PR DESCRIPTION
#### PR Classification
Introduces a new analyzer to detect EF Core-incompatible string.Equals usage in IQueryable LINQ expressions and updates code to ensure SQL translation compatibility.

#### PR Summary
Adds the LinqStringEqualsAnalyzer (EGG003) to warn against non-translatable string.Equals overloads in IQueryable LINQ lambdas, updates affected code, and provides supporting tests.
- LinqStringEqualsAnalyzer.cs: Implements analyzer to detect string.Equals with StringComparison inside IQueryable LINQ lambdas.
- LinqStringEqualsAnalyzerTests.cs: Adds tests to verify analyzer diagnostics for both valid and invalid cases.
- ThreadsCoopStatusUpdater.cs: Replaces problematic .Equals(..., StringComparison) with EF.Functions.Like and adds logging for coop name mismatches.
- AnalyzerReleases.Unshipped.md: Registers the new analyzer rule EGG003.
