### PR TITLE
Fix/Chore: Unbounded StringBuilders in Messages

### DIFF
--- a/EGG9000.Bot/Commands/DemeritCommands.cs
+++ b/EGG9000.Bot/Commands/DemeritCommands.cs
@@ -1,3 +1,4 @@
+using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
 using EGG9000.Common.Database;
@@ -11,7 +12,9 @@ using Microsoft.EntityFrameworkCore;
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
 using static EGG9000.Common.Helpers.Discord.EmbedHelpers;
@@ -33,6 +36,19 @@ namespace EGG9000.Bot.Commands {
             }));
 
             return demeritDesc;
+        }
+
+        public static async Task SendDemeritList(SocketInteraction interaction, string mentionText, string demeritDesc, bool ephemeral) {
+            var header = $"Demerit info for {mentionText}\n";
+
+            if((header.Length + demeritDesc.Length) <= 1900) {
+                await interaction.RespondAsyncGettingMessage(header + demeritDesc, ephemeral: ephemeral);
+            } else {
+                await interaction.RespondWithFilesAsyncGettingMessage(
+                    [new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(demeritDesc)), "Demerits.txt")],
+                    text: header + "_(List too large for Discord - see attached file)_",
+                    ephemeral: ephemeral);
+            }
         }
     }
 
@@ -64,7 +80,7 @@ namespace EGG9000.Bot.Commands {
                     return $"Expires in {timeLeft.Humanize(2)} for reason: {x.Reason}";
                 }));
 
-                await Context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Demerit info for {socketUser.Mention}\n{demeritDesc}");
+                await DemeritCommands.SendDemeritList(Context.Interaction, socketUser.Mention, demeritDesc, ephemeral: true);
             } catch(Exception e) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => x.Embed = EmbedExceptionFrame(e));
             }
@@ -136,7 +152,7 @@ namespace EGG9000.Bot.Commands {
 
                 var demeritDesc = await DemeritCommands.GetDemerits(dbuser.Id, Db);
 
-                await Context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Demerit info for {user.Mention}\n{demeritDesc}");
+                await DemeritCommands.SendDemeritList(Context.Interaction, user.Mention, demeritDesc, ephemeral: hidden);
             } catch(Exception e) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => x.Embed = EmbedExceptionFrame(e));
             }

--- a/EGG9000.Bot/Commands/Informational/EBHistoryCommand.cs
+++ b/EGG9000.Bot/Commands/Informational/EBHistoryCommand.cs
@@ -3,9 +3,11 @@ using Discord.Interactions;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
+using EGG9000.Common.Helpers.Discord;
 using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -95,21 +97,29 @@ namespace EGG9000.Bot.Commands.Informational {
             var longestRankLength = entries.Max(e => e.RankString.Length);
             entries.ForEach(e => e.MutateStrings(longestEBLength, longestRankLength));
 
-            var sb = new StringBuilder();
-            sb.Append($"{Context.User.Mention} - {account.Backup?.UserName ?? account.Name}'s Earnings Boost rank history, with a first entry from {DiscordHelpers.TimeStamper(snapshots.First().Date)}.");
-            sb.AppendLine("```");
-            sb.AppendLine($"Date        EB{new string(' ', longestEBLength - 2)}   Rank{new string(' ', longestRankLength - 2)}");
+            var introText = $"{Context.User.Mention} - {account.Backup?.UserName ?? account.Name}'s Earnings Boost rank history, with a first entry from {DiscordHelpers.TimeStamper(snapshots.First().Date)}.";
+
+            var tableSb = new StringBuilder();
+            tableSb.AppendLine($"Date        EB{new string(' ', longestEBLength - 2)}   Rank{new string(' ', longestRankLength - 2)}");
             foreach(var customEntry in entries) {
-                sb.AppendLine(customEntry.ToString());
+                tableSb.AppendLine(customEntry.ToString());
             }
-            sb.AppendLine("```");
+            var tableBody = tableSb.ToString();
 
-            var builder = new EmbedBuilder();
-            builder.Title = "EB History";
-            builder.Description = sb.ToString();
-            builder.Color = Color.DarkGreen;
+            var embedDescription = $"{introText}\n```\n{tableBody}```";
 
-            await Context.Interaction.ModifyOriginalResponseAsync(c => { c.Content = ""; c.Embed = builder.Build(); });
+            if(embedDescription.Length <= 3900) {
+                var builder = new EmbedBuilder();
+                builder.Title = "EB History";
+                builder.Description = embedDescription;
+                builder.Color = Color.DarkGreen;
+
+                await Context.Interaction.ModifyOriginalResponseAsync(c => { c.Content = ""; c.Embed = builder.Build(); });
+            } else {
+                await Context.Interaction.RespondWithFilesAsyncGettingMessage(
+                    [new FileAttachment(new MemoryStream(Encoding.UTF8.GetBytes(tableBody)), "EBHistory.txt")],
+                    text: $"{introText}\n_(History too large for Discord - see attached file)_");
+            }
         }
 
         [GeneratedRegex(@"^EI\d{16}$")]

--- a/EGG9000.Bot/Commands/UserStatusCommands.cs
+++ b/EGG9000.Bot/Commands/UserStatusCommands.cs
@@ -191,6 +191,17 @@ namespace EGG9000.Bot.Commands {
 
                 var recentDemeritsString = $"{await DemeritCommands.GetDemerits(user.Id, db)}";
                 if(recentDemeritsString != "") {
+                    if(recentDemeritsString.Length > 1000) {
+                        var demeritLines = recentDemeritsString.Split('\n');
+                        var shownLines = new List<string>();
+                        var runningLength = 0;
+                        foreach(var line in demeritLines) {
+                            if(runningLength + line.Length + 1 > 950) break;
+                            shownLines.Add(line);
+                            runningLength += line.Length + 1;
+                        }
+                        recentDemeritsString = $"{string.Join("\n", shownLines)}\n_(+{demeritLines.Length - shownLines.Count} more - see /demerits)_";
+                    }
                     AddInfoSeparatorIfNeeded();
                     lastBuilder.AddField("Recent Demerits", recentDemeritsString);
                 }


### PR DESCRIPTION
Instances where we'd iterate through an abstractly sized list, and append to a message, falling back to sending an attachment, was pre-components, and pre Discord.NET supporting a _lottt_. Dunno why it took so long to modernize this piece.

Replaced them all with scrollable pages, same as existing ones.
I'll be opening a follow up PR with an abstraction layer to heavily dry out the existing implementations, and make it easier to scale.