### PR TITLE
Fix: Update ClientVersion from backups

### DIFF
--- a/EGG9000.Bot/Automated/NewContracts.cs
+++ b/EGG9000.Bot/Automated/NewContracts.cs
@@ -35,6 +35,8 @@ namespace EGG9000.Bot.Automated {
 
         private static readonly bool _debug = BuildConfig.IsDev9002 || BuildConfig.IsDebug;
 
+        private DateTimeOffset _lastWarningSent = DateTimeOffset.MinValue;
+
         public async override Task Run(object state, CancellationToken cancellationToken) {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var needsUpdate = false;
@@ -45,9 +47,17 @@ namespace EGG9000.Bot.Automated {
             await _db.Database.CloseConnectionAsync();
             var contractsResponse = await EggIncApi.GetPeriodicalsAsync();
 
+
             if(contractsResponse == null) {
                 _logger.LogWarning("⚠️ERROR: Invalid Contract Response");
             } else {
+                if(!string.IsNullOrEmpty(contractsResponse.Contracts.WarningMessage) && _lastWarningSent.AddHours(6) < DateTimeOffset.UtcNow) {
+                    _lastWarningSent = DateTimeOffset.UtcNow;
+                    _logger.LogWarning(contractsResponse.Contracts.WarningMessage);
+                    await _client.SendDMToKendrome($"Contracts Response Warning: {contractsResponse.Contracts.WarningMessage}");
+
+                }
+
                 var existingContracts = await _db.Contracts.Include(x => x.GuildContracts).ToListAsync(CancellationToken.None);
 
                 var contracts = contractsResponse.Contracts.Contracts.ToList();
@@ -209,7 +219,7 @@ namespace EGG9000.Bot.Automated {
             await _db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None, logger: _logger);
 
             if(cachesChanged)
-                await _db.ExpireCachedEiContractsAsync(_provider.GetRequiredService<MassTransit.IPublishEndpoint>());
+                await _db.ExpireCachedEiContractsAsync(_provider.GetService<MassTransit.IPublishEndpoint>());
 
             if(needsUpdate)
                 ContractUpdater.ResetTimeStatic();

--- a/EGG9000.Bot/Automated/UpdateBackups.cs
+++ b/EGG9000.Bot/Automated/UpdateBackups.cs
@@ -19,6 +19,7 @@ namespace EGG9000.Bot.Automated {
 
         private static readonly DateTimeOffset StableUltraInfoDTO = new(2026,6,11,0,0,0,DateTimeOffset.UtcNow.Offset);
 
+        private uint clientVersion = 0;
         public async override Task Run(object state, CancellationToken cancellationToken) {
 
             var times = new TimingsFactory(_logger).Start();
@@ -70,7 +71,17 @@ namespace EGG9000.Bot.Automated {
             times.Set("Updated Backups");
             await _db.SaveChangesAsync(cancellationToken);
 
-            var publishEndpoint = _provider.GetRequiredService<MassTransit.IPublishEndpoint>();
+            if(clientVersion > EggIncApi.ClientVersion) {
+                try {
+                    _logger.LogWarning("New Client Version Detected: {old} -> {new}", EggIncApi.ClientVersion, clientVersion);
+                    await _client.SendDMToKendrome($"New Client Version Detected: {EggIncApi.ClientVersion} -> {clientVersion}");
+                } finally {
+                    EggIncApi.ClientVersion = clientVersion;
+                }
+            }
+
+
+            var publishEndpoint = _provider.GetService<MassTransit.IPublishEndpoint>();
             var registered = await _db.RegisterMissingContractsAsync(discoveredContractDefs.Values, publishEndpoint, cancellationToken);
             if(registered > 0)
                 _logger.LogInformation("Self-healed {count} contract(s) missing from the DB from player backups", registered);
@@ -168,7 +179,10 @@ namespace EGG9000.Bot.Automated {
 
                     update = true;
 
-                    // TODO: Track current game version and notify if newer version is available
+                    if(backup.ClientVersion != clientVersion) {
+                        clientVersion = backup.ClientVersion;
+                    }
+
                 } else {
                     _logger.LogWarning("Failed to get backup for {user} {account}", user.DiscordUsername, account.Name ?? account.Id);
                 }

--- a/EGG9000.Common/Database/ApplicationDbContext.cs
+++ b/EGG9000.Common/Database/ApplicationDbContext.cs
@@ -185,6 +185,8 @@ namespace EGG9000.Common.Database {
         // instead of waiting out the 1h TTL.
         public async Task ExpireCachedEiContractsAsync(MassTransit.IPublishEndpoint publishEndpoint) {
             ExpireCachedEiContracts();
+            if(publishEndpoint is null)
+                return;
             foreach(var key in _contractCacheKeys)
                 await publishEndpoint.Publish(new Consumers.ExpireCacheMessage(key));
         }


### PR DESCRIPTION
- Get latest ClientVersion from backups and send warning when it changes. Store that value temporarily

- Send any warnings that are returned when getting contracts.