### PR TITLE
Fix: Comparison Chart Rendering

### DIFF
--- a/EGG9000.Site/Views/Home/Comparison.cshtml
+++ b/EGG9000.Site/Views/Home/Comparison.cshtml
@@ -79,6 +79,7 @@
 </div>
 
 <partial name="_ApexCharts" />
+@section Scripts {
 <script>
 var ebOptions = {
     series: [{
@@ -167,3 +168,4 @@ var ebOptions = {
     var ebChart = new ApexCharts(document.querySelector("#chartEb"), ebOptions);
     ebChart.render();
 </script>
+}

--- a/EGG9000.Site/Views/Home/CraftingLevelComparison.cshtml
+++ b/EGG9000.Site/Views/Home/CraftingLevelComparison.cshtml
@@ -69,6 +69,7 @@
 </div>
 
 <partial name="_ApexCharts" />
+@section Scripts {
 <script>
     var ebOptions = {
         series: [{
@@ -149,3 +150,4 @@
     var gradeChart = new ApexCharts(document.querySelector("#chartGrade"), ebOptions);
     gradeChart.render();
 </script>
+}

--- a/EGG9000.Site/Views/Home/GradeComparison.cshtml
+++ b/EGG9000.Site/Views/Home/GradeComparison.cshtml
@@ -69,6 +69,7 @@
 </div>
 
 <partial name="_ApexCharts" />
+@section Scripts {
 <script>
     var ebOptions = {
         series: [{
@@ -149,3 +150,4 @@
     var gradeChart = new ApexCharts(document.querySelector("#chartGrade"), ebOptions);
     gradeChart.render();
 </script>
+}


### PR DESCRIPTION
Fixes this:
```
Uncaught ReferenceError: chartThemeMode is not defined
    <anonymous> https://egg9000.com/Home/Comparison:162
```
Which was causing comparison charts to not render.