### PR TITLE
Fix: Empty Backup Usernames

### DIFF
--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.Messaging.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.Messaging.cs
@@ -248,12 +248,15 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 var percent = coopDetails.GetProjectedShare(x);
 
-                if(x.DBUser is null) {
+                var igUsername = !string.IsNullOrWhiteSpace(x.CoopStatus?.UserName) ? x.CoopStatus.UserName : x.Backup?.UserName;
+                var csStrippedUsername = MyRegex().Replace(igUsername, "");
 
-                }
+                var usernameEmoji = (everyoneJoined || x.DBUser is null) ? "" : (x.CoopStatus is not null ? "✅" : "❌");
+                if(x.DBUser is null)
+                    usernameEmoji += "👽";
 
                 return new List<FixedWidthCell> {
-                    new(Truncate((everyoneJoined || x.DBUser is null ? "" : x.CoopStatus is not null ? "✅" : "❌") + (x.DBUser is null ? "👽" : "") + MyRegex().Replace(x.CoopStatus?.UserName ?? x.Backup?.UserName, ""), 11)),
+                    new(Truncate($"{usernameEmoji}{csStrippedUsername}", 11)),
                     new(Truncate(MyRegex().Replace(x.DiscordUser?.GetCleanName() ?? "", ""), 11)),
                     new(x.EarningsBonus.ToEggString(), CellAlignment.Right),
                     new(x.EggsShipped.ToEggString(), CellAlignment.Right),

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -145,6 +145,8 @@ namespace EGG9000.Common.Database {
         public double SubscriptionEnds { get; set; } = 0;
         [Key(49)]
         public Ei.UserSubscriptionInfo.Types.Level? SubscriptionLevel { get; set; } = null;
+        [Key(50)]
+        public bool NoAliasInLatestBackup { get; set; }
 
 
         [IgnoreMember]
@@ -240,6 +242,7 @@ namespace EGG9000.Common.Database {
             CurrentMultiplier = backup.Game.CurrentMultiplier;
             EggIncId = backup.GetID();
             UserName = string.IsNullOrEmpty(backup.UserName) ? lastBackup?.UserName ?? "" : backup.UserName;
+            NoAliasInLatestBackup = string.IsNullOrEmpty(backup.UserName);
             LastBackupTime = (long)backup.Settings.LastBackupTime;
             PermitLevel = (ushort)backup.Game.PermitLevel;
             SoulEggs = backup.Game.SoulEggsTotal;

--- a/EGG9000.Common/Database/Entities/Guild.cs
+++ b/EGG9000.Common/Database/Entities/Guild.cs
@@ -290,5 +290,7 @@ namespace EGG9000.Common.Database.Entities {
         CoopStatsChannel = 48,
         [Description("/TC/Optional: Where E9K will log issues that occur with users trying to /register")]
         RegisterIssues = 49,
+        [Description("/R/Role for users whose latest backup came back with no in-game name (likely logged out of Google Play Games/Game Center)")]
+        NoAliasRole = 50,
     }
 }

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -191,6 +191,7 @@ namespace EGG9000.Common.Helpers {
                 await CheckPermitRoles(_client, guild, discordUser, dbUser);
                 await CheckGrades(db, _client, discordUser, dbUser, grades);
                 await CheckOudatedGameRole(_client, guild, discordUser, dbUser);
+                await CheckNoAliasRole(_client, guild, discordUser, dbUser);
                 await CheckUserOSRole(_client, guild, discordUser, dbUser);
                 await CheckUnjoined(guild, discordUser, leaderboardUsers.FirstOrDefault(x => x.User.Id == dbUser.Id));
                 await CheckEnDRole(_client, guild, discordUser, dbUser);
@@ -334,6 +335,11 @@ namespace EGG9000.Common.Helpers {
             var gameOutdatedRole = await _client.GetRoleAsync(GuildChannelType.GameVersionOutdated, Guild);
             var needsRole = user.EggIncAccounts.Where(x => x.Backup is not null).Any(x => x.Backup.ClientVersion > 0 && x.Backup.ClientVersion < EggIncApi.ClientVersion);
             await RoleToggle.ApplyAsync(DiscordUser, gameOutdatedRole, needsRole, "outdated role");
+        }
+        private static async Task CheckNoAliasRole(DiscordHostedService _client, SocketGuild Guild, IGuildUser DiscordUser, DBUser user) {
+            var noAliasRole = await _client.GetRoleAsync(GuildChannelType.NoAliasRole, Guild);
+            var needsRole = user.EggIncAccounts.Where(x => x.Backup is not null).Any(x => x.Backup.NoAliasInLatestBackup);
+            await RoleToggle.ApplyAsync(DiscordUser, noAliasRole, needsRole, "no alias role");
         }
 
         private static async Task CheckEnDRole(DiscordHostedService _client, SocketGuild Guild, IGuildUser DiscordUser, DBUser user) {

--- a/EGG9000.Common/Helpers/Prefarm.cs
+++ b/EGG9000.Common/Helpers/Prefarm.cs
@@ -413,7 +413,7 @@ namespace EGG9000.Common.Helpers {
 
                             xref ??= coop.UserCoopsXrefs.FirstOrDefault(x => !string.IsNullOrEmpty(x.FixedUserName) && x.FixedUserName == participant.UserName);
 
-                            if(xref == null) {
+                            if(xref == null && !string.IsNullOrWhiteSpace(participant.UserName)) {
                                 var matchbackup = userBackupsAssigned.FirstOrDefault(x => x.Backup.UserName == participant.UserName);
                                 xref = coop.UserCoopsXrefs.FirstOrDefault(x => x.UserId == matchbackup?.User.Id && x.EggIncId == matchbackup?.Backup.EggIncId);
                             }

--- a/EGG9000.Common/Helpers/UserFarmDetails.cs
+++ b/EGG9000.Common/Helpers/UserFarmDetails.cs
@@ -248,7 +248,7 @@ namespace EGG9000.Common.Helpers {
 
         public string Name {
             get {
-                return DiscordUser?.GetCleanName() ?? CoopStatus?.UserName ?? DBUser?.DiscordUsername ?? "[error getting name]";
+                return DiscordUser?.GetCleanName() ?? (string.IsNullOrWhiteSpace(CoopStatus?.UserName) ? null : CoopStatus.UserName) ?? DBUser?.DiscordUsername ?? "[error getting name]";
             }
         }
 


### PR DESCRIPTION
- Fixes a couple issues where empty users were being misidentified
- Added a new role type for "No Alias," that the bot will hand out when people's backups come back without a username
  - Figure this can be used to en-masse ping people who need to reconnect Google Play/Game Center 