### PR TITLE
Chore: Minor Fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="5.9.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/EGG9000.Bot/EGG9000.Bot.csproj
+++ b/EGG9000.Bot/EGG9000.Bot.csproj
@@ -119,6 +119,6 @@
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent" Condition="'$(DOCKER_BUILD)' != 'true'">
     <Exec Command="git log -n 1 --format=&quot;%25%25s%25%25n%25%25h%25%25n%25%25an%25%25n%25%25ct&quot; > &quot;$(ProjectDir)version.txt&quot;" ContinueOnError="WarnAndContinue" />
     <Exec Command="git rev-parse --abbrev-ref HEAD >> &quot;$(ProjectDir)version.txt&quot;" ContinueOnError="WarnAndContinue" />
-    <Exec Command="git config --get remote.origin.url >> &quot;$(ProjectDir)version.txt&quot;" ContinueOnError="WarnAndContinue" />
+    <Exec Command="git config --get remote.origin.url >> &quot;$(ProjectDir)version.txt&quot;" ContinueOnError="WarnAndContinue" IgnoreExitCode="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Little things after the version bumps. Rosalyn needs pinning via tools to 5.9.0, since the SDK only ships up to 5.6.0 right now 🤷 