### PR TITLE
Feat: Buffer Calculating CS, User-Data Load Standards

### DIFF
--- a/EGG9000.Bot/Automated/HandleGradeChanges.cs
+++ b/EGG9000.Bot/Automated/HandleGradeChanges.cs
@@ -1,9 +1,7 @@
-﻿using Cronos;
+using Cronos;
 using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
-using EGG9000.Common.EggIncAPI;
 using EGG9000.Common.Helpers;
-using Ei;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -28,18 +26,16 @@ namespace EGG9000.Bot.Automated {
             foreach(var userchunk in chunkedUsers) {
                 StillAlive();
                 var mutatedUsers = new ConcurrentBag<DBUser>();
-                // Network calls only below - no DB scope held while awaiting EggIncApi.
                 await Parallel.ForEachAsync(userchunk, new ParallelOptions { MaxDegreeOfParallelism = 3 }, async (user, token) => {
                     try {
                         var userMutated = false;
                         foreach(var account in user.EggIncAccounts.Where(x => !string.IsNullOrEmpty(x.Id) && x.Id.StartsWith("EI") && x.LastGrade != Ei.Contract.Types.PlayerGrade.GradeUnset)) {
-                            var r = await EggIncApi.Post<ContractPlayerInfo, BasicRequestInfo>(new BasicRequestInfo(), account.Id);
-                            if(r is null) {
+                            var info = await AccountRefresh.FetchExtrasAsync(user, account, _logger);
+                            if(info is null) {
                                 _logger.LogWarning("Null response for {user} ({account})", user.DiscordUsername, account.Id);
                                 continue;
                             }
-                            if(r.Status == ContractPlayerInfo.Types.Status.Complete)
-                                userMutated |= GradeSync.ApplyGradeChange(user, account, r.Grade, setPromotionTime: true, guardUnset: true, _logger);
+                            userMutated |= AccountRefresh.ApplyExtras(user, account, info, _logger);
                         }
                         if(userMutated) mutatedUsers.Add(user);
                     } catch(Exception e) {

--- a/EGG9000.Bot/Automated/UserGrades.cs
+++ b/EGG9000.Bot/Automated/UserGrades.cs
@@ -39,7 +39,8 @@ namespace EGG9000.Bot.Automated {
 
                             if(info is not null) {
                                 var mutated = AccountRefresh.ApplyExtras(user, account, info, _logger);
-                                await AccountRefresh.UpsertSeasonProgress(account.Id, info.SeasonProgress, db, CancellationToken.None);
+                                if(info.Status == Ei.ContractPlayerInfo.Types.Status.Complete)
+                                    await AccountRefresh.UpsertSeasonProgress(account.Id, info.SeasonProgress, db, CancellationToken.None);
                                 if(mutated) {
                                     await db.DBUsers.Where(c => c.Id == user.Id).ExecuteUpdateAsync(s => s
                                         .SetProperty(c => c._contractRegistrationByte, user._contractRegistrationByte));

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -297,7 +297,6 @@ namespace EGG9000.Bot.Commands {
                 return;
             }
 
-            //Add the grade role before moving them, to give them access to the header channel (if applicable)
             var currentGuild = _gateway.Guilds.FirstOrDefault(g => g.Id == Context.Interaction.GuildId);
             var discordUser = currentGuild.GetUser(dbuser.DiscordId);
             var gradeRole = dbGuild.ChannelDetails.FirstOrDefault(x => x.ChannelType == newgrade switch {
@@ -308,26 +307,24 @@ namespace EGG9000.Bot.Commands {
                 5 => GuildChannelType.GradeAAA,
                 _ => default
             });
+
+            var freshBackup = await AccountRefresh.RefreshFullAsync(account, await Db.CachedEiContractsAsync(), dbuser, Db, _logger);
+
+            if((uint)account.LastGrade != newgrade) {
+                await Context.Interaction.ModifyOriginalResponseAsync(x => {
+                    x.Content = ""; x.Embed = EmbedWarning($"A new backup was pulled, and the obtained grade " +
+                    $"({PlayerGradeDetails.GetEmoji(account.LastGrade)}) did not match the new target grade ({PlayerGradeDetails.GetEmoji((PlayerGrade)newgrade)}).\nTry forcing a new backup?");
+                });
+                await Db.SaveChangesAsync();
+                return;
+            }
+            if(freshBackup is not null) {
+                dbuser.UpdateAccounts();
+            }
+
             if(gradeRole != null) {
                 var mainGuild = _gateway.Guilds.FirstOrDefault(g => g.Id == dbGuild.DiscordSeverId);
                 var socketGradeRole = mainGuild.GetRole(gradeRole.Id);
-
-                //Pull a fresh backup (so they keep channel access through the role update) and refresh the
-                //grade via the extras path - the backup alone no longer carries the grade, ApplyExtrasAsync
-                //fetches it through get_contract_player_info so account.LastGrade is genuinely current.
-                var freshBackup = await AccountRefresh.RefreshBackupAsync(account, await Db.CachedEiContractsAsync(), _logger);
-                await AccountRefresh.ApplyExtrasAsync(dbuser, account, Db, _logger);
-
-                if((uint)account.LastGrade != newgrade) {
-                    await Context.Interaction.ModifyOriginalResponseAsync(x => {
-                        x.Content = ""; x.Embed = EmbedWarning($"A new backup was pulled, and the obtained grade " +
-                        $"({PlayerGradeDetails.GetEmoji(account.LastGrade)}) did not match the new target grade ({PlayerGradeDetails.GetEmoji((PlayerGrade)newgrade)}).\nTry forcing a new backup?");
-                    });
-                    return;
-                }
-                if(freshBackup is not null) {
-                    dbuser.UpdateAccounts();
-                }
                 await mainGuild.GetUser(dbuser.DiscordId).AddRoleAsync(socketGradeRole.Id);
                 if(mainGuild.Id != currentGuild.Id) {
                     var currentGuildSocketRole = currentGuild.Roles.FirstOrDefault(r => r.Name == socketGradeRole.Name);

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -309,6 +309,9 @@ namespace EGG9000.Bot.Commands {
             });
 
             var freshBackup = await AccountRefresh.RefreshFullAsync(account, await Db.CachedEiContractsAsync(), dbuser, Db, _logger);
+            if(freshBackup is not null) {
+                dbuser.UpdateAccounts();
+            }
 
             if((uint)account.LastGrade != newgrade) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => {
@@ -317,9 +320,6 @@ namespace EGG9000.Bot.Commands {
                 });
                 await Db.SaveChangesAsync();
                 return;
-            }
-            if(freshBackup is not null) {
-                dbuser.UpdateAccounts();
             }
 
             if(gradeRole != null) {

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -263,6 +263,8 @@ namespace EGG9000.Bot.Commands {
                 dbuser.UpdateAccounts();
             }
 
+            await AccountRefresh.ApplyExtrasAsync(dbuser, newAccount, db, logger);
+
             await db.SaveChangesAsync();
 
             var socketGuildUser = user as SocketGuildUser

--- a/EGG9000.Bot/Commands/UserStatusCommands.cs
+++ b/EGG9000.Bot/Commands/UserStatusCommands.cs
@@ -37,14 +37,12 @@ namespace EGG9000.Bot.Commands {
             if(pullFreshBackup) {
                 var cachedContracts = await db.CachedEiContractsAsync();
                 foreach(var account in dbuser.EggIncAccounts) {
-                    // Capture before RefreshBackupAsync - the Backup setter auto-syncs account.SubscriptionLevel.
                     var oldLevel = account.SubscriptionLevel;
-                    var backup = await AccountRefresh.RefreshBackupAsync(account, cachedContracts, logger);
+                    var backup = await AccountRefresh.RefreshFullAsync(account, cachedContracts, dbuser, db, logger);
                     if(backup is null) {
                         await command.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"Backup for account `{account?.Backup?.UserName ?? account.Id}` returned as null from the API"); });
                         return;
                     }
-                    await AccountRefresh.ApplyExtrasAsync(dbuser, account, db, logger);
                     await EnforceUltraAsync(_client, dbGuild, socketGuild, dbuser, account, logger, oldLevel);
                 }
                 dbuser.LastBackupCheck = DateTime.UtcNow;
@@ -125,12 +123,17 @@ namespace EGG9000.Bot.Commands {
 
                 if(account.GetGrade() != default) {
                     var pGrade = account.GetGrade();
-                    var gradeProgressPercent = Math.Round(account.Backup?.GradeProgress ?? 0 * 100, 2);
+                    var gradeProgressPercent = Math.Round((account.Backup?.GradeProgress ?? 0) * 100, 2);
 
                     if(gradeProgressPercent > 0 && pGrade != Ei.Contract.Types.PlayerGrade.GradeAaa) {
                         builder.AddField("Rankup Percentage", $"{gradeProgressPercent}% to {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)((int)pGrade + 1))} :chart_with_upwards_trend:", true);
                     } else if(gradeProgressPercent < 0 && pGrade != Ei.Contract.Types.PlayerGrade.GradeC) {
                         builder.AddField("Rankdown Percentage", $"\n\t{gradeProgressPercent * -1}% to {PlayerGradeDetails.GetEmoji((Ei.Contract.Types.PlayerGrade)((int)pGrade - 1))} :chart_with_downwards_trend:", true);
+                    }
+
+                    if(account.PendingGrade.HasValue) {
+                        var pendingMinutes = (int)(DateTimeOffset.UtcNow - account.PendingGradeSince).TotalMinutes;
+                        builder.AddField("Grade Check Pending", $"Egg Inc reports {PlayerGradeDetails.GetEmoji(account.PendingGrade.Value)}, still calculating ({pendingMinutes}m) - will apply automatically after 1h if it persists.", true);
                     }
                 }
 

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -104,8 +104,6 @@ namespace EGG9000.Common.Database {
         public byte ClientVersion { get; set; }
         [Key(29)]
         public Dictionary<Ei.Egg, double> FuelAmounts { get; set; }
-        [Key(30)]
-        public double GradeProgress { get; set; }
         [Key(31)]
         public Ei.Egg MaxEggReached { get; set; }
         [Key(32)]
@@ -147,6 +145,38 @@ namespace EGG9000.Common.Database {
         public Ei.UserSubscriptionInfo.Types.Level? SubscriptionLevel { get; set; } = null;
         [Key(50)]
         public bool NoAliasInLatestBackup { get; set; }
+        [Key(51)]
+        public byte[] LastContractPlayerInfoBytes { get; set; }
+
+        [IgnoreMember]
+        public Ei.ContractPlayerInfo LastContractPlayerInfo {
+            get {
+                if(field is null && LastContractPlayerInfoBytes is { Length: > 0 })
+                    field = Ei.ContractPlayerInfo.Parser.ParseFrom(LastContractPlayerInfoBytes);
+                return field;
+            }
+        }
+
+        [IgnoreMember]
+        public double GradeProgress => LastContractPlayerInfo?.GradeProgress ?? 0;
+        [IgnoreMember]
+        public double GradeScore => LastContractPlayerInfo?.GradeScore ?? 0;
+        [IgnoreMember]
+        public double TargetGradeScore => LastContractPlayerInfo?.TargetGradeScore ?? 0;
+        [IgnoreMember]
+        public double SoulPower => LastContractPlayerInfo?.SoulPower ?? 0;
+        [IgnoreMember]
+        public double TargetSoulPower => LastContractPlayerInfo?.TargetSoulPower ?? 0;
+        [IgnoreMember]
+        public double IssueScore => LastContractPlayerInfo?.IssueScore ?? 0;
+        [IgnoreMember]
+        public IReadOnlyList<Ei.ContractEvaluation.Types.PoorBehavior> Issues => LastContractPlayerInfo?.Issues ?? [];
+        [IgnoreMember]
+        public double LastEvaluationTime => LastContractPlayerInfo?.LastEvaluationTime ?? 0;
+        [IgnoreMember]
+        public string LastEvaluationVersion => LastContractPlayerInfo?.LastEvaluationVersion ?? "";
+        [IgnoreMember]
+        public string AggregationNotes => LastContractPlayerInfo?.AggregationNotes ?? "";
 
 
         [IgnoreMember]
@@ -267,6 +297,7 @@ namespace EGG9000.Common.Database {
             // rebuild doesn't reset it to 0 and drop the user from CSLeaderboard's "TotalCS > 0" filter.
             TotalCS = CarryForwardCs(0, lastBackup?.TotalCS ?? 0);
             SeasonCS = CarryForwardCs(0, lastBackup?.SeasonCS ?? 0);
+            LastContractPlayerInfoBytes = lastBackup?.LastContractPlayerInfoBytes;
 
             VirtueEggsDelivered = backup.Virtue?.EggsDelivered.ToArray() ?? [];
             Resets = backup.Virtue?.Resets ?? 0;

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -98,12 +98,16 @@ namespace EGG9000.Common.Database {
         public bool HyperloopPurchased { get; set; }
         [Key(26)]
         public uint TankLevel { get; set; }
+        // Retired - see LastContractPlayerInfoBytes
         //[Key(27)]
         //public PlayerGrade Grade { get; set; }
         [Key(28)]
         public byte ClientVersion { get; set; }
         [Key(29)]
         public Dictionary<Ei.Egg, double> FuelAmounts { get; set; }
+        // Retired - see LastContractPlayerInfoBytes 
+        //[Key(30)]
+        //public double GradeProgress { get; set; }
         [Key(31)]
         public Ei.Egg MaxEggReached { get; set; }
         [Key(32)]
@@ -125,7 +129,7 @@ namespace EGG9000.Common.Database {
         [Key(41)]
         public SpaceMission FuelingMission { get; set; }
         [Key(42)]
-        public Dictionary<string, ulong> CustomEggMaxFarmSizeReached = [];
+        public Dictionary<string, ulong> CustomEggMaxFarmSizeReached { get; set; } = [];
 
 
         //[Key(43)]
@@ -256,12 +260,12 @@ namespace EGG9000.Common.Database {
             return artifacts?.Where(x => x.Count > 0).ToList() ?? [];
         }
 
-        public CustomBackup() { }
-
         // CS is sourced out-of-band (get_contract_player_info), so the protobuf rebuild has no fresh
         // value. Keep the prior value unless a positive fresh one is supplied. -1 is the legacy
         // "unknown" sentinel and counts as no value.
         public static double CarryForwardCs(double fresh, double last) => fresh > 0 ? fresh : last;
+
+        public CustomBackup() { }
 
         public CustomBackup(Ei.Backup backup, FrozenSet<Ei.Contract> contracts, CustomBackup lastBackup = null) {
             if(backup?.Game == null) {
@@ -375,7 +379,6 @@ namespace EGG9000.Common.Database {
                 MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, lastBackup.CustomEggMaxFarmSizeReached);
 
 
-            var temp = backup.ArtifactsDb.MissionArchive.Where(x => x.DurationSeconds > 0).GroupBy(x => x.Ship);
             if(backup.ArtifactsDb is not null) {
                 ShipsSent = [.. backup.ArtifactsDb.MissionArchive.Where(x => x.DurationSeconds > 0).GroupBy(x => new { x.Ship, x.DurationType }).Select(x => (x.Key.Ship, x.Key.DurationType, x.Count()))];
                 foreach(var ship in backup.ArtifactsDb.MissionInfos.Where(x => (int)x.Status > 5)) {

--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -440,6 +440,10 @@ namespace EGG9000.Common.Database.Entities {
         // (which are retained as a recovery copy). See AssignmentSettingsMigration.
         [Key(44)]
         public Contracts.Assignment.AssignmentSettings Assignment { get; set; }
+        [Key(45)]
+        public Contract.Types.PlayerGrade? PendingGrade { get; set; }
+        [Key(46)]
+        public DateTimeOffset PendingGradeSince { get; set; }
         public byte GetGroup(bool Ultra) {
             if(Ultra && UltraGroup > 0)
                 return UltraGroup;

--- a/EGG9000.Common/Helpers/AccountRefresh.cs
+++ b/EGG9000.Common/Helpers/AccountRefresh.cs
@@ -2,6 +2,8 @@ using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.EggIncAPI;
 
+using Google.Protobuf;
+
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -18,6 +20,7 @@ namespace EGG9000.Common.Helpers {
     // every mass backup. Both mutate the account in memory and stage DB changes; the caller persists
     // (UpdateAccounts + SaveChanges, or a targeted ExecuteUpdate). Compose them as needed.
     public static class AccountRefresh {
+        private static readonly TimeSpan CalculatingBufferWindow = TimeSpan.FromHours(1);
 
         // Pulls a fresh backup for one account and assigns it (carry-forward via the prior backup so
         // monotonic data like colleggtible levels is preserved). Returns the new backup, or null if the
@@ -38,6 +41,12 @@ namespace EGG9000.Common.Helpers {
             }
 
             account.Backup = backup;
+            return backup;
+        }
+
+        public static async Task<CustomBackup> RefreshFullAsync(EggIncAccount account, FrozenSet<Ei.Contract> cachedContracts, DBUser user, ApplicationDbContext db, ILogger logger) {
+            var backup = await RefreshBackupAsync(account, cachedContracts, logger);
+            await ApplyExtrasAsync(user, account, db, logger);
             return backup;
         }
 
@@ -63,47 +72,92 @@ namespace EGG9000.Common.Helpers {
                 logger.LogWarning("No response getting grade for user {User} ({Account}): {Error}", user.DiscordUsername, account.Name, error);
                 return null;
             }
-            if(info.Status != Ei.ContractPlayerInfo.Types.Status.Complete) {
-                logger.LogTrace("Skipping non-final grade ({Status}) for user {User} ({Account})", info.Status, user.DiscordUsername, account.Name);
-                return null;
-            }
             return info;
         }
 
         // DB-free half of ApplyExtrasAsync: applies grade + CS changes to the in-memory account blob.
         // Caller still owes UpsertSeasonProgress(account.Id, info.SeasonProgress, db, ...) + persist.
         public static bool ApplyExtras(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
-            var csChanged = account.Backup is not null && (account.Backup.TotalCS != info.TotalCxp || account.Backup.SeasonCS != info.SeasonCxp);
-            if(csChanged) {
-                account.Backup.TotalCS = info.TotalCxp;
-                account.Backup.SeasonCS = info.SeasonCxp;
-            }
+            var backupMutated = false;
+            if(account.Backup is not null) {
+                if(account.Backup.TotalCS != info.TotalCxp || account.Backup.SeasonCS != info.SeasonCxp) {
+                    account.Backup.TotalCS = info.TotalCxp;
+                    account.Backup.SeasonCS = info.SeasonCxp;
+                    backupMutated = true;
+                }
 
-            // get_contract_player_info.Grade is the authoritative current grade. When it differs from
-            // LastGrade the player was promoted, so stamp PromotionTime - otherwise GetGrade's
-            // "accepted > PromotionTime" guard keeps returning the stale most-recent-contract grade.
-            var mutated = GradeSync.ApplyGradeChange(user, account, info.Grade, setPromotionTime: true, guardUnset: true, logger);
-            if(!mutated) {
-                // LastGrade already matches the API. But if PromotionTime predates the most recent
-                // contract (which still carries the old grade), GetGrade would surface that stale grade.
-                // Re-stamp PromotionTime so the authoritative grade wins. Heals already-stuck accounts.
-                var (backupGrade, accepted) = account.Backup?.GetMostRecentContractGrade()
-                    ?? (Ei.Contract.Types.PlayerGrade.GradeUnset, DateTimeOffset.MinValue);
-                if(info.Grade != Ei.Contract.Types.PlayerGrade.GradeUnset && backupGrade != info.Grade && accepted > account.PromotionTime) {
-                    account.PromotionTime = DateTimeOffset.UtcNow;
-                    user.UpdateAccounts();
-                    mutated = true;
-                    logger.LogInformation("Re-stamped PromotionTime for {User} ({Account}) to keep authoritative grade {Grade}", user.DiscordUsername, account.Name, info.Grade);
-                } else {
-                    if(csChanged) {
-                        user.UpdateAccounts();
-                        mutated = true;
-                    }
-                    logger.LogInformation("No grade change for user {User} ({Account}) grade: {Grade}", user.DiscordUsername, account.Name, info.Grade);
+                var freshBytes = info.ToByteArray();
+                if(!freshBytes.AsSpan().SequenceEqual(account.Backup.LastContractPlayerInfoBytes ?? [])) {
+                    account.Backup.LastContractPlayerInfoBytes = freshBytes;
+                    backupMutated = true;
                 }
             }
 
+            var gradeMutated = info.Status switch {
+                Ei.ContractPlayerInfo.Types.Status.Complete => ApplyCompleteGrade(user, account, info, logger),
+                Ei.ContractPlayerInfo.Types.Status.Calculating => ApplyCalculatingGrade(user, account, info, logger),
+                _ => LogSkippedStatus(user, account, info, logger)
+            };
+
+            var mutated = backupMutated || gradeMutated;
+            if(mutated) user.UpdateAccounts();
             return mutated;
+        }
+
+        private static bool ApplyCompleteGrade(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
+            var mutated = GradeSync.ApplyGradeChange(user, account, info.Grade, setPromotionTime: true, guardUnset: true, logger);
+
+            if(account.PendingGrade.HasValue) {
+                account.PendingGrade = null;
+                account.PendingGradeSince = default;
+                mutated = true;
+            }
+
+            if(mutated) return true;
+
+            var (backupGrade, accepted) = account.Backup?.GetMostRecentContractGrade()
+                ?? (Ei.Contract.Types.PlayerGrade.GradeUnset, DateTimeOffset.MinValue);
+            if(info.Grade != Ei.Contract.Types.PlayerGrade.GradeUnset && backupGrade != info.Grade && accepted > account.PromotionTime) {
+                account.PromotionTime = DateTimeOffset.UtcNow;
+                logger.LogInformation("Re-stamped PromotionTime for {User} ({Account}) to keep authoritative grade {Grade}", user.DiscordUsername, account.Name, info.Grade);
+                return true;
+            }
+
+            logger.LogInformation("No grade change for user {User} ({Account}) grade: {Grade}", user.DiscordUsername, account.Name, info.Grade);
+            return false;
+        }
+
+        private static bool ApplyCalculatingGrade(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
+            if(!GradeSync.ShouldUpdateGrade(account.LastGrade, info.Grade, guardUnset: true)) {
+                if(!account.PendingGrade.HasValue) return false;
+                account.PendingGrade = null;
+                account.PendingGradeSince = default;
+                return true;
+            }
+
+            if(account.PendingGrade != info.Grade) {
+                account.PendingGrade = info.Grade;
+                account.PendingGradeSince = DateTimeOffset.UtcNow;
+                logger.LogInformation("Buffering CALCULATING grade candidate {Grade} for {User} ({Account}), current LastGrade {Current}",
+                    info.Grade, user.DiscordUsername, account.Name, account.LastGrade);
+                return true;
+            }
+
+            if(DateTimeOffset.UtcNow - account.PendingGradeSince < CalculatingBufferWindow) {
+                return false;
+            }
+
+            logger.LogInformation("CALCULATING grade candidate {Grade} for {User} ({Account}) persisted past the buffer window, accepting anyway",
+                info.Grade, user.DiscordUsername, account.Name);
+            GradeSync.ApplyGradeChange(user, account, info.Grade, setPromotionTime: true, guardUnset: true, logger);
+            account.PendingGrade = null;
+            account.PendingGradeSince = default;
+            return true;
+        }
+
+        private static bool LogSkippedStatus(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
+            logger.LogTrace("Skipping non-final grade ({Status}) for user {User} ({Account})", info.Status, user.DiscordUsername, account.Name);
+            return false;
         }
 
         public static async Task UpsertSeasonProgress(string eggIncId, IEnumerable<Ei.ContractPlayerInfo.Types.SeasonProgress> seasonProgress, ApplicationDbContext db, CancellationToken cancellationToken) {

--- a/EGG9000.Common/Helpers/AccountRefresh.cs
+++ b/EGG9000.Common/Helpers/AccountRefresh.cs
@@ -46,6 +46,7 @@ namespace EGG9000.Common.Helpers {
 
         public static async Task<CustomBackup> RefreshFullAsync(EggIncAccount account, FrozenSet<Ei.Contract> cachedContracts, DBUser user, ApplicationDbContext db, ILogger logger) {
             var backup = await RefreshBackupAsync(account, cachedContracts, logger);
+            if(backup is null) return null;
             await ApplyExtrasAsync(user, account, db, logger);
             return backup;
         }
@@ -59,7 +60,8 @@ namespace EGG9000.Common.Helpers {
             if(info is null) return false;
 
             var mutated = ApplyExtras(user, account, info, logger);
-            await UpsertSeasonProgress(account.Id, info.SeasonProgress, db, cancellationToken);
+            if(info.Status == Ei.ContractPlayerInfo.Types.Status.Complete)
+                await UpsertSeasonProgress(account.Id, info.SeasonProgress, db, cancellationToken);
             return mutated;
         }
 
@@ -79,14 +81,17 @@ namespace EGG9000.Common.Helpers {
         // Caller still owes UpsertSeasonProgress(account.Id, info.SeasonProgress, db, ...) + persist.
         public static bool ApplyExtras(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
             var backupMutated = false;
-            if(account.Backup is not null) {
+            if(account.Backup is not null && info.Status == Ei.ContractPlayerInfo.Types.Status.Complete) {
                 if(account.Backup.TotalCS != info.TotalCxp || account.Backup.SeasonCS != info.SeasonCxp) {
                     account.Backup.TotalCS = info.TotalCxp;
                     account.Backup.SeasonCS = info.SeasonCxp;
                     backupMutated = true;
                 }
 
-                var freshBytes = info.ToByteArray();
+                var trimmed = info.Clone();
+                trimmed.UnreadEvaluations.Clear();
+                trimmed.SeasonProgress.Clear();
+                var freshBytes = trimmed.ToByteArray();
                 if(!freshBytes.AsSpan().SequenceEqual(account.Backup.LastContractPlayerInfoBytes ?? [])) {
                     account.Backup.LastContractPlayerInfoBytes = freshBytes;
                     backupMutated = true;
@@ -107,10 +112,11 @@ namespace EGG9000.Common.Helpers {
         private static bool ApplyCompleteGrade(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {
             var mutated = GradeSync.ApplyGradeChange(user, account, info.Grade, setPromotionTime: true, guardUnset: true, logger);
 
+            var pendingCleared = false;
             if(account.PendingGrade.HasValue) {
                 account.PendingGrade = null;
                 account.PendingGradeSince = default;
-                mutated = true;
+                pendingCleared = true;
             }
 
             if(mutated) return true;
@@ -124,7 +130,7 @@ namespace EGG9000.Common.Helpers {
             }
 
             logger.LogInformation("No grade change for user {User} ({Account}) grade: {Grade}", user.DiscordUsername, account.Name, info.Grade);
-            return false;
+            return pendingCleared;
         }
 
         private static bool ApplyCalculatingGrade(DBUser user, EggIncAccount account, Ei.ContractPlayerInfo info, ILogger logger) {

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -263,10 +263,8 @@ namespace EGG9000.Site.Controllers {
                     foreach(var account in user.EggIncAccounts) {
                         var refreshed = refreshedBackups.FirstOrDefault(x => x.Id == account.Id);
                         if(refreshed.Backup is not null) account.Backup = refreshed.Backup;
-                    }
-                    // Extras stage DB writes, so run them sequentially against the single context.
-                    foreach(var account in user.EggIncAccounts)
                         await AccountRefresh.ApplyExtrasAsync(user, account, db, _logger);
+                    }
                     user.UpdateAccounts();
                     await db.SaveChangesAsync();
                 } catch(Exception e) {

--- a/EGG9000.Test/AccountRefreshCalculatingBufferTests.cs
+++ b/EGG9000.Test/AccountRefreshCalculatingBufferTests.cs
@@ -1,0 +1,126 @@
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+
+using G = Ei.Contract.Types.PlayerGrade;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class AccountRefreshCalculatingBufferTests {
+        private static (DBUser user, EggIncAccount account) UserWithAccount(G lastGrade) {
+            var account = new EggIncAccount { Id = "EI0000000000000003", LastGrade = lastGrade };
+            var user = new DBUser { DiscordUsername = "test" };
+            user.EggIncAccounts = [account];
+            return (user, account);
+        }
+
+        [TestMethod]
+        public void Complete_AppliesGradeImmediately() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAa, Status = Ei.ContractPlayerInfo.Types.Status.Complete };
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsTrue(mutated);
+            Assert.AreEqual(G.GradeAa, account.LastGrade);
+        }
+
+        [TestMethod]
+        public void Complete_ClearsAnyPendingBuffer() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            account.PendingGrade = G.GradeAa;
+            account.PendingGradeSince = DateTimeOffset.UtcNow;
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAaa, Status = Ei.ContractPlayerInfo.Types.Status.Complete };
+
+            AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsNull(account.PendingGrade);
+        }
+
+        [TestMethod]
+        public void Calculating_FirstSightingBuffersWithoutApplying() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAa, Status = Ei.ContractPlayerInfo.Types.Status.Calculating };
+
+            AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.AreEqual(G.GradeAaa, account.LastGrade);
+            Assert.AreEqual(G.GradeAa, account.PendingGrade);
+        }
+
+        [TestMethod]
+        public void Calculating_SameCandidateUnderWindow_StaysBuffered() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            account.PendingGrade = G.GradeAa;
+            account.PendingGradeSince = DateTimeOffset.UtcNow.AddMinutes(-30);
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAa, Status = Ei.ContractPlayerInfo.Types.Status.Calculating };
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsFalse(mutated);
+            Assert.AreEqual(G.GradeAaa, account.LastGrade);
+        }
+
+        [TestMethod]
+        public void Calculating_SameCandidatePastWindow_AcceptsAnyway() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            account.PendingGrade = G.GradeAa;
+            account.PendingGradeSince = DateTimeOffset.UtcNow.AddHours(-2);
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAa, Status = Ei.ContractPlayerInfo.Types.Status.Calculating };
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsTrue(mutated);
+            Assert.AreEqual(G.GradeAa, account.LastGrade);
+            Assert.IsNull(account.PendingGrade);
+        }
+
+        [TestMethod]
+        public void Calculating_CandidateChangeResetsTheClock() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            account.PendingGrade = G.GradeA;
+            account.PendingGradeSince = DateTimeOffset.UtcNow.AddHours(-2);
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAa, Status = Ei.ContractPlayerInfo.Types.Status.Calculating };
+
+            AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.AreEqual(G.GradeAaa, account.LastGrade);
+            Assert.AreEqual(G.GradeAa, account.PendingGrade);
+            Assert.IsTrue(account.PendingGradeSince > DateTimeOffset.UtcNow.AddMinutes(-1));
+        }
+
+        [TestMethod]
+        public void Calculating_CandidateMatchingCurrentGrade_ClearsBuffer() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            account.PendingGrade = G.GradeAa;
+            account.PendingGradeSince = DateTimeOffset.UtcNow.AddHours(-2);
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAaa, Status = Ei.ContractPlayerInfo.Types.Status.Calculating };
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsTrue(mutated);
+            Assert.IsNull(account.PendingGrade);
+        }
+
+        [TestMethod]
+        public void OutOfDate_NeverTouchesBufferState() {
+            var (user, account) = UserWithAccount(G.GradeAaa);
+            account.PendingGrade = G.GradeA;
+            var pendingSince = DateTimeOffset.UtcNow.AddHours(-5);
+            account.PendingGradeSince = pendingSince;
+            var info = new Ei.ContractPlayerInfo { Grade = G.GradeAa, Status = Ei.ContractPlayerInfo.Types.Status.OutOfDate };
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsFalse(mutated);
+            Assert.AreEqual(G.GradeAaa, account.LastGrade);
+            Assert.AreEqual(G.GradeA, account.PendingGrade);
+            Assert.AreEqual(pendingSince, account.PendingGradeSince);
+        }
+    }
+}

--- a/EGG9000.Test/AccountRefreshCsWriteTests.cs
+++ b/EGG9000.Test/AccountRefreshCsWriteTests.cs
@@ -1,0 +1,78 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
+
+using Google.Protobuf;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class AccountRefreshCsWriteTests {
+        private static (DBUser user, EggIncAccount account) UserWithBackup() {
+            var account = new EggIncAccount {
+                Id = "EI0000000000000004",
+                LastGrade = Ei.Contract.Types.PlayerGrade.GradeAaa,
+                Backup = new CustomBackup { TotalCS = 100, SeasonCS = 50, LastContractPlayerInfoBytes = [1, 2, 3] }
+            };
+            var user = new DBUser { DiscordUsername = "test" };
+            user.EggIncAccounts = [account];
+            return (user, account);
+        }
+
+        [TestMethod]
+        public void Complete_WritesCsAndTrimmedBytes() {
+            var (user, account) = UserWithBackup();
+            var info = new Ei.ContractPlayerInfo {
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAaa,
+                Status = Ei.ContractPlayerInfo.Types.Status.Complete,
+                TotalCxp = 200,
+                SeasonCxp = 75
+            };
+            info.UnreadEvaluations.Add(new Ei.ContractEvaluation());
+            info.SeasonProgress.Add(new Ei.ContractPlayerInfo.Types.SeasonProgress { SeasonId = "winter_2026" });
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsTrue(mutated);
+            Assert.AreEqual(200d, account.Backup.TotalCS);
+            Assert.AreEqual(75d, account.Backup.SeasonCS);
+            var stored = Ei.ContractPlayerInfo.Parser.ParseFrom(account.Backup.LastContractPlayerInfoBytes);
+            Assert.AreEqual(200d, stored.TotalCxp);
+            Assert.AreEqual(0, stored.UnreadEvaluations.Count);
+            Assert.AreEqual(0, stored.SeasonProgress.Count);
+        }
+
+        [TestMethod]
+        public void Calculating_LeavesCsAndBytesAlone() {
+            var (user, account) = UserWithBackup();
+            var info = new Ei.ContractPlayerInfo {
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAaa,
+                Status = Ei.ContractPlayerInfo.Types.Status.Calculating,
+                TotalCxp = 0,
+                SeasonCxp = 0
+            };
+
+            AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.AreEqual(100d, account.Backup.TotalCS);
+            Assert.AreEqual(50d, account.Backup.SeasonCS);
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, account.Backup.LastContractPlayerInfoBytes);
+        }
+
+        [TestMethod]
+        public void DegenerateUnknownResponse_DoesNotZeroCs() {
+            var (user, account) = UserWithBackup();
+            var info = new Ei.ContractPlayerInfo();
+
+            var mutated = AccountRefresh.ApplyExtras(user, account, info, NullLogger.Instance);
+
+            Assert.IsFalse(mutated);
+            Assert.AreEqual(100d, account.Backup.TotalCS);
+            Assert.AreEqual(50d, account.Backup.SeasonCS);
+            CollectionAssert.AreEqual(new byte[] { 1, 2, 3 }, account.Backup.LastContractPlayerInfoBytes);
+        }
+    }
+}

--- a/EGG9000.Test/CustomBackupCarryForwardTests.cs
+++ b/EGG9000.Test/CustomBackupCarryForwardTests.cs
@@ -12,6 +12,7 @@ namespace EGG9000.Test {
     // its 0 default and CSLeaderboard's "TotalCS > 0" filter drops the user until the slower CS sweep
     // runs again. Carry-forward keeps the last known CS across rebuilds.
     [TestClass]
+    [TestCategory("Unit")]
     public class CustomBackupCarryForwardTests {
         [TestMethod]
         public void CarryForwardCs_keeps_last_value_when_fresh_has_none() {

--- a/EGG9000.Test/CustomBackupCarryForwardTests.cs
+++ b/EGG9000.Test/CustomBackupCarryForwardTests.cs
@@ -2,6 +2,9 @@ using EGG9000.Common.Database;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
 namespace EGG9000.Test {
     // CS (TotalCS/SeasonCS) is no longer sourced from the protobuf backup - it is written out-of-band
     // by AccountRefresh.ApplyExtrasAsync from get_contract_player_info. Each mass UpdateBackups pass
@@ -28,6 +31,23 @@ namespace EGG9000.Test {
         [TestMethod]
         public void CarryForwardCs_zero_when_no_history() {
             Assert.AreEqual(0d, CustomBackup.CarryForwardCs(0d, 0d));
+        }
+
+        [TestMethod]
+        public void LastContractPlayerInfoBytes_carries_forward_across_rebuild() {
+            var lastBackup = new CustomBackup { LastContractPlayerInfoBytes = [1, 2, 3, 4] };
+            var backup = new Ei.Backup {
+                Game = new Ei.Backup.Types.Game(),
+                Settings = new Ei.Backup.Types.Settings(),
+                Stats = new Ei.Backup.Types.Stats(),
+                Artifacts = new Ei.Backup.Types.Artifacts(),
+                Contracts = new Ei.MyContracts(),
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+
+            var rebuilt = new CustomBackup(backup, new List<Ei.Contract>().ToFrozenSet(), lastBackup);
+
+            CollectionAssert.AreEqual(lastBackup.LastContractPlayerInfoBytes, rebuilt.LastContractPlayerInfoBytes);
         }
     }
 }

--- a/EGG9000.Test/CustomBackupPlayerInfoTests.cs
+++ b/EGG9000.Test/CustomBackupPlayerInfoTests.cs
@@ -1,0 +1,64 @@
+using EGG9000.Common.Database;
+
+using Google.Protobuf;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class CustomBackupPlayerInfoTests {
+        private static readonly MessagePackSerializerOptions Lz4 =
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+
+        private static Ei.ContractPlayerInfo SampleInfo() => new() {
+            Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+            Status = Ei.ContractPlayerInfo.Types.Status.Complete,
+            GradeProgress = 0.42,
+            GradeScore = 1234.5,
+            TargetGradeScore = 2000,
+            SoulPower = 10,
+            TargetSoulPower = 20,
+            IssueScore = 0,
+            LastEvaluationTime = 1_787_000_000,
+            LastEvaluationVersion = "cxp-v0.2.0",
+            AggregationNotes = "Final grade: GRADE_AA"
+        };
+
+        [TestMethod]
+        public void ComputedProperties_ReadThroughStoredBytes() {
+            var backup = new CustomBackup { LastContractPlayerInfoBytes = SampleInfo().ToByteArray() };
+
+            Assert.AreEqual(0.42, backup.GradeProgress);
+            Assert.AreEqual(1234.5, backup.GradeScore);
+            Assert.AreEqual(2000d, backup.TargetGradeScore);
+            Assert.AreEqual(10d, backup.SoulPower);
+            Assert.AreEqual(20d, backup.TargetSoulPower);
+            Assert.AreEqual(1_787_000_000d, backup.LastEvaluationTime);
+            Assert.AreEqual("cxp-v0.2.0", backup.LastEvaluationVersion);
+            Assert.AreEqual("Final grade: GRADE_AA", backup.AggregationNotes);
+        }
+
+        [TestMethod]
+        public void ComputedProperties_DefaultWhenNoBytesStored() {
+            var backup = new CustomBackup();
+
+            Assert.AreEqual(0d, backup.GradeProgress);
+            Assert.AreEqual("", backup.AggregationNotes);
+            Assert.IsEmpty(backup.Issues);
+        }
+
+        [TestMethod]
+        public void LastContractPlayerInfoBytes_RoundTripsThroughMessagePack() {
+            var backup = new CustomBackup { LastContractPlayerInfoBytes = SampleInfo().ToByteArray() };
+
+            var bytes = MessagePackSerializer.Serialize(backup, Lz4);
+            var back = MessagePackSerializer.Deserialize<CustomBackup>(bytes, Lz4);
+
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeAa, back.LastContractPlayerInfo.Grade);
+            Assert.AreEqual(0.42, back.GradeProgress);
+        }
+    }
+}

--- a/EGG9000.Test/PendingGradeSerializationTests.cs
+++ b/EGG9000.Test/PendingGradeSerializationTests.cs
@@ -1,0 +1,44 @@
+using EGG9000.Common.Database.Entities;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+
+using G = Ei.Contract.Types.PlayerGrade;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class PendingGradeSerializationTests {
+        private static readonly MessagePackSerializerOptions Lz4 =
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+
+        [TestMethod]
+        public void PendingGrade_RoundTrips() {
+            var account = new EggIncAccount {
+                Id = "EI0000000000000001",
+                LastGrade = G.GradeAa,
+                PendingGrade = G.GradeAaa,
+                PendingGradeSince = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000)
+            };
+
+            var bytes = MessagePackSerializer.Serialize(account, Lz4);
+            var back = MessagePackSerializer.Deserialize<EggIncAccount>(bytes, Lz4);
+
+            Assert.AreEqual(G.GradeAaa, back.PendingGrade);
+            Assert.AreEqual(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000), back.PendingGradeSince);
+        }
+
+        [TestMethod]
+        public void PendingGrade_DefaultsToNull() {
+            var account = new EggIncAccount { Id = "EI0000000000000002", LastGrade = G.GradeAa };
+
+            var bytes = MessagePackSerializer.Serialize(account, Lz4);
+            var back = MessagePackSerializer.Deserialize<EggIncAccount>(bytes, Lz4);
+
+            Assert.IsNull(back.PendingGrade);
+        }
+    }
+}

--- a/EGG9000.Test/PendingGradeSerializationTests.cs
+++ b/EGG9000.Test/PendingGradeSerializationTests.cs
@@ -5,6 +5,7 @@ using MessagePack;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using System;
+using System.Buffers;
 
 using G = Ei.Contract.Types.PlayerGrade;
 
@@ -39,6 +40,35 @@ namespace EGG9000.Test {
             var back = MessagePackSerializer.Deserialize<EggIncAccount>(bytes, Lz4);
 
             Assert.IsNull(back.PendingGrade);
+        }
+
+        [TestMethod]
+        public void PendingGrade_OldBlobWithoutNewKeys_Deserializes() {
+            var account = new EggIncAccount {
+                Id = "EI0000000000000003",
+                LastGrade = G.GradeAa,
+                PendingGrade = G.GradeAaa,
+                PendingGradeSince = DateTimeOffset.FromUnixTimeSeconds(1_700_000_000)
+            };
+
+            var bytes = MessagePackSerializer.Serialize(account, MessagePackSerializerOptions.Standard);
+            var reader = new MessagePackReader(bytes);
+            var count = reader.ReadArrayHeader();
+            Assert.IsTrue(count >= 47);
+
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new MessagePackWriter(buffer);
+            writer.WriteArrayHeader(45);
+            for(var i = 0; i < 45; i++) {
+                writer.WriteRaw(reader.ReadRaw());
+            }
+            writer.Flush();
+
+            var back = MessagePackSerializer.Deserialize<EggIncAccount>(buffer.WrittenMemory, MessagePackSerializerOptions.Standard);
+
+            Assert.AreEqual(G.GradeAa, back.LastGrade);
+            Assert.IsNull(back.PendingGrade);
+            Assert.AreEqual(default(DateTimeOffset), back.PendingGradeSince);
         }
     }
 }


### PR DESCRIPTION
See:
https://discord.com/channels/656455567858073601/777303939442802710/1539317052421185577

Seemingly a bug on Aux's side, where a user's latest CxP will be stuck in the `CALCULATING` state, despite correctly reflecting the "new" value, already, in game. This adds a buffering concept, so that we don't "immediately" trust a `CALCULATING` value, but if it's _still_, `CALCULATING`, after an hour, we take the new value.

I also standardized a lot of the code flows that were "fetching user data," and I put that in quotes intentionally, since it means different things depending on context; but for example, we were failing to load users' ultra status when they used `/register`, because the process of "loading user data," was implemented separately in each location.