### PR TITLE
Chore: Cleanup of `CustomBackup`

### DIFF
--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -150,16 +150,23 @@ namespace EGG9000.Common.Database {
         [Key(50)]
         public bool NoAliasInLatestBackup { get; set; }
         [Key(51)]
-        public byte[] LastContractPlayerInfoBytes { get; set; }
+        public byte[] LastContractPlayerInfoBytes {
+            get;
+            set {
+                field = value;
+                _lastContractPlayerInfo = null;
+            }
+        }
 
         [IgnoreMember]
         public Ei.ContractPlayerInfo LastContractPlayerInfo {
             get {
-                if(field is null && LastContractPlayerInfoBytes is { Length: > 0 })
-                    field = Ei.ContractPlayerInfo.Parser.ParseFrom(LastContractPlayerInfoBytes);
-                return field;
+                if(_lastContractPlayerInfo is null && LastContractPlayerInfoBytes is { Length: > 0 })
+                    _lastContractPlayerInfo = Ei.ContractPlayerInfo.Parser.ParseFrom(LastContractPlayerInfoBytes);
+                return _lastContractPlayerInfo;
             }
         }
+        private Ei.ContractPlayerInfo _lastContractPlayerInfo;
 
         [IgnoreMember]
         public double GradeProgress => LastContractPlayerInfo?.GradeProgress ?? 0;
@@ -189,53 +196,11 @@ namespace EGG9000.Common.Database {
         [IgnoreMember]
         public int EggsOfTruthTotal { get { return VirtueEggsDelivered?.Select(x => VirtueHelper.CurrentLevel(x)).Sum() ?? 0; } }
 
-        // Bonus schedule per https://egg-inc.fandom.com/wiki/Piggy_Bank: 2% at level 1, 25% at
-        // level 2, then 10n+10% after. NumPiggyBreaks starts at 1 for a new account, hence the
-        // < 2 / < 3 offsets below.
         [IgnoreMember]
-        public ulong TotalGEInPiggyBank {
-            get {
-                try {
-                    return NumPiggyBreaks switch {
-                        < 2 => (ulong)(PiggyBank * 1.02),
-                        < 3 => (ulong)(PiggyBank * 1.25),
-                        _ => PiggyBank + (PiggyBank * (10 * (NumPiggyBreaks + 1) + 10) / 100 + 1)
-                    };
-                } catch(OverflowException) {
-                    return ulong.MaxValue;
-                }
-            }
-        }
+        public ulong TotalGEInPiggyBank => AccountFormulas.TotalGeInPiggyBank(PiggyBank, NumPiggyBreaks);
 
         [IgnoreMember]
-        public int PEFromTrophies {
-            get {
-                if(EggMedalLevel is null)
-                    return -1;
-                if(EggMedalLevel.Count != 19)
-                    throw new Exception($"Unexpected number of trophies, should be 19 but instead got {EggMedalLevel.Count}");
-                var count = 0;
-
-                if(EggMedalLevel[(int)Ei.Egg.Edible - 1] >= (uint)TrophyLevel.Diamond) count += 5;
-                if(EggMedalLevel[(int)Ei.Egg.Superfood - 1] >= (uint)TrophyLevel.Diamond) count += 4;
-                if(EggMedalLevel[(int)Ei.Egg.Medical - 1] >= (uint)TrophyLevel.Diamond) count += 3;
-                if(EggMedalLevel[(int)Ei.Egg.RocketFuel - 1] >= (uint)TrophyLevel.Diamond) count += 2;
-
-                if(EggMedalLevel[(int)Ei.Egg.SuperMaterial - 1] >= (uint)TrophyLevel.Diamond) count += 1;
-                if(EggMedalLevel[(int)Ei.Egg.Fusion - 1] >= (uint)TrophyLevel.Diamond) count += 1;
-                if(EggMedalLevel[(int)Ei.Egg.Quantum - 1] >= (uint)TrophyLevel.Diamond) count += 1;
-                if(EggMedalLevel[(int)Ei.Egg.Immortality - 1] >= (uint)TrophyLevel.Diamond) count += 1;
-                if(EggMedalLevel[(int)Ei.Egg.Tachyon - 1] >= (uint)TrophyLevel.Diamond) count += 1;
-
-                if(EggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Diamond) count += 10;
-                if(EggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Platinum) count += 5;
-                if(EggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Gold) count += 3;
-                if(EggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Silver) count += 2;
-                if(EggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Bronze) count += 1;
-
-                return count;
-            }
-        }
+        public int PEFromTrophies => AccountFormulas.PeFromTrophies(EggMedalLevel);
 
         public List<ArtifactCount> GetAvailableArtifacts() {
             if(ArtifactHall is null || ArtifactHall.Count == 0) {
@@ -490,9 +455,6 @@ namespace EGG9000.Common.Database {
             if(currentCoopStatus != null)
                 customFarm.Creator = currentCoopStatus.CreatorId == backup.GetID();
 
-
-            var coops = backup.Contracts.CurrentCoopStatuses.Where(x => x.CoopIdentifier == contract?.CoopIdentifier);
-
             var uuids = backup.Contracts.CurrentCoopStatuses.Where(x => x.CoopIdentifier == contract?.CoopIdentifier).SelectMany(x => x.Contributors.Where(y => y.UserId == backup.EiUserId).Select(y => y.Uuid)).ToList();
 
             customFarm.ReportedUUIDs = uuids;
@@ -502,39 +464,29 @@ namespace EGG9000.Common.Database {
             var farmIndex = backup.Farms.IndexOf(farm);
             if(backup.ArtifactsDb != null) {
                 if(farmIndex == 0 && (int)farm.EggType >= 50 && (int)farm.EggType <= 54) {
-                    //Handle Virtue Eggs
-
                     var activeArtifactSlots = backup.ArtifactsDb.VirtueAfxDb.ActiveArtifacts.Slots;
                     var activeArtifacts = activeArtifactSlots.Select(x => backup.ArtifactsDb.VirtueAfxDb.InventoryItems.FirstOrDefault(y => y.ItemId == x.ItemId));
-
-                    customFarm.Artifacts.AddRange(activeArtifacts.Where(x => x != null).Select(x => {
-                        var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
-                        if(artifact == null)
-                            return null;
-                        artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
-                        return artifact;
-                    }).Where(x => x != null));
-
-                    customFarm.Artifacts = [.. customFarm.Artifacts.Where(x => x != null)];
+                    customFarm.Artifacts = ResolveActiveArtifacts(activeArtifacts);
                 } else {
                     var activeArtifactSlots = backup.ArtifactsDb.ActiveArtifactSets.Count - 1 < farmIndex ? [] : backup.ArtifactsDb.ActiveArtifactSets[farmIndex].Slots.Where(x => x.Occupied);
                     var activeArtifacts = activeArtifactSlots.Select(x => backup.ArtifactsDb.InventoryItems.FirstOrDefault(y => y.ItemId == x.ItemId));
-
-                    customFarm.Artifacts.AddRange(activeArtifacts.Where(x => x != null).Select(x => {
-                        var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
-                        if(artifact == null)
-                            return null;
-                        artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
-                        return artifact;
-                    }).Where(x => x != null));
-
-                    customFarm.Artifacts = [.. customFarm.Artifacts.Where(x => x != null)];
+                    customFarm.Artifacts = ResolveActiveArtifacts(activeArtifacts);
                 }
             }
 
 
 
             Farms.Add(customFarm);
+        }
+
+        private static List<EggIncArtifactInstance> ResolveActiveArtifacts(IEnumerable<Ei.ArtifactInventoryItem> activeArtifacts) {
+            return [.. activeArtifacts.Where(x => x != null).Select(x => {
+                var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
+                if(artifact == null)
+                    return null;
+                artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
+                return artifact;
+            }).Where(x => x != null)];
         }
 
         private static void MergeMaxFarmSizes(Dictionary<string, ulong> target, Dictionary<string, ulong> source) {
@@ -597,13 +549,7 @@ namespace EGG9000.Common.Database {
         public double EarningsBonus { get { return SoulEggs * SoulEggBonus * Math.Pow(ProphecyEggBonus, EggsOfProphecy) * (Math.Pow(1.01, EggsOfTruth)); } }
 
         [IgnoreMember]
-        public double MER => Math.Round(MerValue(SoulEggs, EggsOfProphecy), 2);
-
-        public static double MerValue(double soulEggs, double eggsOfProphecy) {
-            if(soulEggs <= 0 || !double.IsFinite(soulEggs)) return 0.0;
-            var seQ = soulEggs / 1e18; // Convert to quintillions
-            return (91 * Math.Log10(seQ) + 200 - eggsOfProphecy) / 10;
-        }
+        public double MER => Math.Round(AccountFormulas.MerValue(SoulEggs, EggsOfProphecy), 2);
     }
 
     [MessagePackObject]
@@ -714,31 +660,34 @@ namespace EGG9000.Common.Database {
         [IgnoreMember]
         public bool isVirtueEgg { get { return (int)EggType >= 50 && (int)EggType <= 54; } }
 
+        private double GetEggLayingBuff(Coop coop, double? ignoreBuff) {
+            if(coop?.LastStatusUpdate is null)
+                return 1.0;
+            var eggLayingBuff = coop.LastStatusUpdate.Participants.Where(x => x.BuffHistory.Any())
+                .Sum(x => x.BuffHistory.Last().EggLayingRate - 1);
+            ignoreBuff ??= (Artifacts.FirstOrDefault(x => x.Boost == EggIncBoostTypeEnum.CoopMembersEggLayingRates)?.Value ?? 1) - 1;
+            if(ignoreBuff.HasValue)
+                eggLayingBuff -= ignoreBuff.Value;
+            return eggLayingBuff + 1;
+        }
+
+        private static (double eggLayRatePerc, double shipCapPerc) GetLeagueModifierPercentages(Coop coop, DBContract contract) {
+            if(coop is null || (coop.Contract is null && contract is null) || coop.League <= 1)
+                return (1.0, 1.0);
+            var modifiers = (coop.Contract ?? contract).Details.GradeSpecs[(int)coop.League - 1].Modifiers;
+            var eggLayRateMod = modifiers.FirstOrDefault(x => x.Dimension == GameDimension.EggLayingRate);
+            var shipCapMod = modifiers.FirstOrDefault(x => x.Dimension == GameDimension.ShippingCapacity);
+            return (
+                eggLayRateMod is not null ? (double)eggLayRateMod.Value : 1.0,
+                shipCapMod is not null ? (double)shipCapMod.Value : 1.0
+            );
+        }
+
         private CustomFarmStats _stats = null;
         public CustomFarmStats WithStats(CustomBackup backup, Coop coop, List<DBCustomEgg> customEggs, double? ignoreBuff = null, DBContract contract = null) {
             if(_stats == null) {
-                var eggLayingBuff = 1.0;
-                if(coop != null && coop.LastStatusUpdate is not null) {
-                    eggLayingBuff = coop.LastStatusUpdate.Participants.Where(x => x.BuffHistory.Any())
-                        .Sum(x => x.BuffHistory.Last().EggLayingRate - 1);
-                    ignoreBuff = ignoreBuff ?? (Artifacts.FirstOrDefault(x => x.Boost == EggIncBoostTypeEnum.CoopMembersEggLayingRates)?.Value ?? 1) - 1;
-                    if(ignoreBuff.HasValue) {
-                        eggLayingBuff -= ignoreBuff.Value;
-                    }
-                    eggLayingBuff += 1;
-                }
-
-                var shipCapPerc = 1.0;
-                var eggLayRatePerc = 1.0;
-                if(coop is not null && (coop.Contract is not null || contract is not null) && coop.League > 1) {
-                    //Very uncommon, but contracts may have nerfs/buffs associated with them
-                    var modifiers = (coop.Contract ?? contract).Details.GradeSpecs[(int)coop.League - 1].Modifiers;
-                    var eggLayRateMod = modifiers.FirstOrDefault(x => x.Dimension == GameDimension.EggLayingRate);
-                    eggLayRatePerc = eggLayRateMod is not null ? (double)eggLayRateMod.Value : 1.0;
-
-                    var shipCapMod = modifiers.FirstOrDefault(x => x.Dimension == GameDimension.ShippingCapacity);
-                    shipCapPerc = shipCapMod is not null ? (double)shipCapMod.Value : 1.0;
-                }
+                var eggLayingBuff = GetEggLayingBuff(coop, ignoreBuff);
+                var (eggLayRatePerc, shipCapPerc) = GetLeagueModifierPercentages(coop, contract);
 
                 var eggLayingResearch = Research.GetEggLayingRatePerSec(this, backup.EpicResearch);
                 var eggLayingArtifact = EggIncArtifacts.GetEggLayingRateMultiple(this);
@@ -755,8 +704,7 @@ namespace EGG9000.Common.Database {
                 _stats.MaxRunningBonus = Research.MaxRunningBonus(this, backup.EpicResearch) + EggIncArtifacts.GetMaxRunningBonusAdditive(this);
                 _stats.HabSpace = Research.GetHabSpace(this, backup.EpicResearch) * Math.Round(EggIncArtifacts.GetHabSpaceMultiple(this), 5) * dimensionColleggtibleEffect[GameDimension.HabCapacity];
                 _stats.InternalHatchery = (int)(Research.InternalHatchery(this, backup.EpicResearch) * EggIncArtifacts.GetMultiple(EggIncBoostTypeEnum.InternalHatchery, this) * dimensionColleggtibleEffect[GameDimension.InternalHatcheryRate]);
-                if((int)EggType >= 50 && (int)EggType <= 54) {
-                    //Virtue Egg
+                if(isVirtueEgg) {
                     _stats.InternalHatchery = (int)((double)_stats.InternalHatchery * Math.Pow(1.1, backup.EggsOfTruth));
                 }
             }

--- a/EGG9000.Common/Helpers/AccountFormulas.cs
+++ b/EGG9000.Common/Helpers/AccountFormulas.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+using EGG9000.Common.Database;
+
+namespace EGG9000.Common.Helpers {
+    public static class AccountFormulas {
+        public static double MerValue(double soulEggs, double eggsOfProphecy) {
+            if(soulEggs <= 0 || !double.IsFinite(soulEggs)) return 0.0;
+            var seQ = soulEggs / 1e18;
+            return (91 * Math.Log10(seQ) + 200 - eggsOfProphecy) / 10;
+        }
+
+        public static ulong TotalGeInPiggyBank(ulong piggyBank, ulong numPiggyBreaks) {
+            try {
+                return numPiggyBreaks switch {
+                    < 2 => (ulong)(piggyBank * 1.02),
+                    < 3 => (ulong)(piggyBank * 1.25),
+                    _ => piggyBank + (piggyBank * (10 * (numPiggyBreaks + 1) + 10) / 100 + 1)
+                };
+            } catch(OverflowException) {
+                return ulong.MaxValue;
+            }
+        }
+
+        public static int PeFromTrophies(List<uint> eggMedalLevel) {
+            if(eggMedalLevel is null)
+                return -1;
+            if(eggMedalLevel.Count != 19)
+                throw new Exception($"Unexpected number of trophies, should be 19 but instead got {eggMedalLevel.Count}");
+            var count = 0;
+
+            if(eggMedalLevel[(int)Ei.Egg.Edible - 1] >= (uint)TrophyLevel.Diamond) count += 5;
+            if(eggMedalLevel[(int)Ei.Egg.Superfood - 1] >= (uint)TrophyLevel.Diamond) count += 4;
+            if(eggMedalLevel[(int)Ei.Egg.Medical - 1] >= (uint)TrophyLevel.Diamond) count += 3;
+            if(eggMedalLevel[(int)Ei.Egg.RocketFuel - 1] >= (uint)TrophyLevel.Diamond) count += 2;
+
+            if(eggMedalLevel[(int)Ei.Egg.SuperMaterial - 1] >= (uint)TrophyLevel.Diamond) count += 1;
+            if(eggMedalLevel[(int)Ei.Egg.Fusion - 1] >= (uint)TrophyLevel.Diamond) count += 1;
+            if(eggMedalLevel[(int)Ei.Egg.Quantum - 1] >= (uint)TrophyLevel.Diamond) count += 1;
+            if(eggMedalLevel[(int)Ei.Egg.Immortality - 1] >= (uint)TrophyLevel.Diamond) count += 1;
+            if(eggMedalLevel[(int)Ei.Egg.Tachyon - 1] >= (uint)TrophyLevel.Diamond) count += 1;
+
+            if(eggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Diamond) count += 10;
+            if(eggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Platinum) count += 5;
+            if(eggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Gold) count += 3;
+            if(eggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Silver) count += 2;
+            if(eggMedalLevel[(int)Ei.Egg.Enlightenment - 1] >= (uint)TrophyLevel.Bronze) count += 1;
+
+            return count;
+        }
+    }
+}

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -19,20 +19,19 @@ namespace Ei {
         public string Error { get; set; }
 
 
-        private List<Types.ContributionInfo> _participants { get; set; }
         public List<Types.ContributionInfo> Participants {
             get {
-                if(_participants != null)
-                    return _participants;
-                _participants = [];
+                if(field != null)
+                    return field;
+                field = [];
                 if(Contributors == null || Contributors.Count == 0) {
-                    return _participants;
+                    return field;
                 }
                 foreach(var p in Contributors) {
                     p.TimeLeftSeconds = SecondsRemaining;
-                    _participants.Add(p);
+                    field.Add(p);
                 }
-                return _participants;
+                return field;
             }
         }
 

--- a/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
+++ b/EGG9000.Site/Views/MyFarms/-EBHistory.cshtml
@@ -1,8 +1,9 @@
 @using EGG9000.Site.Models.MyFarms
+@using EGG9000.Common.Helpers
 @model MyFarms_Partial_EBHistoryModel
 @{
     string calculateMER(double se, ulong pe) {
-        var result = EGG9000.Common.Database.CustomBackup.MerValue(se, pe);
+        var result = AccountFormulas.MerValue(se, pe);
         return String.Format(result % 1 == 0 ? "{0:0}" : "{0:0.00}", result);
     }
 
@@ -25,7 +26,7 @@
         seStr = se.ToEggString(numberOfDecimalPlaces: 3),
         pe,
         eot,
-        mer = EGG9000.Common.Database.CustomBackup.MerValue(se, pe)
+        mer = AccountFormulas.MerValue(se, pe)
     };
 
     var ebStatsPoints = collapsedSnapshots

--- a/EGG9000.Test/AccountFormulasTests.cs
+++ b/EGG9000.Test/AccountFormulasTests.cs
@@ -1,0 +1,88 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Helpers;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class AccountFormulasTests {
+        [TestMethod]
+        public void MerValue_ZeroOrNegativeSoulEggs_ReturnsZero() {
+            Assert.AreEqual(0.0, AccountFormulas.MerValue(0, 10));
+            Assert.AreEqual(0.0, AccountFormulas.MerValue(-5, 10));
+        }
+
+        [TestMethod]
+        public void MerValue_NonFiniteSoulEggs_ReturnsZero() {
+            Assert.AreEqual(0.0, AccountFormulas.MerValue(double.PositiveInfinity, 10));
+            Assert.AreEqual(0.0, AccountFormulas.MerValue(double.NaN, 10));
+        }
+
+        [TestMethod]
+        public void MerValue_KnownInput_MatchesFormula() {
+            var result = AccountFormulas.MerValue(1e21, 0);
+            Assert.AreEqual(47.3, result, 0.0001);
+        }
+
+        [TestMethod]
+        public void TotalGeInPiggyBank_UnderTwoBreaks_UsesTwoPercentBonus() {
+            Assert.AreEqual((ulong)(1000 * 1.02), AccountFormulas.TotalGeInPiggyBank(1000, 0));
+            Assert.AreEqual((ulong)(1000 * 1.02), AccountFormulas.TotalGeInPiggyBank(1000, 1));
+        }
+
+        [TestMethod]
+        public void TotalGeInPiggyBank_TwoBreaks_UsesTwentyFivePercentBonus() {
+            Assert.AreEqual((ulong)(1000 * 1.25), AccountFormulas.TotalGeInPiggyBank(1000, 2));
+        }
+
+        [TestMethod]
+        public void TotalGeInPiggyBank_ThreeOrMoreBreaks_UsesTieredFormula() {
+            Assert.AreEqual(1501ul, AccountFormulas.TotalGeInPiggyBank(1000, 3));
+        }
+
+        [TestMethod]
+        public void TotalGeInPiggyBank_ExtremeValues_WrapsRatherThanThrowing() {
+            Assert.AreEqual(184467440737095514ul, AccountFormulas.TotalGeInPiggyBank(ulong.MaxValue, 10));
+        }
+
+        [TestMethod]
+        public void PeFromTrophies_NullList_ReturnsNegativeOne() {
+            Assert.AreEqual(-1, AccountFormulas.PeFromTrophies(null));
+        }
+
+        [TestMethod]
+        public void PeFromTrophies_WrongCount_Throws() {
+            Assert.ThrowsExactly<Exception>(() => AccountFormulas.PeFromTrophies(Enumerable.Repeat(0u, 5).ToList()));
+        }
+
+        [TestMethod]
+        public void PeFromTrophies_AllBelowDiamond_ReturnsZero() {
+            var levels = Enumerable.Repeat(0u, 19).ToList();
+            Assert.AreEqual(0, AccountFormulas.PeFromTrophies(levels));
+        }
+
+        [TestMethod]
+        public void PeFromTrophies_SomeAtDiamond_SumsWeights() {
+            var levels = Enumerable.Repeat(0u, 19).ToList();
+            levels[(int)Ei.Egg.Edible - 1] = (uint)TrophyLevel.Diamond;
+            levels[(int)Ei.Egg.Superfood - 1] = (uint)TrophyLevel.Diamond;
+            levels[(int)Ei.Egg.Medical - 1] = (uint)TrophyLevel.Diamond;
+            levels[(int)Ei.Egg.RocketFuel - 1] = (uint)TrophyLevel.Diamond;
+
+            Assert.AreEqual(5 + 4 + 3 + 2, AccountFormulas.PeFromTrophies(levels));
+        }
+
+        [TestMethod]
+        public void PeFromTrophies_EnlightenmentAtDiamond_AccumulatesAllTiers() {
+            var levels = Enumerable.Repeat(0u, 19).ToList();
+            levels[(int)Ei.Egg.Enlightenment - 1] = (uint)TrophyLevel.Diamond;
+
+            Assert.AreEqual(10 + 5 + 3 + 2 + 1, AccountFormulas.PeFromTrophies(levels));
+        }
+    }
+}


### PR DESCRIPTION
Extracted a lot of the "helper" stuff from `CustomBackup` into `AccountFormulas`, where we had some shared code between Formulae commands and the backup parsers.

Part 1 of a comprehensive rework of the struct here