### PR TITLE
Chore: Technical Rework of EI-Extended DB Storage

### DIFF
--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -72,6 +72,8 @@ namespace EGG9000.Common.Database {
             get => EiBackup?.Game is { } g ? (ushort)g.PermitLevel : field;
             set;
         }
+        [Key(7)]
+        public DateTime CacheAdded { get; set; }
         [Key(8)]
         [DerivedSlot(nameof(EiBackupBytes))]
         public ushort EggsOfProphecy {
@@ -290,6 +292,9 @@ namespace EGG9000.Common.Database {
         }
 
         [IgnoreMember]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
+        [System.Runtime.Serialization.IgnoreDataMember]
         public Ei.ContractPlayerInfo LastContractPlayerInfo {
             get {
                 if(_lastContractPlayerInfo is null && LastContractPlayerInfoBytes is { Length: > 0 })
@@ -300,6 +305,8 @@ namespace EGG9000.Common.Database {
         private Ei.ContractPlayerInfo _lastContractPlayerInfo;
 
         [Key(52)]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
         public byte[] EiBackupBytes {
             get;
             set {
@@ -900,6 +907,8 @@ namespace EGG9000.Common.Database {
         [Key(40)]
         public bool Creator { get; set; }
         [Key(41)]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
         public byte[] SimulationBytes {
             get;
             set {
@@ -925,6 +934,8 @@ namespace EGG9000.Common.Database {
         private Ei.Backup.Types.Simulation _simulation;
 
         [Key(42)]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
         public byte[] LocalContractBytes {
             get;
             set {

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -175,22 +175,13 @@ namespace EGG9000.Common.Database {
         }
         [Key(32)]
         public Dictionary<Ei.Egg, ulong> MaxFarmSizeReached {
-            get => EiBackup?.Game is { } g ? _maxFarmSizeReached ??= BuildMaxFarmSizeReached(g) : field;
+            get => EiBackup?.Game is { } g ? _maxFarmSizeReached ??= BackupProjections.BuildMaxFarmSizeReached(g) : field;
             set {
                 field = value;
                 _maxFarmSizeReached = null;
             }
         }
         private Dictionary<Ei.Egg, ulong> _maxFarmSizeReached;
-
-        private static Dictionary<Ei.Egg, ulong> BuildMaxFarmSizeReached(Ei.Backup.Types.Game game) {
-            var sizes = new Dictionary<Ei.Egg, ulong>();
-            for(var i = 0; i < game.MaxFarmSizeReached.Count; i++) {
-                if(game.MaxFarmSizeReached[i] > 0)
-                    sizes.Add((Ei.Egg)(i + 1), game.MaxFarmSizeReached[i]);
-            }
-            return sizes;
-        }
 
         [Key(33)]
         public bool HasDeviceId {
@@ -378,7 +369,7 @@ namespace EGG9000.Common.Database {
             }
             EiBackupBytes = StorageTrimmer.TrimmedBytes(backup);
             UserName = string.IsNullOrEmpty(backup.UserName) ? lastBackup?.UserName ?? "" : backup.UserName;
-            var activeTankArtifacts = ResolveActiveTankArtifacts(backup);
+            var activeTankArtifacts = BackupProjections.ResolveActiveTankArtifacts(backup);
             TankLevel = activeTankArtifacts.TankLevel;
 
             // CS is written out-of-band by AccountRefresh.ApplyExtrasAsync (from get_contract_player_info),
@@ -399,27 +390,27 @@ namespace EGG9000.Common.Database {
                 AddFarm(farm, backup);
             }
 
-            SpaceMissions = backup.ArtifactsDb?.MissionInfos?.Select(ToSpaceMission).ToList();
+            SpaceMissions = backup.ArtifactsDb?.MissionInfos?.Select(BackupProjections.ToSpaceMission).ToList();
 
             var fm = backup.ArtifactsDb?.FuelingMission ?? null;
             if(fm != null) {
-                FuelingMission = ToSpaceMission(fm);
+                FuelingMission = BackupProjections.ToSpaceMission(fm);
             }
 
-            FuelAmounts = BuildFuelAmounts(activeTankArtifacts);
+            FuelAmounts = BackupProjections.BuildFuelAmounts(activeTankArtifacts);
 
             CustomEggMaxFarmSizeReached = [];
-            MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, backup.Contracts.Archive.Concat(backup.Contracts.Contracts), contracts);
+            BackupProjections.MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, backup.Contracts.Archive.Concat(backup.Contracts.Contracts), contracts);
             if(lastBackup?.CustomEggMaxFarmSizeReached is not null)
-                MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, lastBackup.CustomEggMaxFarmSizeReached);
+                BackupProjections.MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, lastBackup.CustomEggMaxFarmSizeReached);
 
             if(backup.ArtifactsDb is not null) {
-                ShipsSent = BuildShipsSent(backup.ArtifactsDb);
+                ShipsSent = BackupProjections.BuildShipsSent(backup.ArtifactsDb);
             }
 
-            ArtifactHall = BuildArtifactHall(backup.ArtifactsDb);
+            ArtifactHall = BackupProjections.BuildArtifactHall(backup.ArtifactsDb);
 
-            ArtifactSets = BuildArtifactSets(backup.ArtifactsDb);
+            ArtifactSets = BackupProjections.BuildArtifactSets(backup.ArtifactsDb);
         }
 
         private void SetSubscriptionInfo(Ei.Backup backup) {
@@ -464,11 +455,11 @@ namespace EGG9000.Common.Database {
                 if(farmIndex == 0 && (int)farm.EggType >= 50 && (int)farm.EggType <= 54) {
                     var activeArtifactSlots = backup.ArtifactsDb.VirtueAfxDb.ActiveArtifacts.Slots;
                     var activeArtifacts = activeArtifactSlots.Select(x => backup.ArtifactsDb.VirtueAfxDb.InventoryItems.FirstOrDefault(y => y.ItemId == x.ItemId));
-                    customFarm.Artifacts = ResolveActiveArtifacts(activeArtifacts);
+                    customFarm.Artifacts = BackupProjections.ResolveActiveArtifacts(activeArtifacts);
                 } else {
                     var activeArtifactSlots = backup.ArtifactsDb.ActiveArtifactSets.Count - 1 < farmIndex ? [] : backup.ArtifactsDb.ActiveArtifactSets[farmIndex].Slots.Where(x => x.Occupied);
                     var activeArtifacts = activeArtifactSlots.Select(x => backup.ArtifactsDb.InventoryItems.FirstOrDefault(y => y.ItemId == x.ItemId));
-                    customFarm.Artifacts = ResolveActiveArtifacts(activeArtifacts);
+                    customFarm.Artifacts = BackupProjections.ResolveActiveArtifacts(activeArtifacts);
                 }
             }
 

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -955,84 +955,51 @@ namespace EGG9000.Common.Database {
     [MessagePackObject]
     public class CustomArchivedFarms : CustomFarmBase {
         [Key(0)]
-        public string CoopId {
-            get => LocalContract is { } l ? l.CoopIdentifier : field;
-            set;
-        }
+        public string CoopId { get; set; }
         [Key(1)]
-        public string ContractId {
-            get => LocalContract is { } l && l.HasContractIdentifier ? l.ContractIdentifier : field;
-            set;
-        }
+        public string ContractId { get; set; }
         [Key(2)]
-        public float TimeAccepted {
-            get => LocalContract is { } l ? (float)l.TimeAccepted : field;
-            set;
-        }
+        public float TimeAccepted { get; set; }
         [Key(3)]
         public bool Completed { get; set; }
         [Key(4)]
-        public byte? League {
-            get => LocalContract is { } l ? (byte?)l.League : field;
-            set;
-        }
+        public byte? League { get; set; }
         [Key(5)]
         public byte PEPossible { get; set; }
         [Key(6)]
         public byte PEGained { get; set; }
         [Key(7)]
-        public float ContributionAmount {
-            get => LocalContract is { } l ? (float)l.CoopLastUploadedContribution : field;
-            set;
-        }
+        public float ContributionAmount { get; set; }
         [Key(8)]
-        public PlayerGrade Grade {
-            get => LocalContract is { } l ? l.Grade : field;
-            set;
-        }
+        public PlayerGrade Grade { get; set; }
         [Key(9)]
-        public float EvaluationCxp {
-            get => LocalContract is { } l ? (l.Evaluation is { } e ? (float)e.Cxp : 0f) : field;
-            set;
-        }
+        public float EvaluationCxp { get; set; }
         [Key(10)]
-        public byte NumGoalsAchieved {
-            get => LocalContract is { } l ? (byte)l.NumGoalsAchieved : field;
-            set;
-        }
+        public byte NumGoalsAchieved { get; set; }
         [Key(11)]
-        public List<string> ReportedUUIDs {
-            get => LocalContract is { } l ? _reportedUUIDs ??= [.. l.ReportedUuids] : field;
-            set {
-                field = value;
-                _reportedUUIDs = null;
-            }
-        }
-        private List<string> _reportedUUIDs;
-        [Key(12)]
-        public byte[] LocalContractBytes {
-            get;
-            set {
-                field = value;
-                InvalidateLocalContract();
-                _reportedUUIDs = null;
-            }
-        }
+        public List<string> ReportedUUIDs { get; set; }
 
-        protected override byte[] LocalContractBytesStorage => LocalContractBytes;
+        protected override byte[] LocalContractBytesStorage => null;
 
         protected override long TimeAcceptedUnix => (long)TimeAccepted;
 
         public CustomArchivedFarms() { }
         public CustomArchivedFarms(Ei.LocalContract localContract) {
+            CoopId = localContract.CoopIdentifier;
             ContractId = localContract.Contract?.Identifier;
+            TimeAccepted = (float)localContract.TimeAccepted;
+            League = (byte)localContract.League;
+            ContributionAmount = (float)localContract.CoopLastUploadedContribution;
+            Grade = localContract.Grade;
+            EvaluationCxp = localContract.Evaluation is { } e ? (float)e.Cxp : 0f;
+            NumGoalsAchieved = (byte)localContract.NumGoalsAchieved;
+            ReportedUUIDs = [.. localContract.ReportedUuids];
             var goals = localContract.Contract is not null ? localContract.Contract.GetGoals(localContract) : null;
             Completed = localContract.Contract is not null && localContract.NumGoalsAchieved == goals.Count;
             if(goals is not null) {
                 PEPossible = (byte)goals.Where(x => x.RewardType == Ei.RewardType.EggsOfProphecy).Sum(x => x.RewardAmount);
                 PEGained = (byte)goals.Where(x => x.RewardType == Ei.RewardType.EggsOfProphecy && goals.IndexOf(x) < localContract.NumGoalsAchieved).Sum(x => x.RewardAmount);
             }
-            LocalContractBytes = StorageTrimmer.TrimmedBytes(localContract);
         }
     }
 

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -20,8 +20,9 @@ namespace EGG9000.Common.Database {
         [Key(0)]
         public List<CustomFarm> Farms { get; set; }
         [Key(1)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public string EggIncId {
-            get => EiBackup is { } p ? p.GetID() : field;
+            get => EiBackup is { } p ? p.GetID() : field ?? string.Empty;
             set;
         }
         [Key(2)]
@@ -32,6 +33,7 @@ namespace EGG9000.Common.Database {
         //[Key(3)]
         //public double EarningsBonus { get; set; }
         [Key(4)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public long LastBackupTime {
             get => EiBackup?.Settings is { } s ? (long)s.LastBackupTime : field;
             set;
@@ -55,6 +57,7 @@ namespace EGG9000.Common.Database {
             return (grade, DateTimeOffset.FromUnixTimeSeconds((long)time));
         }
         [Key(5)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public List<CustomResearch> EpicResearch {
             get => EiBackup?.Game is { } g ? _epicResearch ??= [.. g.EpicResearch.Select(x => new CustomResearch(x))] : field;
             set {
@@ -64,21 +67,25 @@ namespace EGG9000.Common.Database {
         }
         private List<CustomResearch> _epicResearch;
         [Key(6)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ushort PermitLevel {
             get => EiBackup?.Game is { } g ? (ushort)g.PermitLevel : field;
             set;
         }
         [Key(8)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ushort EggsOfProphecy {
             get => EiBackup?.Game is { } g ? (ushort)g.EggsOfProphecy : field;
             set;
         }
         [Key(9)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public double SoulEggs {
             get => EiBackup?.Game is { } g ? g.SoulEggsTotal : field;
             set;
         }
         [Key(10)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public double CurrentMultiplier {
             get => EiBackup?.Game is { } g ? g.CurrentMultiplier : field;
             set;
@@ -90,6 +97,7 @@ namespace EGG9000.Common.Database {
         [Key(13)]
         public List<CustomArchivedFarms> ArchivedFarms { get; set; }
         [Key(14)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong NumPrestiges {
             get => EiBackup?.Stats is { } s ? s.NumPrestiges : field;
             set;
@@ -98,6 +106,7 @@ namespace EGG9000.Common.Database {
         public List<SpaceMission> SpaceMissions { get; set; }
 
         [Key(16)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public uint NumDailyGiftsCollected {
             get => EiBackup?.Game is { } g ? g.NumDailyGiftsCollected : field;
             set;
@@ -107,6 +116,7 @@ namespace EGG9000.Common.Database {
         public uint PEFromDailyGifts => Math.Min(24, NumDailyGiftsCollected / 28);
 
         [Key(17)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public List<uint> EggMedalLevel {
             get => EiBackup?.Game is { } g ? _eggMedalLevel ??= [.. g.EggMedalLevel] : field;
             set {
@@ -117,31 +127,37 @@ namespace EGG9000.Common.Database {
         private List<uint> _eggMedalLevel;
 
         [Key(18)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong GoldenEggsEarned {
             get => EiBackup?.Game is { } g ? g.GoldenEggsEarned : field;
             set;
         }
         [Key(19)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong GoldenEggsSpent {
             get => EiBackup?.Game is { } g ? g.GoldenEggsSpent : field;
             set;
         }
         [Key(20)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong PiggyBank {
             get => EiBackup?.Game is { } g ? g.PiggyBank : field;
             set;
         }
         [Key(21)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong DroneTakedowns {
             get => EiBackup?.Stats is { } s ? s.DroneTakedowns : field;
             set;
         }
         [Key(22)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong DroneTakedownsElite {
             get => EiBackup?.Stats is { } s ? s.DroneTakedownsElite : field;
             set;
         }
         [Key(23)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public ulong NumPiggyBreaks {
             get => EiBackup?.Stats is { } s ? s.NumPiggyBreaks : field;
             set;
@@ -149,6 +165,7 @@ namespace EGG9000.Common.Database {
         [Key(24)]
         public List<ArtifactCount> ArtifactHall { get; set; }
         [Key(25)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public bool HyperloopPurchased {
             get => EiBackup?.Game is { } g ? g.HyperloopStation : field;
             set;
@@ -159,6 +176,7 @@ namespace EGG9000.Common.Database {
         //[Key(27)]
         //public PlayerGrade Grade { get; set; }
         [Key(28)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public byte ClientVersion {
             get => EiBackup is { } p ? (byte)p.Version : field;
             set;
@@ -169,11 +187,13 @@ namespace EGG9000.Common.Database {
         //[Key(30)]
         //public double GradeProgress { get; set; }
         [Key(31)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public Ei.Egg MaxEggReached {
             get => EiBackup?.Game is { } g ? g.MaxEggReached : field;
             set;
         }
         [Key(32)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public Dictionary<Ei.Egg, ulong> MaxFarmSizeReached {
             get => EiBackup?.Game is { } g ? _maxFarmSizeReached ??= BackupProjections.BuildMaxFarmSizeReached(g) : field;
             set {
@@ -184,13 +204,15 @@ namespace EGG9000.Common.Database {
         private Dictionary<Ei.Egg, ulong> _maxFarmSizeReached;
 
         [Key(33)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public bool HasDeviceId {
             get => EiBackup is { } p ? p.HasDeviceId : field;
             set;
         } = false;
         [Key(34)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public string DeviceId {
-            get => EiBackup is { HasDeviceId: true } p ? p.DeviceId : field;
+            get => EiBackup is { HasDeviceId: true } p ? p.DeviceId : field ?? string.Empty;
             set;
         } = string.Empty;
         [Key(36)]
@@ -202,6 +224,7 @@ namespace EGG9000.Common.Database {
         [Key(39)]
         public List<List<EggIncArtifactInstance>> ArtifactSets { get; set; } = [];
         [Key(40)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public double CraftingXP {
             get => EiBackup?.Artifacts is { } a ? a.CraftingXp : field;
             set;
@@ -216,6 +239,7 @@ namespace EGG9000.Common.Database {
         //public uint EoV { get; set; } = 0;
 
         [Key(44)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public double[] VirtueEggsDelivered {
             get => EiBackup?.Virtue is { } v ? _virtueEggsDelivered ??= [.. v.EggsDelivered] : field ?? [];
             set {
@@ -225,18 +249,21 @@ namespace EGG9000.Common.Database {
         } = [];
         private double[] _virtueEggsDelivered;
         [Key(45)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public uint Resets {
             get => EiBackup?.Virtue is { } v ? v.Resets : field;
             set;
         }
         [Key(46)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public uint ShiftCount {
             get => EiBackup?.Virtue is { } v ? v.ShiftCount : field;
             set;
         }
         [Key(47)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public uint[] EovEarned {
-            get => EiBackup?.Virtue is { } v ? _eovEarned ??= [.. v.EovEarned] : field;
+            get => EiBackup?.Virtue is { } v ? _eovEarned ??= [.. v.EovEarned] : field ?? [];
             set {
                 field = value;
                 _eovEarned = null;
@@ -248,6 +275,7 @@ namespace EGG9000.Common.Database {
         [Key(49)]
         public Ei.UserSubscriptionInfo.Types.Level? SubscriptionLevel { get; set; } = null;
         [Key(50)]
+        [DerivedSlot(nameof(EiBackupBytes))]
         public bool NoAliasInLatestBackup {
             get => EiBackup is { } p ? string.IsNullOrEmpty(p.UserName) : field;
             set;
@@ -668,31 +696,37 @@ namespace EGG9000.Common.Database {
     [MessagePackObject]
     public class CustomFarm : CustomFarmBase {
         [Key(0)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public Ei.FarmType FarmType {
             get => Simulation is { } s ? s.FarmType : field;
             set;
         }
         [Key(1)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public string ContractId {
             get => Simulation is { } s ? s.ContractId : field;
             set;
         }
         [Key(2)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public double EggsPaidFor {
             get => Simulation is { } s ? s.EggsPaidFor : field;
             set;
         }
         [Key(3)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public uint? League {
             get => LocalContract is { } l ? l.League : field;
             set;
         }
         [Key(4)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public string CoopId {
             get => LocalContract is { } l ? l.CoopIdentifier : field;
             set;
         }
         [Key(5)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public bool Cancelled {
             get => LocalContract is { } l ? l.Cancelled : field;
             set;
@@ -700,6 +734,7 @@ namespace EGG9000.Common.Database {
         [Key(6)]
         public bool Completed { get; set; }
         [Key(7)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public List<CustomResearch> CommonResearch {
             get => Simulation is { } s ? _commonResearch ??= [.. s.CommonResearch.Select(x => new CustomResearch(x))] : field;
             set {
@@ -709,16 +744,19 @@ namespace EGG9000.Common.Database {
         }
         private List<CustomResearch> _commonResearch;
         [Key(8)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public ulong NumChickens {
             get => Simulation is { } s ? s.NumChickens : field;
             set;
         }
         [Key(10)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public Ei.Egg EggType {
             get => Simulation is { } s ? s.EggType : field;
             set;
         }
         [Key(11)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public List<uint> TrainLength {
             get => Simulation is { } s ? _trainLength ??= [.. s.TrainLength] : field;
             set {
@@ -732,11 +770,13 @@ namespace EGG9000.Common.Database {
         [Key(13)]
         public List<EggIncArtifactInstance> Artifacts { get; set; }
         [Key(14)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public uint SilosOwned {
             get => Simulation is { } s ? s.SilosOwned : field;
             set;
         }
         [Key(15)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public long TimeAccepted {
             get => LocalContract is { } l ? (long)l.TimeAccepted : field;
             set;
@@ -744,46 +784,55 @@ namespace EGG9000.Common.Database {
         [Key(16)]
         public bool CoopAllowed { get; set; }
         [Key(17)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public long CoopSharedEndTime {
             get => LocalContract is { } l ? (long)l.CoopSharedEndTime : field;
             set;
         }
         [Key(18)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public ushort BoostTokensReceived {
             get => Simulation is { } s ? (ushort)s.BoostTokensReceived : field;
             set;
         }
         [Key(19)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public ushort BoostTokensGiven {
             get => Simulation is { } s ? (ushort)s.BoostTokensGiven : field;
             set;
         }
         [Key(20)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public ushort BoostTokensSpent {
             get => Simulation is { } s ? (ushort)s.BoostTokensSpent : field;
             set;
         }
         [Key(21)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public double CashEarned {
             get => Simulation is { } s ? s.CashEarned : field;
             set;
         }
         [Key(22)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public double CashSpent {
             get => Simulation is { } s ? s.CashSpent : field;
             set;
         }
         [Key(23)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public long TimeCheatDebt {
             get => Simulation is { } s ? (long)s.TimeCheatDebtDEP : field;
             set;
         }
         [Key(24)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public ushort BoostsUsed {
             get => LocalContract is { } l ? (ushort)l.BoostsUsed : field;
             set;
         }
         [Key(25)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public ushort TimeCheatsDetected {
             get => Simulation is { } s ? (ushort)s.TimeCheatsDetected : field;
             set;
@@ -801,6 +850,7 @@ namespace EGG9000.Common.Database {
         //[Key(31)]
         //public Double MaxRunningBonus { get; set; }
         [Key(32)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public List<ushort> Habs {
             get => Simulation is { } s ? _habs ??= [.. s.Habs.Select(x => (ushort)x)] : field;
             set {
@@ -810,6 +860,7 @@ namespace EGG9000.Common.Database {
         }
         private List<ushort> _habs;
         [Key(33)]
+        [DerivedSlot(nameof(SimulationBytes))]
         public float LastStepTime {
             get => Simulation is { } s ? (float)s.LastStepTime : field;
             set;
@@ -817,26 +868,31 @@ namespace EGG9000.Common.Database {
         [Key(34)]
         public List<string> ReportedUUIDs { get; set; }
         [Key(35)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public PlayerGrade Grade {
             get => LocalContract is { } l ? l.Grade : field;
             set;
         }
         [Key(36)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public double EvaluationCxp {
             get => LocalContract is { } l ? (l.Evaluation is { } e ? (float)e.Cxp : 0.0) : field;
             set;
         }
         [Key(37)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public bool ContributionFinalized {
             get => LocalContract is { } l ? l.CoopContributionFinalized : field;
             set;
         }
         [Key(38)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public double CoopSimulationEndTime {
             get => LocalContract is { } l ? l.CoopSimulationEndTime : field;
             set;
         }
         [Key(39)]
+        [DerivedSlot(nameof(LocalContractBytes))]
         public byte NumGoalsAchieved {
             get => LocalContract is { } l ? (byte)l.NumGoalsAchieved : field;
             set;

--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -1,6 +1,7 @@
 using EGG9000.Common.Database.Entities;
 using EGG9000.Common.Helpers;
 using EGG9000.Common.JsonData;
+using EGG9000.Common.Proto;
 using Google.Protobuf.Collections;
 using MessagePack;
 using System;
@@ -19,13 +20,22 @@ namespace EGG9000.Common.Database {
         [Key(0)]
         public List<CustomFarm> Farms { get; set; }
         [Key(1)]
-        public string EggIncId { get; set; }
+        public string EggIncId {
+            get => EiBackup is { } p ? p.GetID() : field;
+            set;
+        }
         [Key(2)]
-        public string UserName { get; set; }
+        public string UserName {
+            get => EiBackup is { } p && !string.IsNullOrEmpty(p.UserName) ? p.UserName : field;
+            set;
+        }
         //[Key(3)]
         //public double EarningsBonus { get; set; }
         [Key(4)]
-        public long LastBackupTime { get; set; }
+        public long LastBackupTime {
+            get => EiBackup?.Settings is { } s ? (long)s.LastBackupTime : field;
+            set;
+        }
         public DateTimeOffset GetLastBackupDateTime() {
             return DateTimeOffset.FromUnixTimeSeconds(LastBackupTime);
         }
@@ -39,23 +49,40 @@ namespace EGG9000.Common.Database {
                 graded.AddRange(Farms.Where(x => x.Grade != PlayerGrade.GradeUnset).Select(x => ((double)x.TimeAccepted, x.Grade)));
             if(ArchivedFarms is not null)
                 graded.AddRange(ArchivedFarms.Where(x => x.Grade != PlayerGrade.GradeUnset).Select(x => ((double)x.TimeAccepted, x.Grade)));
-            var latest = graded.OrderByDescending(x => x.time).FirstOrDefault();
-            if(latest.grade == PlayerGrade.GradeUnset)
+            var (time, grade) = graded.OrderByDescending(x => x.time).FirstOrDefault();
+            if(grade == PlayerGrade.GradeUnset)
                 return (PlayerGrade.GradeUnset, DateTimeOffset.MinValue);
-            return (latest.grade, DateTimeOffset.FromUnixTimeSeconds((long)latest.time));
+            return (grade, DateTimeOffset.FromUnixTimeSeconds((long)time));
         }
         [Key(5)]
-        public List<CustomResearch> EpicResearch { get; set; }
+        public List<CustomResearch> EpicResearch {
+            get => EiBackup?.Game is { } g ? _epicResearch ??= [.. g.EpicResearch.Select(x => new CustomResearch(x))] : field;
+            set {
+                field = value;
+                _epicResearch = null;
+            }
+        }
+        private List<CustomResearch> _epicResearch;
         [Key(6)]
-        public ushort PermitLevel { get; set; }
-        [Key(7)]
-        public DateTime CacheAdded { get; set; }
+        public ushort PermitLevel {
+            get => EiBackup?.Game is { } g ? (ushort)g.PermitLevel : field;
+            set;
+        }
         [Key(8)]
-        public ushort EggsOfProphecy { get; set; }
+        public ushort EggsOfProphecy {
+            get => EiBackup?.Game is { } g ? (ushort)g.EggsOfProphecy : field;
+            set;
+        }
         [Key(9)]
-        public double SoulEggs { get; set; }
+        public double SoulEggs {
+            get => EiBackup?.Game is { } g ? g.SoulEggsTotal : field;
+            set;
+        }
         [Key(10)]
-        public double CurrentMultiplier { get; set; }
+        public double CurrentMultiplier {
+            get => EiBackup?.Game is { } g ? g.CurrentMultiplier : field;
+            set;
+        }
         //[Key(11)]
         //public List<string> CompleteContracts { get; set; }
         [Key(12)]
@@ -63,59 +90,118 @@ namespace EGG9000.Common.Database {
         [Key(13)]
         public List<CustomArchivedFarms> ArchivedFarms { get; set; }
         [Key(14)]
-        public ulong NumPrestiges { get; set; }
+        public ulong NumPrestiges {
+            get => EiBackup?.Stats is { } s ? s.NumPrestiges : field;
+            set;
+        }
         [Key(15)]
         public List<SpaceMission> SpaceMissions { get; set; }
 
         [Key(16)]
-        public uint NumDailyGiftsCollected { get; set; }
-
-        [IgnoreMember]
-        public uint PEFromDailyGifts {
-            get {
-                return Math.Min(24, NumDailyGiftsCollected / 28);
-            }
+        public uint NumDailyGiftsCollected {
+            get => EiBackup?.Game is { } g ? g.NumDailyGiftsCollected : field;
+            set;
         }
 
+        [IgnoreMember]
+        public uint PEFromDailyGifts => Math.Min(24, NumDailyGiftsCollected / 28);
+
         [Key(17)]
-        public List<uint> EggMedalLevel { get; set; }
+        public List<uint> EggMedalLevel {
+            get => EiBackup?.Game is { } g ? _eggMedalLevel ??= [.. g.EggMedalLevel] : field;
+            set {
+                field = value;
+                _eggMedalLevel = null;
+            }
+        }
+        private List<uint> _eggMedalLevel;
 
         [Key(18)]
-        public ulong GoldenEggsEarned { get; set; }
+        public ulong GoldenEggsEarned {
+            get => EiBackup?.Game is { } g ? g.GoldenEggsEarned : field;
+            set;
+        }
         [Key(19)]
-        public ulong GoldenEggsSpent { get; set; }
+        public ulong GoldenEggsSpent {
+            get => EiBackup?.Game is { } g ? g.GoldenEggsSpent : field;
+            set;
+        }
         [Key(20)]
-        public ulong PiggyBank { get; set; }
+        public ulong PiggyBank {
+            get => EiBackup?.Game is { } g ? g.PiggyBank : field;
+            set;
+        }
         [Key(21)]
-        public ulong DroneTakedowns { get; set; }
+        public ulong DroneTakedowns {
+            get => EiBackup?.Stats is { } s ? s.DroneTakedowns : field;
+            set;
+        }
         [Key(22)]
-        public ulong DroneTakedownsElite { get; set; }
+        public ulong DroneTakedownsElite {
+            get => EiBackup?.Stats is { } s ? s.DroneTakedownsElite : field;
+            set;
+        }
         [Key(23)]
-        public ulong NumPiggyBreaks { get; set; }
+        public ulong NumPiggyBreaks {
+            get => EiBackup?.Stats is { } s ? s.NumPiggyBreaks : field;
+            set;
+        }
         [Key(24)]
         public List<ArtifactCount> ArtifactHall { get; set; }
         [Key(25)]
-        public bool HyperloopPurchased { get; set; }
+        public bool HyperloopPurchased {
+            get => EiBackup?.Game is { } g ? g.HyperloopStation : field;
+            set;
+        }
         [Key(26)]
         public uint TankLevel { get; set; }
         // Retired - see LastContractPlayerInfoBytes
         //[Key(27)]
         //public PlayerGrade Grade { get; set; }
         [Key(28)]
-        public byte ClientVersion { get; set; }
+        public byte ClientVersion {
+            get => EiBackup is { } p ? (byte)p.Version : field;
+            set;
+        }
         [Key(29)]
         public Dictionary<Ei.Egg, double> FuelAmounts { get; set; }
         // Retired - see LastContractPlayerInfoBytes 
         //[Key(30)]
         //public double GradeProgress { get; set; }
         [Key(31)]
-        public Ei.Egg MaxEggReached { get; set; }
+        public Ei.Egg MaxEggReached {
+            get => EiBackup?.Game is { } g ? g.MaxEggReached : field;
+            set;
+        }
         [Key(32)]
-        public Dictionary<Ei.Egg, ulong> MaxFarmSizeReached { get; set; }
+        public Dictionary<Ei.Egg, ulong> MaxFarmSizeReached {
+            get => EiBackup?.Game is { } g ? _maxFarmSizeReached ??= BuildMaxFarmSizeReached(g) : field;
+            set {
+                field = value;
+                _maxFarmSizeReached = null;
+            }
+        }
+        private Dictionary<Ei.Egg, ulong> _maxFarmSizeReached;
+
+        private static Dictionary<Ei.Egg, ulong> BuildMaxFarmSizeReached(Ei.Backup.Types.Game game) {
+            var sizes = new Dictionary<Ei.Egg, ulong>();
+            for(var i = 0; i < game.MaxFarmSizeReached.Count; i++) {
+                if(game.MaxFarmSizeReached[i] > 0)
+                    sizes.Add((Ei.Egg)(i + 1), game.MaxFarmSizeReached[i]);
+            }
+            return sizes;
+        }
+
         [Key(33)]
-        public bool HasDeviceId { get; set; } = false;
+        public bool HasDeviceId {
+            get => EiBackup is { } p ? p.HasDeviceId : field;
+            set;
+        } = false;
         [Key(34)]
-        public string DeviceId { get; set; } = string.Empty;
+        public string DeviceId {
+            get => EiBackup is { HasDeviceId: true } p ? p.DeviceId : field;
+            set;
+        } = string.Empty;
         [Key(36)]
         public List<(Spaceship ship, DurationType type, int count)> ShipsSent { get; set; }
         [Key(37)]
@@ -125,7 +211,10 @@ namespace EGG9000.Common.Database {
         [Key(39)]
         public List<List<EggIncArtifactInstance>> ArtifactSets { get; set; } = [];
         [Key(40)]
-        public double CraftingXP { get; set; } = 0;
+        public double CraftingXP {
+            get => EiBackup?.Artifacts is { } a ? a.CraftingXp : field;
+            set;
+        } = 0;
         [Key(41)]
         public SpaceMission FuelingMission { get; set; }
         [Key(42)]
@@ -137,22 +226,41 @@ namespace EGG9000.Common.Database {
 
         [Key(44)]
         public double[] VirtueEggsDelivered {
-            get => _virtueEggsDelivered ?? [];
-            set => _virtueEggsDelivered = value;
-        }
-        private double[] _virtueEggsDelivered = [];
+            get => EiBackup?.Virtue is { } v ? _virtueEggsDelivered ??= [.. v.EggsDelivered] : field ?? [];
+            set {
+                field = value;
+                _virtueEggsDelivered = null;
+            }
+        } = [];
+        private double[] _virtueEggsDelivered;
         [Key(45)]
-        public uint Resets { get; set; }
+        public uint Resets {
+            get => EiBackup?.Virtue is { } v ? v.Resets : field;
+            set;
+        }
         [Key(46)]
-        public uint ShiftCount { get; set; }
+        public uint ShiftCount {
+            get => EiBackup?.Virtue is { } v ? v.ShiftCount : field;
+            set;
+        }
         [Key(47)]
-        public uint[] EovEarned { get; set; }
+        public uint[] EovEarned {
+            get => EiBackup?.Virtue is { } v ? _eovEarned ??= [.. v.EovEarned] : field;
+            set {
+                field = value;
+                _eovEarned = null;
+            }
+        } = [];
+        private uint[] _eovEarned;
         [Key(48)]
         public double SubscriptionEnds { get; set; } = 0;
         [Key(49)]
         public Ei.UserSubscriptionInfo.Types.Level? SubscriptionLevel { get; set; } = null;
         [Key(50)]
-        public bool NoAliasInLatestBackup { get; set; }
+        public bool NoAliasInLatestBackup {
+            get => EiBackup is { } p ? string.IsNullOrEmpty(p.UserName) : field;
+            set;
+        }
         [Key(51)]
         public byte[] LastContractPlayerInfoBytes {
             get;
@@ -171,6 +279,33 @@ namespace EGG9000.Common.Database {
             }
         }
         private Ei.ContractPlayerInfo _lastContractPlayerInfo;
+
+        [Key(52)]
+        public byte[] EiBackupBytes {
+            get;
+            set {
+                field = value;
+                _eiBackup = null;
+                _epicResearch = null;
+                _eggMedalLevel = null;
+                _maxFarmSizeReached = null;
+                _virtueEggsDelivered = null;
+                _eovEarned = null;
+            }
+        }
+
+        [IgnoreMember]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
+        [System.Runtime.Serialization.IgnoreDataMember]
+        public Ei.Backup EiBackup {
+            get {
+                if(_eiBackup is null && EiBackupBytes is { Length: > 0 })
+                    _eiBackup = Ei.Backup.Parser.ParseFrom(EiBackupBytes);
+                return _eiBackup;
+            }
+        }
+        private Ei.Backup _eiBackup;
 
         [IgnoreMember]
         public double GradeProgress => LastContractPlayerInfo?.GradeProgress ?? 0;
@@ -241,29 +376,10 @@ namespace EGG9000.Common.Database {
                 EmptyBackup = true;
                 return;
             }
-            EpicResearch = [.. backup.Game.EpicResearch.Select(x => new CustomResearch(x))];
-            CurrentMultiplier = backup.Game.CurrentMultiplier;
-            EggIncId = backup.GetID();
+            EiBackupBytes = StorageTrimmer.TrimmedBytes(backup);
             UserName = string.IsNullOrEmpty(backup.UserName) ? lastBackup?.UserName ?? "" : backup.UserName;
-            NoAliasInLatestBackup = string.IsNullOrEmpty(backup.UserName);
-            LastBackupTime = (long)backup.Settings.LastBackupTime;
-            PermitLevel = (ushort)backup.Game.PermitLevel;
-            SoulEggs = backup.Game.SoulEggsTotal;
-            EggsOfProphecy = (ushort)backup.Game.EggsOfProphecy;
-            NumPrestiges = backup.Stats.NumPrestiges;
-
-            GoldenEggsEarned = backup.Game.GoldenEggsEarned;
-            GoldenEggsSpent = backup.Game.GoldenEggsSpent;
-            PiggyBank = backup.Game.PiggyBank;
-            NumPiggyBreaks = backup.Stats.NumPiggyBreaks;
-            DroneTakedowns = backup.Stats.DroneTakedowns;
-            DroneTakedownsElite = backup.Stats.DroneTakedownsElite;
-            HyperloopPurchased = backup.Game.HyperloopStation;
-            var currentFarm = backup.Farms.ElementAtOrDefault((int)backup.Game.CurrentFarm);
-            var inVirtueDimension = currentFarm is not null && (int)currentFarm.EggType >= 50 && (int)currentFarm.EggType <= 54;
-            var activeTankArtifacts = inVirtueDimension && backup.Virtue?.Afx is not null ? backup.Virtue.Afx : backup.Artifacts;
+            var activeTankArtifacts = ResolveActiveTankArtifacts(backup);
             TankLevel = activeTankArtifacts.TankLevel;
-            ClientVersion = (byte)backup.Version;
 
             // CS is written out-of-band by AccountRefresh.ApplyExtrasAsync (from get_contract_player_info),
             // not derived from this protobuf backup. Carry the last known value forward so a mass-backup
@@ -272,19 +388,7 @@ namespace EGG9000.Common.Database {
             SeasonCS = CarryForwardCs(0, lastBackup?.SeasonCS ?? 0);
             LastContractPlayerInfoBytes = lastBackup?.LastContractPlayerInfoBytes;
 
-            VirtueEggsDelivered = backup.Virtue?.EggsDelivered.ToArray() ?? [];
-            Resets = backup.Virtue?.Resets ?? 0;
-            ShiftCount = backup.Virtue?.ShiftCount ?? 0;
-            EovEarned = backup.Virtue?.EovEarned.ToArray() ?? [];
-
             SetSubscriptionInfo(backup);
-
-            HasDeviceId = backup.HasDeviceId;
-            if(backup.HasDeviceId) DeviceId = backup.DeviceId;
-
-            MaxEggReached = backup.Game.MaxEggReached;
-
-            CraftingXP = backup.Artifacts.CraftingXp;
 
             ArchivedFarms = [];
             AddContracts(backup.Contracts.Contracts, contracts);
@@ -295,110 +399,27 @@ namespace EGG9000.Common.Database {
                 AddFarm(farm, backup);
             }
 
-
-
-            SpaceMissions = backup.ArtifactsDb?.MissionInfos?.Select(m => new SpaceMission {
-                Ship = m.Ship,
-                Duration = m.DurationType,
-                Status = m.Status,
-                DurationSeconds = (long)m.DurationSeconds,
-                StartTime = (long)m.StartTimeDerived,
-                Fuels = [.. m.Fuel.Select(f => new SpaceMissionFuel {
-                    Amount = f.Amount,
-                    Egg = f.Egg
-                })],
-                Targeting = (int)m.Ship >= 4 ? m?.TargetArtifact ?? Name.Unknown : Name.Unknown,
-                Capacity = m.Capacity,
-                Stars = m.Level
-            }).ToList();
+            SpaceMissions = backup.ArtifactsDb?.MissionInfos?.Select(ToSpaceMission).ToList();
 
             var fm = backup.ArtifactsDb?.FuelingMission ?? null;
             if(fm != null) {
-                FuelingMission = new SpaceMission {
-                    Ship = fm.Ship,
-                    Duration = fm.DurationType,
-                    Status = fm.Status,
-                    DurationSeconds = (long)fm.DurationSeconds,
-                    StartTime = (long)fm.StartTimeDerived,
-                    Fuels = [.. fm.Fuel.Select(f => new SpaceMissionFuel {
-                        Amount = f.Amount,
-                        Egg = f.Egg
-                    })],
-                    Targeting = (int)fm.Ship >= 4 ? fm?.TargetArtifact ?? Name.Unknown : Name.Unknown,
-                    Capacity = fm.Capacity,
-                    Stars = fm.Level
-                };
+                FuelingMission = ToSpaceMission(fm);
             }
 
-            FuelAmounts = [];
-            for(var i = 0; i < activeTankArtifacts.TankFuels.Count; i++) {
-                if(activeTankArtifacts.TankFuels[i] > 0)
-                    FuelAmounts.Add((Ei.Egg)(i + 1), activeTankArtifacts.TankFuels[i]);
-            }
-
-            MaxFarmSizeReached = [];
-            for(var i = 0; i < backup.Game.MaxFarmSizeReached.Count; i++) {
-                if(backup.Game.MaxFarmSizeReached[i] > 0)
-                    MaxFarmSizeReached.Add((Ei.Egg)(i + 1), backup.Game.MaxFarmSizeReached[i]);
-            }
+            FuelAmounts = BuildFuelAmounts(activeTankArtifacts);
 
             CustomEggMaxFarmSizeReached = [];
             MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, backup.Contracts.Archive.Concat(backup.Contracts.Contracts), contracts);
             if(lastBackup?.CustomEggMaxFarmSizeReached is not null)
                 MergeMaxFarmSizes(CustomEggMaxFarmSizeReached, lastBackup.CustomEggMaxFarmSizeReached);
 
-
             if(backup.ArtifactsDb is not null) {
-                ShipsSent = [.. backup.ArtifactsDb.MissionArchive.Where(x => x.DurationSeconds > 0).GroupBy(x => new { x.Ship, x.DurationType }).Select(x => (x.Key.Ship, x.Key.DurationType, x.Count()))];
-                foreach(var ship in backup.ArtifactsDb.MissionInfos.Where(x => (int)x.Status > 5)) {
-                    var shipInfo = ShipsSent.FirstOrDefault(x => x.ship == ship.Ship && x.type == ship.DurationType);
-                    if(shipInfo != default) {
-                        shipInfo.count++;
-                        ShipsSent.RemoveAll(x => x.ship == ship.Ship && x.type == ship.DurationType);
-                        ShipsSent.Add(shipInfo);
-                    } else {
-                        ShipsSent.Add((ship.Ship, ship.DurationType, 1));
-                    }
-                }
+                ShipsSent = BuildShipsSent(backup.ArtifactsDb);
             }
 
+            ArtifactHall = BuildArtifactHall(backup.ArtifactsDb);
 
-
-            NumDailyGiftsCollected = backup.Game.NumDailyGiftsCollected;
-
-            EggMedalLevel = [.. backup.Game.EggMedalLevel];
-
-            ArtifactHall = [.. backup.ArtifactsDb.InventoryItems.Select(x => {
-                var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
-                if(artifact is not null) {
-                    artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
-                }
-                var artifactStatus = backup.ArtifactsDb.ArtifactStatus.FirstOrDefault(a =>
-                    a.Spec.Name == x.Artifact.Spec.Name &&
-                    a.Spec.Level == x.Artifact.Spec.Level &&
-                    a.Spec.Rarity == x.Artifact.Spec.Rarity
-                );
-                return new ArtifactCount { Count = (int)x.Quantity, Artifact = artifact, NumberCrafted = artifactStatus?.Count ?? 0 };
-            })];
-
-            var afxSetsProjected = backup.ArtifactsDb.SavedArtifactSets.Select(s =>
-                s.Slots.Select(sl => {
-                    var x = backup.ArtifactsDb.InventoryItems.FirstOrDefault(item => item.ItemId == sl.ItemId);
-                    if(x is null) return null;
-                    var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
-                    if(artifact is null) return null;
-                    artifact.Stones = [.. x.Artifact.Stones.Select(EggIncArtifacts.GetArtifact).Where(y => y != null)];
-                    return artifact;
-                })
-            );
-            ArtifactSets = Helpers.AfxSets.AfxSetsBuilder.BuildSetsPreservingEmpty(afxSetsProjected);
-
-            ArtifactHall.AddRange(backup.ArtifactsDb.ArtifactStatus.Where(a =>
-                !backup.ArtifactsDb.InventoryItems.Any(x => a.Spec.Name == x.Artifact.Spec.Name &&
-                    a.Spec.Level == x.Artifact.Spec.Level &&
-                    a.Spec.Rarity == x.Artifact.Spec.Rarity
-                )
-            ).Select(a => new ArtifactCount { Count = 0, Artifact = EggIncArtifacts.GetArtifact(a.Spec), NumberCrafted = a.Count }));
+            ArtifactSets = BuildArtifactSets(backup.ArtifactsDb);
         }
 
         private void SetSubscriptionInfo(Ei.Backup backup) {
@@ -421,48 +442,21 @@ namespace EGG9000.Common.Database {
                 ?? backup.Contracts.Archive.Where(x => x != null).FirstOrDefault(x => x.ContractIdentifier == farm.ContractId);
 
             var customFarm = new CustomFarm {
-                FarmType = farm.FarmType,
-                ContractId = farm.ContractId,
-                EggsPaidFor = farm.EggsPaidFor,
-                League = contract?.League,
-                CoopId = contract?.CoopIdentifier,
-                Cancelled = contract?.Cancelled ?? false,
+                SimulationBytes = StorageTrimmer.TrimmedBytes(farm),
+                LocalContractBytes = contract is null ? null : StorageTrimmer.TrimmedBytes(contract),
                 Completed = contract?.Contract != null && contract.NumGoalsAchieved == contract.Contract.GetGoals(contract).Count,
-                NumChickens = farm.NumChickens,
-                CommonResearch = [.. farm.CommonResearch.Select(x => new CustomResearch(x))],
-                EggType = farm.EggType,
                 Vehicles = [.. farm.Vehicles],
-                TrainLength = [.. farm.TrainLength],
-                SilosOwned = farm.SilosOwned,
-                TimeAccepted = (long)(contract?.TimeAccepted ?? 0),
                 CoopAllowed = contract?.Contract?.CoopAllowed ?? false,
-                CoopSharedEndTime = (long)(contract?.CoopSharedEndTime ?? 0),
-                BoostTokensReceived = (ushort)farm.BoostTokensReceived,
-                BoostTokensGiven = (ushort)farm.BoostTokensGiven,
-                BoostTokensSpent = (ushort)farm.BoostTokensSpent,
-                CashEarned = farm.CashEarned,
-                CashSpent = farm.CashSpent,
-                TimeCheatDebt = (long)farm.TimeCheatDebtDEP,
-                BoostsUsed = (ushort)(contract?.BoostsUsed ?? 0),
-                TimeCheatsDetected = (ushort)farm.TimeCheatsDetected,
-                Habs = [.. farm.Habs.Select(x => (ushort)x)],
-                LastStepTime = (float)farm.LastStepTime,
-                Grade = contract?.Grade ?? PlayerGrade.GradeUnset,
-                EvaluationCxp = (contract?.Evaluation == null ? 0.0 : (float)contract.Evaluation.Cxp),
-                ContributionFinalized = contract?.CoopContributionFinalized ?? false,
-                CoopSimulationEndTime = contract?.CoopSimulationEndTime ?? 0,
-                NumGoalsAchieved = (byte?)contract?.NumGoalsAchieved ?? (byte)0,
             };
 
 
-            var currentCoopStatus = backup.Contracts.CurrentCoopStatuses.Where(x => x.ContractIdentifier == farm.ContractId).FirstOrDefault();
+            var currentCoopStatus = backup.Contracts.CurrentCoopStatuses.FirstOrDefault(x => x.ContractIdentifier == farm.ContractId);
             if(currentCoopStatus != null)
                 customFarm.Creator = currentCoopStatus.CreatorId == backup.GetID();
 
             var uuids = backup.Contracts.CurrentCoopStatuses.Where(x => x.CoopIdentifier == contract?.CoopIdentifier).SelectMany(x => x.Contributors.Where(y => y.UserId == backup.EiUserId).Select(y => y.Uuid)).ToList();
 
             customFarm.ReportedUUIDs = uuids;
-
 
             customFarm.Artifacts = [];
             var farmIndex = backup.Farms.IndexOf(farm);
@@ -478,8 +472,6 @@ namespace EGG9000.Common.Database {
                 }
             }
 
-
-
             Farms.Add(customFarm);
         }
 
@@ -491,6 +483,91 @@ namespace EGG9000.Common.Database {
                 artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
                 return artifact;
             }).Where(x => x != null)];
+        }
+
+        private static SpaceMission ToSpaceMission(Ei.MissionInfo m) {
+            return new SpaceMission {
+                Ship = m.Ship,
+                Duration = m.DurationType,
+                Status = m.Status,
+                DurationSeconds = (long)m.DurationSeconds,
+                StartTime = (long)m.StartTimeDerived,
+                Fuels = [.. m.Fuel.Select(f => new SpaceMissionFuel {
+                    Amount = f.Amount,
+                    Egg = f.Egg
+                })],
+                Targeting = (int)m.Ship >= 4 ? m?.TargetArtifact ?? Name.Unknown : Name.Unknown,
+                Capacity = m.Capacity,
+                Stars = m.Level
+            };
+        }
+
+        private static Dictionary<Ei.Egg, double> BuildFuelAmounts(Ei.Backup.Types.Artifacts activeTankArtifacts) {
+            var fuelAmounts = new Dictionary<Ei.Egg, double>();
+            for(var i = 0; i < activeTankArtifacts.TankFuels.Count; i++) {
+                if(activeTankArtifacts.TankFuels[i] > 0)
+                    fuelAmounts.Add((Ei.Egg)(i + 1), activeTankArtifacts.TankFuels[i]);
+            }
+            return fuelAmounts;
+        }
+
+        private static List<(Spaceship ship, DurationType type, int count)> BuildShipsSent(Ei.ArtifactsDB artifactsDb) {
+            List<(Spaceship ship, DurationType type, int count)> shipsSent = [.. artifactsDb.MissionArchive.Where(x => x.DurationSeconds > 0).GroupBy(x => new { x.Ship, x.DurationType }).Select(x => (x.Key.Ship, x.Key.DurationType, x.Count()))];
+            foreach(var ship in artifactsDb.MissionInfos.Where(x => (int)x.Status > 5)) {
+                var shipInfo = shipsSent.FirstOrDefault(x => x.ship == ship.Ship && x.type == ship.DurationType);
+                if(shipInfo != default) {
+                    shipInfo.count++;
+                    shipsSent.RemoveAll(x => x.ship == ship.Ship && x.type == ship.DurationType);
+                    shipsSent.Add(shipInfo);
+                } else {
+                    shipsSent.Add((ship.Ship, ship.DurationType, 1));
+                }
+            }
+            return shipsSent;
+        }
+
+        private static List<ArtifactCount> BuildArtifactHall(Ei.ArtifactsDB artifactsDb) {
+            List<ArtifactCount> artifactHall = [.. artifactsDb.InventoryItems.Select(x => {
+                var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
+                if(artifact is not null) {
+                    artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
+                }
+                var artifactStatus = artifactsDb.ArtifactStatus.FirstOrDefault(a =>
+                    a.Spec.Name == x.Artifact.Spec.Name &&
+                    a.Spec.Level == x.Artifact.Spec.Level &&
+                    a.Spec.Rarity == x.Artifact.Spec.Rarity
+                );
+                return new ArtifactCount { Count = (int)x.Quantity, Artifact = artifact, NumberCrafted = artifactStatus?.Count ?? 0 };
+            })];
+
+            artifactHall.AddRange(artifactsDb.ArtifactStatus.Where(a =>
+                !artifactsDb.InventoryItems.Any(x => a.Spec.Name == x.Artifact.Spec.Name &&
+                    a.Spec.Level == x.Artifact.Spec.Level &&
+                    a.Spec.Rarity == x.Artifact.Spec.Rarity
+                )
+            ).Select(a => new ArtifactCount { Count = 0, Artifact = EggIncArtifacts.GetArtifact(a.Spec), NumberCrafted = a.Count }));
+
+            return artifactHall;
+        }
+
+        private static List<List<EggIncArtifactInstance>> BuildArtifactSets(Ei.ArtifactsDB artifactsDb) {
+            var afxSetsProjected = artifactsDb.SavedArtifactSets.Select(s =>
+                s.Slots.Select(sl => {
+                    var x = artifactsDb.InventoryItems.FirstOrDefault(item => item.ItemId == sl.ItemId);
+                    if(x is null) return null;
+                    var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
+                    if(artifact is null) return null;
+                    artifact.Stones = [.. x.Artifact.Stones.Select(EggIncArtifacts.GetArtifact).Where(y => y != null)];
+                    return artifact;
+                })
+            );
+            return Helpers.AfxSets.AfxSetsBuilder.BuildSetsPreservingEmpty(afxSetsProjected);
+        }
+
+        private static Ei.Backup.Types.Artifacts ResolveActiveTankArtifacts(Ei.Backup backup) {
+            var currentFarm = backup.Farms.ElementAtOrDefault((int)backup.Game.CurrentFarm);
+            var inVirtueDimension = currentFarm is not null && (int)currentFarm.EggType >= 50 && (int)currentFarm.EggType <= 54;
+            return inVirtueDimension && backup.Virtue?.Afx is not null ? backup.Virtue.Afx : backup.Artifacts;
         }
 
         private static void MergeMaxFarmSizes(Dictionary<string, ulong> target, Dictionary<string, ulong> source) {
@@ -571,58 +648,155 @@ namespace EGG9000.Common.Database {
         }
     }
 
+    public abstract class CustomFarmBase {
+        [IgnoreMember]
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
+        [System.Runtime.Serialization.IgnoreDataMember]
+        public Ei.LocalContract LocalContract {
+            get {
+                if(_localContract is null && LocalContractBytesStorage is { Length: > 0 })
+                    _localContract = Ei.LocalContract.Parser.ParseFrom(LocalContractBytesStorage);
+                return _localContract;
+            }
+        }
+        private Ei.LocalContract _localContract;
+
+        protected void InvalidateLocalContract() {
+            _localContract = null;
+        }
+
+        protected abstract byte[] LocalContractBytesStorage { get; }
+
+        protected abstract long TimeAcceptedUnix { get; }
+
+        [IgnoreMember]
+        public DateTimeOffset Started => DateTimeOffset.FromUnixTimeSeconds(TimeAcceptedUnix);
+    }
+
     [MessagePackObject]
-    public class CustomFarm {
+    public class CustomFarm : CustomFarmBase {
         [Key(0)]
-        public Ei.FarmType FarmType { get; set; }
+        public Ei.FarmType FarmType {
+            get => Simulation is { } s ? s.FarmType : field;
+            set;
+        }
         [Key(1)]
-        public string ContractId { get; set; }
+        public string ContractId {
+            get => Simulation is { } s ? s.ContractId : field;
+            set;
+        }
         [Key(2)]
-        public double EggsPaidFor { get; set; }
+        public double EggsPaidFor {
+            get => Simulation is { } s ? s.EggsPaidFor : field;
+            set;
+        }
         [Key(3)]
-        public uint? League { get; set; }
+        public uint? League {
+            get => LocalContract is { } l ? l.League : field;
+            set;
+        }
         [Key(4)]
-        public string CoopId { get; set; }
+        public string CoopId {
+            get => LocalContract is { } l ? l.CoopIdentifier : field;
+            set;
+        }
         [Key(5)]
-        public bool Cancelled { get; set; }
+        public bool Cancelled {
+            get => LocalContract is { } l ? l.Cancelled : field;
+            set;
+        }
         [Key(6)]
         public bool Completed { get; set; }
         [Key(7)]
-        public List<CustomResearch> CommonResearch { get; set; }
+        public List<CustomResearch> CommonResearch {
+            get => Simulation is { } s ? _commonResearch ??= [.. s.CommonResearch.Select(x => new CustomResearch(x))] : field;
+            set {
+                field = value;
+                _commonResearch = null;
+            }
+        }
+        private List<CustomResearch> _commonResearch;
         [Key(8)]
-        public ulong NumChickens { get; set; }
+        public ulong NumChickens {
+            get => Simulation is { } s ? s.NumChickens : field;
+            set;
+        }
         [Key(10)]
-        public Ei.Egg EggType { get; set; }
+        public Ei.Egg EggType {
+            get => Simulation is { } s ? s.EggType : field;
+            set;
+        }
         [Key(11)]
-        public List<uint> TrainLength { get; set; }
+        public List<uint> TrainLength {
+            get => Simulation is { } s ? _trainLength ??= [.. s.TrainLength] : field;
+            set {
+                field = value;
+                _trainLength = null;
+            }
+        }
+        private List<uint> _trainLength;
         [Key(12)]
         public List<uint> Vehicles;
         [Key(13)]
         public List<EggIncArtifactInstance> Artifacts { get; set; }
         [Key(14)]
-        public uint SilosOwned { get; set; }
+        public uint SilosOwned {
+            get => Simulation is { } s ? s.SilosOwned : field;
+            set;
+        }
         [Key(15)]
-        public long TimeAccepted { get; set; }
+        public long TimeAccepted {
+            get => LocalContract is { } l ? (long)l.TimeAccepted : field;
+            set;
+        }
         [Key(16)]
         public bool CoopAllowed { get; set; }
         [Key(17)]
-        public long CoopSharedEndTime { get; set; }
+        public long CoopSharedEndTime {
+            get => LocalContract is { } l ? (long)l.CoopSharedEndTime : field;
+            set;
+        }
         [Key(18)]
-        public ushort BoostTokensReceived { get; set; }
+        public ushort BoostTokensReceived {
+            get => Simulation is { } s ? (ushort)s.BoostTokensReceived : field;
+            set;
+        }
         [Key(19)]
-        public ushort BoostTokensGiven { get; set; }
+        public ushort BoostTokensGiven {
+            get => Simulation is { } s ? (ushort)s.BoostTokensGiven : field;
+            set;
+        }
         [Key(20)]
-        public ushort BoostTokensSpent { get; set; }
+        public ushort BoostTokensSpent {
+            get => Simulation is { } s ? (ushort)s.BoostTokensSpent : field;
+            set;
+        }
         [Key(21)]
-        public double CashEarned { get; set; }
+        public double CashEarned {
+            get => Simulation is { } s ? s.CashEarned : field;
+            set;
+        }
         [Key(22)]
-        public double CashSpent { get; set; }
+        public double CashSpent {
+            get => Simulation is { } s ? s.CashSpent : field;
+            set;
+        }
         [Key(23)]
-        public long TimeCheatDebt { get; set; }
+        public long TimeCheatDebt {
+            get => Simulation is { } s ? (long)s.TimeCheatDebtDEP : field;
+            set;
+        }
         [Key(24)]
-        public ushort BoostsUsed { get; set; }
+        public ushort BoostsUsed {
+            get => LocalContract is { } l ? (ushort)l.BoostsUsed : field;
+            set;
+        }
         [Key(25)]
-        public ushort TimeCheatsDetected { get; set; }
+        public ushort TimeCheatsDetected {
+            get => Simulation is { } s ? (ushort)s.TimeCheatsDetected : field;
+            set;
+        }
         //[Key(26)]
         //public Double CurrentShippingRate { get; set; }
         //[Key(27)]
@@ -636,26 +810,85 @@ namespace EGG9000.Common.Database {
         //[Key(31)]
         //public Double MaxRunningBonus { get; set; }
         [Key(32)]
-        public List<ushort> Habs { get; set; }
+        public List<ushort> Habs {
+            get => Simulation is { } s ? _habs ??= [.. s.Habs.Select(x => (ushort)x)] : field;
+            set {
+                field = value;
+                _habs = null;
+            }
+        }
+        private List<ushort> _habs;
         [Key(33)]
-        public float LastStepTime { get; set; }
+        public float LastStepTime {
+            get => Simulation is { } s ? (float)s.LastStepTime : field;
+            set;
+        }
         [Key(34)]
         public List<string> ReportedUUIDs { get; set; }
         [Key(35)]
-        public PlayerGrade Grade { get; set; }
+        public PlayerGrade Grade {
+            get => LocalContract is { } l ? l.Grade : field;
+            set;
+        }
         [Key(36)]
-        public double EvaluationCxp { get; set; }
+        public double EvaluationCxp {
+            get => LocalContract is { } l ? (l.Evaluation is { } e ? (float)e.Cxp : 0.0) : field;
+            set;
+        }
         [Key(37)]
-        public bool ContributionFinalized { get; set; }
+        public bool ContributionFinalized {
+            get => LocalContract is { } l ? l.CoopContributionFinalized : field;
+            set;
+        }
         [Key(38)]
-        public double CoopSimulationEndTime { get; set; }
+        public double CoopSimulationEndTime {
+            get => LocalContract is { } l ? l.CoopSimulationEndTime : field;
+            set;
+        }
         [Key(39)]
-        public byte NumGoalsAchieved { get; set; }
+        public byte NumGoalsAchieved {
+            get => LocalContract is { } l ? (byte)l.NumGoalsAchieved : field;
+            set;
+        }
         [Key(40)]
         public bool Creator { get; set; }
+        [Key(41)]
+        public byte[] SimulationBytes {
+            get;
+            set {
+                field = value;
+                _simulation = null;
+                _commonResearch = null;
+                _trainLength = null;
+                _habs = null;
+            }
+        }
 
         [IgnoreMember]
-        public DateTimeOffset Started { get { return DateTimeOffset.FromUnixTimeSeconds((long)TimeAccepted); } }
+        [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
+        [System.Runtime.Serialization.IgnoreDataMember]
+        public Ei.Backup.Types.Simulation Simulation {
+            get {
+                if(_simulation is null && SimulationBytes is { Length: > 0 })
+                    _simulation = Ei.Backup.Types.Simulation.Parser.ParseFrom(SimulationBytes);
+                return _simulation;
+            }
+        }
+        private Ei.Backup.Types.Simulation _simulation;
+
+        [Key(42)]
+        public byte[] LocalContractBytes {
+            get;
+            set {
+                field = value;
+                InvalidateLocalContract();
+            }
+        }
+
+        protected override byte[] LocalContractBytesStorage => LocalContractBytes;
+
+        protected override long TimeAcceptedUnix => TimeAccepted;
 
         public class Colleggtible {
             public GameDimension Dimension { get; set; }
@@ -729,57 +962,86 @@ namespace EGG9000.Common.Database {
     }
 
     [MessagePackObject]
-    public class CustomArchivedFarms {
+    public class CustomArchivedFarms : CustomFarmBase {
         [Key(0)]
-        public string CoopId { get; set; }
+        public string CoopId {
+            get => LocalContract is { } l ? l.CoopIdentifier : field;
+            set;
+        }
         [Key(1)]
-        public string ContractId { get; set; }
+        public string ContractId {
+            get => LocalContract is { } l && l.HasContractIdentifier ? l.ContractIdentifier : field;
+            set;
+        }
         [Key(2)]
-        public float TimeAccepted { get; set; }
+        public float TimeAccepted {
+            get => LocalContract is { } l ? (float)l.TimeAccepted : field;
+            set;
+        }
         [Key(3)]
         public bool Completed { get; set; }
         [Key(4)]
-        public byte? League { get; set; }
+        public byte? League {
+            get => LocalContract is { } l ? (byte?)l.League : field;
+            set;
+        }
         [Key(5)]
         public byte PEPossible { get; set; }
         [Key(6)]
         public byte PEGained { get; set; }
         [Key(7)]
-        public float ContributionAmount { get; set; }
+        public float ContributionAmount {
+            get => LocalContract is { } l ? (float)l.CoopLastUploadedContribution : field;
+            set;
+        }
         [Key(8)]
-        public PlayerGrade Grade { get; set; }
+        public PlayerGrade Grade {
+            get => LocalContract is { } l ? l.Grade : field;
+            set;
+        }
         [Key(9)]
-        public float EvaluationCxp { get; set; }
+        public float EvaluationCxp {
+            get => LocalContract is { } l ? (l.Evaluation is { } e ? (float)e.Cxp : 0f) : field;
+            set;
+        }
         [Key(10)]
-        public byte NumGoalsAchieved { get; set; }
+        public byte NumGoalsAchieved {
+            get => LocalContract is { } l ? (byte)l.NumGoalsAchieved : field;
+            set;
+        }
         [Key(11)]
-        public List<string> ReportedUUIDs { get; set; }
+        public List<string> ReportedUUIDs {
+            get => LocalContract is { } l ? _reportedUUIDs ??= [.. l.ReportedUuids] : field;
+            set {
+                field = value;
+                _reportedUUIDs = null;
+            }
+        }
+        private List<string> _reportedUUIDs;
+        [Key(12)]
+        public byte[] LocalContractBytes {
+            get;
+            set {
+                field = value;
+                InvalidateLocalContract();
+                _reportedUUIDs = null;
+            }
+        }
 
-        [IgnoreMember]
-        public DateTimeOffset Started { get { return DateTimeOffset.FromUnixTimeSeconds((long)TimeAccepted); } }
+        protected override byte[] LocalContractBytesStorage => LocalContractBytes;
+
+        protected override long TimeAcceptedUnix => (long)TimeAccepted;
 
         public CustomArchivedFarms() { }
         public CustomArchivedFarms(Ei.LocalContract localContract) {
-            CoopId = localContract.CoopIdentifier;
-            ContractId = localContract.Contract.Identifier;
-            TimeAccepted = (float)localContract.TimeAccepted;
-            Completed = localContract.Completed;
-            League = (byte)localContract.League;
-            ContributionAmount = (float)localContract.CoopLastUploadedContribution;
-            Grade = localContract.Grade;
-
-            if(localContract.Evaluation != null) {
-                EvaluationCxp = ((float?)localContract?.Evaluation?.Cxp) ?? 0.0f;
+            ContractId = localContract.Contract?.Identifier;
+            var goals = localContract.Contract is not null ? localContract.Contract.GetGoals(localContract) : null;
+            Completed = localContract.Contract is not null && localContract.NumGoalsAchieved == goals.Count;
+            if(goals is not null) {
+                PEPossible = (byte)goals.Where(x => x.RewardType == Ei.RewardType.EggsOfProphecy).Sum(x => x.RewardAmount);
+                PEGained = (byte)goals.Where(x => x.RewardType == Ei.RewardType.EggsOfProphecy && goals.IndexOf(x) < localContract.NumGoalsAchieved).Sum(x => x.RewardAmount);
             }
-            var goals = localContract.Contract.Goals;
-            if(localContract.Contract.GoalSets is not null && localContract.Contract.GoalSets.Count > localContract.League)
-                goals = localContract.Contract.GoalSets[(int)localContract.League].Goals;
-            if(localContract.Contract.GradeSpecs is not null && localContract.Contract.GradeSpecs.Count > 0 && localContract.Grade > 0)
-                goals = localContract.Contract.GradeSpecs[(int)localContract.Grade - 1].Goals;
-            PEPossible += (byte)goals.Where(x => x.RewardType == Ei.RewardType.EggsOfProphecy).Sum(x => x.RewardAmount);
-            PEGained += (byte)goals.Where(x => x.RewardType == Ei.RewardType.EggsOfProphecy && goals.IndexOf(x) < localContract.NumGoalsAchieved).Sum(x => x.RewardAmount);
-            NumGoalsAchieved = (byte)localContract.NumGoalsAchieved;
-            ReportedUUIDs = [.. localContract.ReportedUuids];
+            LocalContractBytes = StorageTrimmer.TrimmedBytes(localContract);
         }
     }
 

--- a/EGG9000.Common/Database/DerivedSlotFormatter.cs
+++ b/EGG9000.Common/Database/DerivedSlotFormatter.cs
@@ -1,0 +1,158 @@
+using MessagePack;
+using MessagePack.Formatters;
+using MessagePack.Resolvers;
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace EGG9000.Common.Database {
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class DerivedSlotAttribute(string gate) : Attribute {
+        public string Gate { get; } = gate;
+    }
+
+    public sealed class DerivedSlotFormatter<T>(int initialBufferSize = 4096) : IMessagePackFormatter<T> where T : class {
+        private readonly int _initialBufferSize = initialBufferSize;
+
+        private enum SlotDefault {
+            Nil,
+            Zero,
+            False
+        }
+
+        private sealed class DerivedSlot {
+            public int GateIndex { get; init; }
+            public SlotDefault Default { get; init; }
+        }
+
+        private static readonly IMessagePackFormatter<T> Inner = StandardResolver.Instance.GetFormatterWithVerify<T>();
+        private static readonly Func<T, byte[]>[] Gates;
+        private static readonly DerivedSlot[] Plan;
+
+        static DerivedSlotFormatter() {
+            (Gates, Plan) = BuildPlan();
+        }
+
+        public void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options) {
+            if(value is null) {
+                writer.WriteNil();
+                return;
+            }
+
+            var buffer = new ArrayBufferWriter<byte>(_initialBufferSize);
+            var inner = writer.Clone(buffer);
+            Inner.Serialize(ref inner, value, options);
+            inner.Flush();
+
+            if(Plan.Length == 0) {
+                writer.WriteRaw(buffer.WrittenSpan);
+                return;
+            }
+
+            var present = new bool[Gates.Length];
+            var anyPresent = false;
+            for(var g = 0; g < Gates.Length; g++) {
+                present[g] = Gates[g](value) is { Length: > 0 };
+                anyPresent |= present[g];
+            }
+
+            var reader = new MessagePackReader(buffer.WrittenMemory);
+            if(!anyPresent || reader.NextMessagePackType != MessagePackType.Array) {
+                writer.WriteRaw(buffer.WrittenSpan);
+                return;
+            }
+
+            var count = reader.ReadArrayHeader();
+            writer.WriteArrayHeader(count);
+            for(var i = 0; i < count; i++) {
+                if(i < Plan.Length && Plan[i] is { } slot && present[slot.GateIndex]) {
+                    reader.Skip();
+                    WriteDefault(ref writer, slot.Default);
+                    continue;
+                }
+                writer.WriteRaw(reader.ReadRaw());
+            }
+        }
+
+        public T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options) {
+            return Inner.Deserialize(ref reader, options);
+        }
+
+        private static void WriteDefault(ref MessagePackWriter writer, SlotDefault slotDefault) {
+            switch(slotDefault) {
+                case SlotDefault.False:
+                    writer.Write(false);
+                    break;
+                case SlotDefault.Zero:
+                    writer.Write(0);
+                    break;
+                default:
+                    writer.WriteNil();
+                    break;
+            }
+        }
+
+        private static (Func<T, byte[]>[] Gates, DerivedSlot[] Plan) BuildPlan() {
+            var gates = new List<string>();
+            var found = new List<(int Index, DerivedSlot Slot)>();
+            foreach(var property in typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+                if(property.GetCustomAttribute<DerivedSlotAttribute>() is not { } derived)
+                    continue;
+                if(property.GetCustomAttribute<KeyAttribute>()?.IntKey is not { } index)
+                    throw new InvalidOperationException($"[DerivedSlot] on {typeof(T).FullName}.{property.Name} requires an int [Key].");
+                var gateIndex = gates.IndexOf(derived.Gate);
+                if(gateIndex < 0) {
+                    gates.Add(derived.Gate);
+                    gateIndex = gates.Count - 1;
+                }
+                found.Add((index, new DerivedSlot { GateIndex = gateIndex, Default = Classify(property) }));
+            }
+
+            if(found.Count == 0)
+                return ([], []);
+
+            var plan = new DerivedSlot[found.Max(x => x.Index) + 1];
+            foreach(var (index, slot) in found)
+                plan[index] = slot;
+            return ([.. gates.Select(BuildGate)], plan);
+        }
+
+        private static Func<T, byte[]> BuildGate(string name) {
+            var gate = typeof(T).GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+            if(gate is null || gate.PropertyType != typeof(byte[]))
+                throw new InvalidOperationException($"[DerivedSlot] gate '{name}' on {typeof(T).FullName} must name a public byte[] property.");
+            var parameter = Expression.Parameter(typeof(T), "value");
+            return Expression.Lambda<Func<T, byte[]>>(Expression.Property(parameter, gate), parameter).Compile();
+        }
+
+        private static SlotDefault Classify(PropertyInfo property) {
+            var type = property.PropertyType;
+            if(type == typeof(bool))
+                return SlotDefault.False;
+            if(type.IsEnum)
+                return SlotDefault.Zero;
+            if(!type.IsValueType || Nullable.GetUnderlyingType(type) is not null)
+                return SlotDefault.Nil;
+            return Type.GetTypeCode(type) switch {
+                TypeCode.Byte or TypeCode.SByte or TypeCode.Int16 or TypeCode.UInt16 or TypeCode.Int32 or TypeCode.UInt32
+                    or TypeCode.Int64 or TypeCode.UInt64 or TypeCode.Single or TypeCode.Double => SlotDefault.Zero,
+                _ => throw new InvalidOperationException($"[DerivedSlot] on {typeof(T).FullName}.{property.Name} has no suppressed default for {type.FullName}.")
+            };
+        }
+    }
+
+    public static class StorageMessagePack {
+        public static readonly MessagePackSerializerOptions Options = MessagePackSerializerOptions.Standard
+            .WithCompression(MessagePackCompression.Lz4BlockArray)
+            .WithResolver(CompositeResolver.Create(
+                new IMessagePackFormatter[] {
+                    new DerivedSlotFormatter<CustomBackup>(65536),
+                    new DerivedSlotFormatter<CustomFarm>()
+                },
+                new IFormatterResolver[] { StandardResolver.Instance }));
+    }
+}

--- a/EGG9000.Common/Database/DerivedSlotFormatter.cs
+++ b/EGG9000.Common/Database/DerivedSlotFormatter.cs
@@ -43,6 +43,13 @@ namespace EGG9000.Common.Database {
                 return;
             }
 
+            var present = new bool[Gates.Length];
+            var anyPresent = false;
+            for(var g = 0; g < Gates.Length; g++) {
+                present[g] = Gates[g](value) is { Length: > 0 };
+                anyPresent |= present[g];
+            }
+
             var buffer = new ArrayBufferWriter<byte>(_initialBufferSize);
             var inner = writer.Clone(buffer);
             Inner.Serialize(ref inner, value, options);
@@ -51,13 +58,6 @@ namespace EGG9000.Common.Database {
             if(Plan.Length == 0) {
                 writer.WriteRaw(buffer.WrittenSpan);
                 return;
-            }
-
-            var present = new bool[Gates.Length];
-            var anyPresent = false;
-            for(var g = 0; g < Gates.Length; g++) {
-                present[g] = Gates[g](value) is { Length: > 0 };
-                anyPresent |= present[g];
             }
 
             var reader = new MessagePackReader(buffer.WrittenMemory);

--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -20,7 +20,7 @@ namespace EGG9000.Common.Database.Entities {
     [Index(nameof(LastBackupCheck))]
     public class DBUser : ILastModified {
         [NotMapped]
-        public static readonly MessagePackSerializerOptions lz4Options = MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+        public static readonly MessagePackSerializerOptions lz4Options = StorageMessagePack.Options;
 
         public Guid Id { get; set; }
         public DateTimeOffset LastModified { get; set; } = DateTimeOffset.UtcNow;

--- a/EGG9000.Common/Helpers/BackupProjections.cs
+++ b/EGG9000.Common/Helpers/BackupProjections.cs
@@ -1,0 +1,130 @@
+using EGG9000.Common.Database;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using static Ei.ArtifactSpec.Types;
+using static Ei.MissionInfo.Types;
+
+namespace EGG9000.Common.Helpers {
+    public static class BackupProjections {
+        public static Dictionary<Ei.Egg, ulong> BuildMaxFarmSizeReached(Ei.Backup.Types.Game game) {
+            var sizes = new Dictionary<Ei.Egg, ulong>();
+            for(var i = 0; i < game.MaxFarmSizeReached.Count; i++) {
+                if(game.MaxFarmSizeReached[i] > 0)
+                    sizes.Add((Ei.Egg)(i + 1), game.MaxFarmSizeReached[i]);
+            }
+            return sizes;
+        }
+
+        public static List<EggIncArtifactInstance> ResolveActiveArtifacts(IEnumerable<Ei.ArtifactInventoryItem> activeArtifacts) {
+            return [.. activeArtifacts.Where(x => x != null).Select(x => {
+                var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
+                if(artifact == null)
+                    return null;
+                artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
+                return artifact;
+            }).Where(x => x != null)];
+        }
+
+        public static SpaceMission ToSpaceMission(Ei.MissionInfo m) {
+            return new SpaceMission {
+                Ship = m.Ship,
+                Duration = m.DurationType,
+                Status = m.Status,
+                DurationSeconds = (long)m.DurationSeconds,
+                StartTime = (long)m.StartTimeDerived,
+                Fuels = [.. m.Fuel.Select(f => new SpaceMissionFuel {
+                    Amount = f.Amount,
+                    Egg = f.Egg
+                })],
+                Targeting = (int)m.Ship >= 4 ? m?.TargetArtifact ?? Name.Unknown : Name.Unknown,
+                Capacity = m.Capacity,
+                Stars = m.Level
+            };
+        }
+
+        public static Dictionary<Ei.Egg, double> BuildFuelAmounts(Ei.Backup.Types.Artifacts activeTankArtifacts) {
+            var fuelAmounts = new Dictionary<Ei.Egg, double>();
+            for(var i = 0; i < activeTankArtifacts.TankFuels.Count; i++) {
+                if(activeTankArtifacts.TankFuels[i] > 0)
+                    fuelAmounts.Add((Ei.Egg)(i + 1), activeTankArtifacts.TankFuels[i]);
+            }
+            return fuelAmounts;
+        }
+
+        public static List<(Spaceship ship, DurationType type, int count)> BuildShipsSent(Ei.ArtifactsDB artifactsDb) {
+            List<(Spaceship ship, DurationType type, int count)> shipsSent = [.. artifactsDb.MissionArchive.Where(x => x.DurationSeconds > 0).GroupBy(x => new { x.Ship, x.DurationType }).Select(x => (x.Key.Ship, x.Key.DurationType, x.Count()))];
+            foreach(var ship in artifactsDb.MissionInfos.Where(x => (int)x.Status > 5)) {
+                var shipInfo = shipsSent.FirstOrDefault(x => x.ship == ship.Ship && x.type == ship.DurationType);
+                if(shipInfo != default) {
+                    shipInfo.count++;
+                    shipsSent.RemoveAll(x => x.ship == ship.Ship && x.type == ship.DurationType);
+                    shipsSent.Add(shipInfo);
+                } else {
+                    shipsSent.Add((ship.Ship, ship.DurationType, 1));
+                }
+            }
+            return shipsSent;
+        }
+
+        public static List<ArtifactCount> BuildArtifactHall(Ei.ArtifactsDB artifactsDb) {
+            List<ArtifactCount> artifactHall = [.. artifactsDb.InventoryItems.Select(x => {
+                var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
+                if(artifact is not null) {
+                    artifact.Stones = [.. x.Artifact.Stones.Select(y => EggIncArtifacts.GetArtifact(y)).Where(y => y != null)];
+                }
+                var artifactStatus = artifactsDb.ArtifactStatus.FirstOrDefault(a =>
+                    a.Spec.Name == x.Artifact.Spec.Name &&
+                    a.Spec.Level == x.Artifact.Spec.Level &&
+                    a.Spec.Rarity == x.Artifact.Spec.Rarity
+                );
+                return new ArtifactCount { Count = (int)x.Quantity, Artifact = artifact, NumberCrafted = artifactStatus?.Count ?? 0 };
+            })];
+
+            artifactHall.AddRange(artifactsDb.ArtifactStatus.Where(a =>
+                !artifactsDb.InventoryItems.Any(x => a.Spec.Name == x.Artifact.Spec.Name &&
+                    a.Spec.Level == x.Artifact.Spec.Level &&
+                    a.Spec.Rarity == x.Artifact.Spec.Rarity
+                )
+            ).Select(a => new ArtifactCount { Count = 0, Artifact = EggIncArtifacts.GetArtifact(a.Spec), NumberCrafted = a.Count }));
+
+            return artifactHall;
+        }
+
+        public static List<List<EggIncArtifactInstance>> BuildArtifactSets(Ei.ArtifactsDB artifactsDb) {
+            var afxSetsProjected = artifactsDb.SavedArtifactSets.Select(s =>
+                s.Slots.Select(sl => {
+                    var x = artifactsDb.InventoryItems.FirstOrDefault(item => item.ItemId == sl.ItemId);
+                    if(x is null) return null;
+                    var artifact = EggIncArtifacts.GetArtifact(x.Artifact.Spec);
+                    if(artifact is null) return null;
+                    artifact.Stones = [.. x.Artifact.Stones.Select(EggIncArtifacts.GetArtifact).Where(y => y != null)];
+                    return artifact;
+                })
+            );
+            return Helpers.AfxSets.AfxSetsBuilder.BuildSetsPreservingEmpty(afxSetsProjected);
+        }
+
+        public static Ei.Backup.Types.Artifacts ResolveActiveTankArtifacts(Ei.Backup backup) {
+            var currentFarm = backup.Farms.ElementAtOrDefault((int)backup.Game.CurrentFarm);
+            var inVirtueDimension = currentFarm is not null && (int)currentFarm.EggType >= 50 && (int)currentFarm.EggType <= 54;
+            return inVirtueDimension && backup.Virtue?.Afx is not null ? backup.Virtue.Afx : backup.Artifacts;
+        }
+
+        public static void MergeMaxFarmSizes(Dictionary<string, ulong> target, Dictionary<string, ulong> source) {
+            foreach(var kvp in source)
+                if(!target.TryGetValue(kvp.Key, out var existing) || kvp.Value > existing)
+                    target[kvp.Key] = kvp.Value;
+        }
+
+        public static void MergeMaxFarmSizes(Dictionary<string, ulong> target, IEnumerable<Ei.LocalContract> farms, FrozenSet<Ei.Contract> contracts) {
+            var eggIdByContractId = contracts
+                .Where(c => c.Egg == Ei.Egg.CustomEgg && !string.IsNullOrEmpty(c.CustomEggId))
+                .ToDictionary(c => c.Identifier, c => c.CustomEggId.ToLower());
+            MergeMaxFarmSizes(target,
+                farms.Where(f => f.MaxFarmSizeReached > 0 && eggIdByContractId.ContainsKey(f.ContractIdentifier))
+                     .GroupBy(f => eggIdByContractId[f.ContractIdentifier])
+                     .ToDictionary(g => g.Key, g => (ulong)g.Max(f => f.MaxFarmSizeReached)));
+        }
+    }
+}

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -123,19 +123,6 @@ namespace Ei {
         }
 
         public partial class Types {
-            [NotStored(nameof(Afx))]
-            public partial class Virtue {
-            }
-
-            [NotStored(
-                nameof(HabPopulation), nameof(HabPopulationIndound), nameof(HabIncubatorPopuplation),
-                nameof(ActiveBoosts), nameof(HatcheryPopulation), nameof(EggsLaid), nameof(EggsShipped),
-                nameof(UnclaimedCash), nameof(NumChickensUnsettled), nameof(NumChickensRunning),
-                nameof(LastCashBoostTime), nameof(UnclaimedBoostTokens), nameof(GametimeUntilNextBoostToken),
-                nameof(TotalStepTime))]
-            public partial class Simulation {
-            }
-
             [NotStored(nameof(News), nameof(Achievements), nameof(Boosts))]
             public partial class Game {
                 public double SoulEggsTotal { get { return SoulEggsD == 0 ? SoulEggs : SoulEggsD; } }

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -113,7 +113,8 @@ namespace Ei {
         nameof(Farms), nameof(Contracts), nameof(ArtifactsDb), nameof(ShellDb), nameof(Tutorial),
         nameof(Misc), nameof(Shells), nameof(Mission), nameof(MailState), nameof(Sim),
         nameof(ReadMailIds), nameof(GameServicesId), nameof(GameServicesIdScoped), nameof(PushUserId),
-        nameof(ApproxTime), nameof(ForceOfferBackup), nameof(ForceBackup), nameof(Checksum), nameof(Signature))]
+        nameof(ApproxTime), nameof(ForceOfferBackup), nameof(ForceBackup), nameof(Checksum), nameof(Signature),
+        nameof(SubInfo))]
     public partial class Backup {
         public string GetID() {
             if(!string.IsNullOrEmpty(EiUserId)) {
@@ -142,10 +143,25 @@ namespace Ei {
             public partial class Virtue { }
 
             [NotStored(
+                nameof(EggTotalsOLD), nameof(EggTotals), nameof(UnlimitedChickensUses), nameof(RefillUses),
+                nameof(Warp1Uses), nameof(Warp8Uses), nameof(BoostsUsed), nameof(VideoDoublerUses),
+                nameof(IapPacksPurchased), nameof(PiggyFull), nameof(PiggyFoundFull),
+                nameof(TimePiggyFilledRealtime), nameof(TimePiggyFullGametime), nameof(LostPiggyIncrements))]
+            public partial class Stats { }
+
+            [NotStored(
+                nameof(Infusing), nameof(ItemBeingInfused), nameof(SpecBeingInfused), nameof(EggTypeInfusing),
+                nameof(InfusingEggsRequired), nameof(EggsInfused), nameof(FlowPercentageArtifacts),
+                nameof(FuelingEnabled), nameof(TankFillingEnabled), nameof(TankLevel), nameof(TankFuels),
+                nameof(TankLimits), nameof(LastFueledShip), nameof(InventoryScore), nameof(Enabled),
+                nameof(IntroShown), nameof(InfusingEnabledDEPRECATED))]
+            public partial class Artifacts { }
+
+            [NotStored(
                 nameof(HabPopulation), nameof(HabPopulationIndound), nameof(HabIncubatorPopuplation), nameof(ActiveBoosts),
                 nameof(HatcheryPopulation), nameof(EggsLaid), nameof(EggsShipped), nameof(UnclaimedCash), nameof(NumChickensUnsettled),
                 nameof(NumChickensRunning), nameof(LastCashBoostTime), nameof(UnclaimedBoostTokens), nameof(GametimeUntilNextBoostToken),
-                nameof(TotalStepTime))]
+                nameof(TotalStepTime), nameof(Vehicles))]
             public partial class Simulation { }
         }
     }

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -137,6 +137,16 @@ namespace Ei {
                 }
 
             }
+
+            [NotStored(nameof(Afx))]
+            public partial class Virtue { }
+
+            [NotStored(
+                nameof(HabPopulation), nameof(HabPopulationIndound), nameof(HabIncubatorPopuplation), nameof(ActiveBoosts),
+                nameof(HatcheryPopulation), nameof(EggsLaid), nameof(EggsShipped), nameof(UnclaimedCash), nameof(NumChickensUnsettled),
+                nameof(NumChickensRunning), nameof(LastCashBoostTime), nameof(UnclaimedBoostTokens), nameof(GametimeUntilNextBoostToken),
+                nameof(TotalStepTime))]
+            public partial class Simulation { }
         }
     }
 

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using EGG9000.Common.Helpers;
+using EGG9000.Common.Proto;
 using Humanizer;
 using System;
 using System.Collections.Generic;
@@ -103,22 +104,17 @@ namespace Ei {
         }
     }
 
+    [NotStored(nameof(Contract))]
     public partial class LocalContract {
         public DateTimeOffset Started { get { return DateTimeOffset.FromUnixTimeSeconds((long)TimeAccepted); } }
-        public bool Completed {
-            get {
-                if(Contract == null) return false; // Rare corrupted byte
-                var targetGoals = Contract.GradeSpecs.Count > 0 && Grade != PlayerGrade.GradeUnset ?
-                    Contract.GradeSpecs[(int)(Grade - 1)].Goals.Count :
-                    (Contract.GoalSets.Any() ?
-                    Contract.GoalSets[0].Goals.Count : Contract.Goals.Count);
-                return NumGoalsAchieved == targetGoals;
-            }
-        }
     }
 
+    [NotStored(
+        nameof(Farms), nameof(Contracts), nameof(ArtifactsDb), nameof(ShellDb), nameof(Tutorial),
+        nameof(Misc), nameof(Shells), nameof(Mission), nameof(MailState), nameof(Sim),
+        nameof(ReadMailIds), nameof(GameServicesId), nameof(GameServicesIdScoped), nameof(PushUserId),
+        nameof(ApproxTime), nameof(ForceOfferBackup), nameof(ForceBackup), nameof(Checksum), nameof(Signature))]
     public partial class Backup {
-        public DateTime CacheAdded { get; set; }
         public string GetID() {
             if(!string.IsNullOrEmpty(EiUserId)) {
                 return EiUserId;
@@ -127,6 +123,20 @@ namespace Ei {
         }
 
         public partial class Types {
+            [NotStored(nameof(Afx))]
+            public partial class Virtue {
+            }
+
+            [NotStored(
+                nameof(HabPopulation), nameof(HabPopulationIndound), nameof(HabIncubatorPopuplation),
+                nameof(ActiveBoosts), nameof(HatcheryPopulation), nameof(EggsLaid), nameof(EggsShipped),
+                nameof(UnclaimedCash), nameof(NumChickensUnsettled), nameof(NumChickensRunning),
+                nameof(LastCashBoostTime), nameof(UnclaimedBoostTokens), nameof(GametimeUntilNextBoostToken),
+                nameof(TotalStepTime))]
+            public partial class Simulation {
+            }
+
+            [NotStored(nameof(News), nameof(Achievements), nameof(Boosts))]
             public partial class Game {
                 public double SoulEggsTotal { get { return SoulEggsD == 0 ? SoulEggs : SoulEggsD; } }
 

--- a/EGG9000.Common/Proto/NotStoredAttribute.cs
+++ b/EGG9000.Common/Proto/NotStoredAttribute.cs
@@ -59,9 +59,24 @@ namespace EGG9000.Common.Proto {
             }
 
             var clearedSet = cleared.ToHashSet();
+
+            foreach(var field in fields)
+                GuardRepeatedElement(descriptor, field, clearedSet);
+
             FieldDescriptor[] children = [.. fields.Where(x => x.FieldType == FieldType.Message && !x.IsRepeated && !x.IsMap && !clearedSet.Contains(x))];
 
             return new TrimPlan { Cleared = [.. cleared], Children = children };
+        }
+
+        private static void GuardRepeatedElement(MessageDescriptor descriptor, FieldDescriptor field, HashSet<FieldDescriptor> clearedSet) {
+            if(field.FieldType != FieldType.Message || (!field.IsRepeated && !field.IsMap) || clearedSet.Contains(field))
+                return;
+            var elementField = field.IsMap ? field.MessageType.Fields.InFieldNumberOrder()[1] : field;
+            if(elementField.FieldType != FieldType.Message)
+                return;
+            var element = elementField.MessageType;
+            if(element.ClrType?.GetCustomAttribute<NotStoredAttribute>(false) is not null)
+                throw new InvalidOperationException($"{descriptor.ClrType.FullName}.{field.PropertyName} is a repeated or map field whose element type {element.ClrType.FullName} carries [NotStored]; StorageTrimmer cannot trim inside repeated or map fields.");
         }
     }
 }

--- a/EGG9000.Common/Proto/NotStoredAttribute.cs
+++ b/EGG9000.Common/Proto/NotStoredAttribute.cs
@@ -1,0 +1,67 @@
+using Google.Protobuf;
+using Google.Protobuf.Reflection;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace EGG9000.Common.Proto {
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class NotStoredAttribute(params string[] fields) : Attribute {
+        public string[] Fields { get; } = fields;
+    }
+
+    public static class StorageTrimmer {
+        private sealed class TrimPlan {
+            public FieldDescriptor[] Cleared { get; init; }
+            public FieldDescriptor[] Children { get; init; }
+        }
+
+        private static readonly ConcurrentDictionary<Type, TrimPlan> Plans = new();
+
+        public static byte[] TrimmedBytes<T>(T message) where T : IMessage<T>, IDeepCloneable<T> {
+            ArgumentNullException.ThrowIfNull(message);
+            var clone = message.Clone();
+            Apply(clone);
+            return clone.ToByteArray();
+        }
+
+        private static void Apply(IMessage message) {
+            var descriptor = message.Descriptor;
+            var plan = Plans.GetOrAdd(descriptor.ClrType, _ => BuildPlan(descriptor));
+
+            foreach(var field in plan.Cleared)
+                field.Accessor.Clear(message);
+
+            foreach(var field in plan.Children) {
+                if(field.Accessor.GetValue(message) is IMessage child)
+                    Apply(child);
+            }
+        }
+
+        private static TrimPlan BuildPlan(MessageDescriptor descriptor) {
+            var fields = descriptor.Fields.InDeclarationOrder();
+            var attribute = descriptor.ClrType.GetCustomAttribute<NotStoredAttribute>(false);
+
+            var cleared = new List<FieldDescriptor>();
+            if(attribute is not null) {
+                var byProperty = fields.ToDictionary(x => x.PropertyName);
+                var unknown = new List<string>();
+                foreach(var name in attribute.Fields) {
+                    if(byProperty.TryGetValue(name, out var field))
+                        cleared.Add(field);
+                    else
+                        unknown.Add(name);
+                }
+                if(unknown.Count > 0)
+                    throw new ArgumentException($"[NotStored] on {descriptor.ClrType.FullName} names fields that do not exist: {string.Join(", ", unknown)}");
+            }
+
+            var clearedSet = cleared.ToHashSet();
+            FieldDescriptor[] children = [.. fields.Where(x => x.FieldType == FieldType.Message && !x.IsRepeated && !x.IsMap && !clearedSet.Contains(x))];
+
+            return new TrimPlan { Cleared = [.. cleared], Children = children };
+        }
+    }
+}

--- a/EGG9000.Test/CustomBackupParentDerivationTests.cs
+++ b/EGG9000.Test/CustomBackupParentDerivationTests.cs
@@ -300,7 +300,7 @@ namespace EGG9000.Test {
             Assert.IsTrue(backup.EmptyBackup);
             Assert.IsNull(backup.EiBackupBytes);
             Assert.IsNull(backup.Farms);
-            Assert.IsNull(backup.EggIncId);
+            Assert.AreEqual(string.Empty, backup.EggIncId);
             Assert.AreEqual((ushort)0, backup.PermitLevel);
             Assert.AreEqual(0d, backup.SoulEggs);
             Assert.AreEqual((byte)0, backup.ClientVersion);

--- a/EGG9000.Test/CustomBackupParentDerivationTests.cs
+++ b/EGG9000.Test/CustomBackupParentDerivationTests.cs
@@ -1,0 +1,354 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Proto;
+
+using Google.Protobuf;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Buffers;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class CustomBackupParentDerivationTests {
+        private static readonly MessagePackSerializerOptions Lz4 =
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+
+        private static readonly FrozenSet<Ei.Contract> EmptyContracts = new List<Ei.Contract>().ToFrozenSet();
+
+        private static Ei.Backup BuildBackup() {
+            var backup = new Ei.Backup {
+                UserId = "backup-user-1",
+                EiUserId = "EI0000000000012345",
+                UserName = "ProtoName",
+                DeviceId = "device-proto-1",
+                Version = 41,
+                Game = new Ei.Backup.Types.Game {
+                    PermitLevel = 3,
+                    EggsOfProphecy = 11,
+                    SoulEggsD = 5432.25,
+                    CurrentMultiplier = 1.75,
+                    NumDailyGiftsCollected = 12,
+                    GoldenEggsEarned = 500,
+                    GoldenEggsSpent = 200,
+                    PiggyBank = 33,
+                    HyperloopStation = true,
+                    MaxEggReached = Ei.Egg.Medical,
+                    EpicResearch = { new Ei.Backup.Types.ResearchItem { Id = "soul_eggs", Level = 8 } },
+                    EggMedalLevel = { 1u, 2u, 3u },
+                    MaxFarmSizeReached = { 10UL, 0UL, 20UL },
+                    News = { new Ei.Backup.Types.NewsHeadline() },
+                    Achievements = { new Ei.Backup.Types.AchievementInfo() },
+                    Boosts = { new Ei.Backup.Types.OwnedBoost() }
+                },
+                Settings = new Ei.Backup.Types.Settings { LastBackupTime = 1_700_000_500 },
+                Stats = new Ei.Backup.Types.Stats {
+                    NumPrestiges = 6,
+                    DroneTakedowns = 9,
+                    DroneTakedownsElite = 3,
+                    NumPiggyBreaks = 2
+                },
+                Artifacts = new Ei.Backup.Types.Artifacts { CraftingXp = 77.5 },
+                Virtue = new Ei.Backup.Types.Virtue {
+                    Resets = 5,
+                    ShiftCount = 9,
+                    EggsDelivered = { 1.5, 2.5 },
+                    EovEarned = { 4u, 6u },
+                    Afx = new Ei.Backup.Types.Artifacts { CraftingXp = 12.5 }
+                },
+                Contracts = new Ei.MyContracts(),
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+            backup.Farms.Add(new Ei.Backup.Types.Simulation { FarmType = Ei.FarmType.Empty });
+            return backup;
+        }
+
+        private static void AssertDerivedFromBuildBackup(CustomBackup backup) {
+            Assert.AreEqual("EI0000000000012345", backup.EggIncId);
+            Assert.AreEqual("ProtoName", backup.UserName);
+            Assert.AreEqual(1700000500L, backup.LastBackupTime);
+            Assert.AreEqual(1, backup.EpicResearch.Count);
+            Assert.AreEqual("soul_eggs", backup.EpicResearch[0].Id);
+            Assert.AreEqual(8u, backup.EpicResearch[0].Level);
+            Assert.AreEqual((ushort)3, backup.PermitLevel);
+            Assert.AreEqual((ushort)11, backup.EggsOfProphecy);
+            Assert.AreEqual(5432.25, backup.SoulEggs);
+            Assert.AreEqual(1.75, backup.CurrentMultiplier);
+            Assert.AreEqual(6UL, backup.NumPrestiges);
+            Assert.AreEqual(12u, backup.NumDailyGiftsCollected);
+            CollectionAssert.AreEqual(new List<uint> { 1u, 2u, 3u }, backup.EggMedalLevel);
+            Assert.AreEqual(500UL, backup.GoldenEggsEarned);
+            Assert.AreEqual(200UL, backup.GoldenEggsSpent);
+            Assert.AreEqual(33UL, backup.PiggyBank);
+            Assert.AreEqual(9UL, backup.DroneTakedowns);
+            Assert.AreEqual(3UL, backup.DroneTakedownsElite);
+            Assert.AreEqual(2UL, backup.NumPiggyBreaks);
+            Assert.IsTrue(backup.HyperloopPurchased);
+            Assert.AreEqual((byte)41, backup.ClientVersion);
+            Assert.AreEqual(Ei.Egg.Medical, backup.MaxEggReached);
+            Assert.AreEqual(10UL, backup.MaxFarmSizeReached[Ei.Egg.Edible]);
+            Assert.AreEqual(20UL, backup.MaxFarmSizeReached[Ei.Egg.Medical]);
+            Assert.IsFalse(backup.MaxFarmSizeReached.ContainsKey(Ei.Egg.Superfood));
+            Assert.IsTrue(backup.HasDeviceId);
+            Assert.AreEqual("device-proto-1", backup.DeviceId);
+            Assert.AreEqual(77.5, backup.CraftingXP);
+            CollectionAssert.AreEqual(new double[] { 1.5, 2.5 }, backup.VirtueEggsDelivered);
+            Assert.AreEqual(5u, backup.Resets);
+            Assert.AreEqual(9u, backup.ShiftCount);
+            CollectionAssert.AreEqual(new uint[] { 4u, 6u }, backup.EovEarned);
+            Assert.IsFalse(backup.NoAliasInLatestBackup);
+        }
+
+        [TestMethod]
+        public void BackCompat_ConvertedMembers_ReturnLegacyValues_WhenEiBackupBytesNull() {
+            var backup = new CustomBackup {
+                EggIncId = "EI-legacy-0001",
+                UserName = "LegacyName",
+                LastBackupTime = 1_650_000_000,
+                EpicResearch = [new CustomResearch { Id = "soul_eggs", Level = 4 }],
+                PermitLevel = 2,
+                EggsOfProphecy = 6,
+                SoulEggs = 999.5,
+                CurrentMultiplier = 1.2,
+                NumPrestiges = 3,
+                NumDailyGiftsCollected = 7,
+                EggMedalLevel = [9u, 8u],
+                GoldenEggsEarned = 44,
+                GoldenEggsSpent = 11,
+                PiggyBank = 5,
+                DroneTakedowns = 2,
+                DroneTakedownsElite = 1,
+                NumPiggyBreaks = 3,
+                HyperloopPurchased = true,
+                ClientVersion = 12,
+                MaxEggReached = Ei.Egg.Tachyon,
+                MaxFarmSizeReached = new Dictionary<Ei.Egg, ulong> { [Ei.Egg.Tachyon] = 55 },
+                HasDeviceId = true,
+                DeviceId = "legacy-device",
+                CraftingXP = 21.5,
+                VirtueEggsDelivered = [3.3, 4.4],
+                Resets = 8,
+                ShiftCount = 2,
+                EovEarned = [1u, 2u],
+                NoAliasInLatestBackup = true
+            };
+
+            var bytes = MessagePackSerializer.Serialize(backup, Lz4);
+            var back = MessagePackSerializer.Deserialize<CustomBackup>(bytes, Lz4);
+
+            Assert.IsNull(back.EiBackupBytes);
+            Assert.AreEqual("EI-legacy-0001", back.EggIncId);
+            Assert.AreEqual("LegacyName", back.UserName);
+            Assert.AreEqual(1_650_000_000L, back.LastBackupTime);
+            Assert.AreEqual(1, back.EpicResearch.Count);
+            Assert.AreEqual("soul_eggs", back.EpicResearch[0].Id);
+            Assert.AreEqual((ushort)2, back.PermitLevel);
+            Assert.AreEqual((ushort)6, back.EggsOfProphecy);
+            Assert.AreEqual(999.5, back.SoulEggs);
+            Assert.AreEqual(1.2, back.CurrentMultiplier);
+            Assert.AreEqual(3UL, back.NumPrestiges);
+            Assert.AreEqual(7u, back.NumDailyGiftsCollected);
+            CollectionAssert.AreEqual(new List<uint> { 9u, 8u }, back.EggMedalLevel);
+            Assert.AreEqual(44UL, back.GoldenEggsEarned);
+            Assert.AreEqual(11UL, back.GoldenEggsSpent);
+            Assert.AreEqual(5UL, back.PiggyBank);
+            Assert.AreEqual(2UL, back.DroneTakedowns);
+            Assert.AreEqual(1UL, back.DroneTakedownsElite);
+            Assert.AreEqual(3UL, back.NumPiggyBreaks);
+            Assert.IsTrue(back.HyperloopPurchased);
+            Assert.AreEqual((byte)12, back.ClientVersion);
+            Assert.AreEqual(Ei.Egg.Tachyon, back.MaxEggReached);
+            Assert.AreEqual(55UL, back.MaxFarmSizeReached[Ei.Egg.Tachyon]);
+            Assert.IsTrue(back.HasDeviceId);
+            Assert.AreEqual("legacy-device", back.DeviceId);
+            Assert.AreEqual(21.5, back.CraftingXP);
+            CollectionAssert.AreEqual(new double[] { 3.3, 4.4 }, back.VirtueEggsDelivered);
+            Assert.AreEqual(8u, back.Resets);
+            Assert.AreEqual(2u, back.ShiftCount);
+            CollectionAssert.AreEqual(new uint[] { 1u, 2u }, back.EovEarned);
+            Assert.IsTrue(back.NoAliasInLatestBackup);
+        }
+
+        [TestMethod]
+        public void Truncation_OldBlobWithoutEiBackupBytesKey_FallsBackToLegacyValues() {
+            var backup = new CustomBackup(BuildBackup(), EmptyContracts);
+
+            var bytes = MessagePackSerializer.Serialize(backup, MessagePackSerializerOptions.Standard);
+            var reader = new MessagePackReader(bytes);
+            var count = reader.ReadArrayHeader();
+            Assert.IsTrue(count >= 53);
+
+            var buffer = new ArrayBufferWriter<byte>();
+            var writer = new MessagePackWriter(buffer);
+            writer.WriteArrayHeader(52);
+            for(var i = 0; i < 52; i++) {
+                writer.WriteRaw(reader.ReadRaw());
+            }
+            writer.Flush();
+
+            var truncated = MessagePackSerializer.Deserialize<CustomBackup>(buffer.WrittenMemory, MessagePackSerializerOptions.Standard);
+
+            Assert.IsNull(truncated.EiBackupBytes);
+            AssertDerivedFromBuildBackup(truncated);
+        }
+
+        [TestMethod]
+        public void Derivation_ConvertedMembers_EqualEiBackupValues() {
+            var backup = new CustomBackup(BuildBackup(), EmptyContracts);
+
+            AssertDerivedFromBuildBackup(backup);
+        }
+
+        [TestMethod]
+        public void Derivation_IgnoresLegacyFieldWrites_WhileEiBackupBytesSet() {
+            var backup = new CustomBackup(BuildBackup(), EmptyContracts);
+
+            backup.NumPrestiges = 999;
+            backup.SoulEggs = -1;
+            backup.HyperloopPurchased = false;
+            backup.EpicResearch = [new CustomResearch { Id = "overridden", Level = 0 }];
+            backup.MaxEggReached = Ei.Egg.Edible;
+
+            Assert.AreEqual(6UL, backup.NumPrestiges);
+            Assert.AreEqual(5432.25, backup.SoulEggs);
+            Assert.IsTrue(backup.HyperloopPurchased);
+            Assert.AreEqual(1, backup.EpicResearch.Count);
+            Assert.AreEqual("soul_eggs", backup.EpicResearch[0].Id);
+            Assert.AreEqual(Ei.Egg.Medical, backup.MaxEggReached);
+        }
+
+        [TestMethod]
+        public void NoAliasInLatestBackup_DerivesTrue_WhenEiBackupUserNameEmpty_IgnoringLegacyField() {
+            var backupWithNoAlias = new Ei.Backup {
+                UserId = "backup-user-no-alias",
+                UserName = "",
+                Game = new Ei.Backup.Types.Game(),
+                Artifacts = new Ei.Backup.Types.Artifacts(),
+                Contracts = new Ei.MyContracts(),
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+
+            var backup = new CustomBackup(backupWithNoAlias, EmptyContracts);
+            backup.NoAliasInLatestBackup = false;
+
+            Assert.IsTrue(backup.NoAliasInLatestBackup);
+        }
+
+        [TestMethod]
+        public void RoundTrip_ConvertedMembersAndEiBackupBytes_SurviveMessagePack() {
+            var backup = new CustomBackup(BuildBackup(), EmptyContracts);
+
+            var bytes = MessagePackSerializer.Serialize(backup, Lz4);
+            var back = MessagePackSerializer.Deserialize<CustomBackup>(bytes, Lz4);
+
+            CollectionAssert.AreEqual(backup.EiBackupBytes, back.EiBackupBytes);
+            AssertDerivedFromBuildBackup(back);
+        }
+
+        [TestMethod]
+        public void TrimmedBytes_ClearsNotStoredFields_KeepsGameStatsVirtue() {
+            var backup = new CustomBackup(BuildBackup(), EmptyContracts);
+
+            var trimmed = Ei.Backup.Parser.ParseFrom(backup.EiBackupBytes);
+
+            Assert.AreEqual(0, trimmed.Farms.Count);
+            Assert.IsNull(trimmed.Contracts);
+            Assert.IsNull(trimmed.ArtifactsDb);
+            Assert.IsNotNull(trimmed.Game);
+            Assert.AreEqual(3u, trimmed.Game.PermitLevel);
+            Assert.AreEqual(11UL, trimmed.Game.EggsOfProphecy);
+            Assert.AreEqual(0, trimmed.Game.News.Count);
+            Assert.AreEqual(0, trimmed.Game.Achievements.Count);
+            Assert.AreEqual(0, trimmed.Game.Boosts.Count);
+            Assert.IsNotNull(trimmed.Stats);
+            Assert.AreEqual(6UL, trimmed.Stats.NumPrestiges);
+            Assert.IsNotNull(trimmed.Virtue);
+            Assert.AreEqual(5u, trimmed.Virtue.Resets);
+            Assert.AreEqual(9u, trimmed.Virtue.ShiftCount);
+            Assert.IsNull(trimmed.Virtue.Afx);
+        }
+
+        [TestMethod]
+        public void TrimmedBytes_TypeWithoutNotStored_RoundTripsWhole() {
+            var evaluation = new Ei.ContractEvaluation {
+                ContractIdentifier = "contract-untrimmed",
+                CoopIdentifier = "coop-untrimmed",
+                Cxp = 123.5,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+                CoopSize = 10,
+                ChickenRunsSent = 4,
+                GiftTokensSent = 7,
+                TeamworkScore = 0.75,
+                SeasonId = "season-1",
+                Issues = { Ei.ContractEvaluation.Types.PoorBehavior.LowContribution },
+                Notes = { "note-a", "note-b" }
+            };
+
+            var parsed = Ei.ContractEvaluation.Parser.ParseFrom(StorageTrimmer.TrimmedBytes(evaluation));
+
+            Assert.AreEqual(evaluation, parsed);
+        }
+
+        [TestMethod]
+        public void EmptyBackup_NullGame_ProducesDefaultsAndNullEiBackupBytes() {
+            var backup = new CustomBackup(new Ei.Backup(), EmptyContracts);
+
+            Assert.IsTrue(backup.EmptyBackup);
+            Assert.IsNull(backup.EiBackupBytes);
+            Assert.IsNull(backup.Farms);
+            Assert.IsNull(backup.EggIncId);
+            Assert.AreEqual((ushort)0, backup.PermitLevel);
+            Assert.AreEqual(0d, backup.SoulEggs);
+            Assert.AreEqual((byte)0, backup.ClientVersion);
+            Assert.AreEqual(0UL, backup.NumPrestiges);
+            Assert.IsFalse(backup.HyperloopPurchased);
+        }
+
+        [TestMethod]
+        public void EiBackupBytes_ResettingInvalidatesDerivedCollectionCaches() {
+            var backup = new CustomBackup();
+
+            var first = new Ei.Backup {
+                Game = new Ei.Backup.Types.Game {
+                    EpicResearch = { new Ei.Backup.Types.ResearchItem { Id = "soul_eggs", Level = 1 } },
+                    EggMedalLevel = { 1u },
+                    MaxFarmSizeReached = { 5UL }
+                },
+                Virtue = new Ei.Backup.Types.Virtue {
+                    EggsDelivered = { 1.1 },
+                    EovEarned = { 2u }
+                }
+            };
+            var second = new Ei.Backup {
+                Game = new Ei.Backup.Types.Game {
+                    EpicResearch = { new Ei.Backup.Types.ResearchItem { Id = "prophecy_bonus", Level = 9 } },
+                    EggMedalLevel = { 7u, 8u },
+                    MaxFarmSizeReached = { 0UL, 40UL }
+                },
+                Virtue = new Ei.Backup.Types.Virtue {
+                    EggsDelivered = { 9.9, 8.8 },
+                    EovEarned = { 3u, 4u }
+                }
+            };
+
+            backup.EiBackupBytes = first.ToByteArray();
+            Assert.AreEqual("soul_eggs", backup.EpicResearch[0].Id);
+            CollectionAssert.AreEqual(new List<uint> { 1u }, backup.EggMedalLevel);
+            Assert.AreEqual(5UL, backup.MaxFarmSizeReached[Ei.Egg.Edible]);
+            CollectionAssert.AreEqual(new double[] { 1.1 }, backup.VirtueEggsDelivered);
+            CollectionAssert.AreEqual(new uint[] { 2u }, backup.EovEarned);
+
+            backup.EiBackupBytes = second.ToByteArray();
+            Assert.AreEqual("prophecy_bonus", backup.EpicResearch[0].Id);
+            CollectionAssert.AreEqual(new List<uint> { 7u, 8u }, backup.EggMedalLevel);
+            Assert.AreEqual(40UL, backup.MaxFarmSizeReached[Ei.Egg.Superfood]);
+            Assert.IsFalse(backup.MaxFarmSizeReached.ContainsKey(Ei.Egg.Edible));
+            CollectionAssert.AreEqual(new double[] { 9.9, 8.8 }, backup.VirtueEggsDelivered);
+            CollectionAssert.AreEqual(new uint[] { 3u, 4u }, backup.EovEarned);
+        }
+    }
+}

--- a/EGG9000.Test/CustomBackupParentDerivationTests.cs
+++ b/EGG9000.Test/CustomBackupParentDerivationTests.cs
@@ -269,8 +269,7 @@ namespace EGG9000.Test {
             Assert.IsNotNull(trimmed.Virtue);
             Assert.AreEqual(5u, trimmed.Virtue.Resets);
             Assert.AreEqual(9u, trimmed.Virtue.ShiftCount);
-            Assert.IsNotNull(trimmed.Virtue.Afx);
-            Assert.AreEqual(12.5, trimmed.Virtue.Afx.CraftingXp);
+            Assert.IsNull(trimmed.Virtue.Afx);
         }
 
         [TestMethod]

--- a/EGG9000.Test/CustomBackupParentDerivationTests.cs
+++ b/EGG9000.Test/CustomBackupParentDerivationTests.cs
@@ -269,7 +269,8 @@ namespace EGG9000.Test {
             Assert.IsNotNull(trimmed.Virtue);
             Assert.AreEqual(5u, trimmed.Virtue.Resets);
             Assert.AreEqual(9u, trimmed.Virtue.ShiftCount);
-            Assert.IsNull(trimmed.Virtue.Afx);
+            Assert.IsNotNull(trimmed.Virtue.Afx);
+            Assert.AreEqual(12.5, trimmed.Virtue.Afx.CraftingXp);
         }
 
         [TestMethod]

--- a/EGG9000.Test/CustomFarmParentDerivationTests.cs
+++ b/EGG9000.Test/CustomFarmParentDerivationTests.cs
@@ -1,0 +1,415 @@
+using EGG9000.Common.Database;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class CustomFarmParentDerivationTests {
+        private static readonly MessagePackSerializerOptions Lz4 =
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+
+        private static (Ei.Backup backup, FrozenSet<Ei.Contract> contracts) BuildBackupWithFarm(string contractId, uint league, double timeAccepted) {
+            var contract = new Ei.Contract { Identifier = contractId };
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                ContractIdentifier = contractId,
+                League = league,
+                TimeAccepted = timeAccepted,
+                CoopIdentifier = "coop-xyz",
+                Cancelled = true,
+                CoopSharedEndTime = 1_650_500_000,
+                BoostsUsed = 3,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+                CoopContributionFinalized = true,
+                CoopSimulationEndTime = 1_650_600_000,
+                NumGoalsAchieved = 2
+            };
+            var simulation = new Ei.Backup.Types.Simulation {
+                ContractId = contractId,
+                FarmType = Ei.FarmType.Contract,
+                EggsPaidFor = 55.5,
+                NumChickens = 12345,
+                EggType = Ei.Egg.RocketFuel,
+                SilosOwned = 4,
+                BoostTokensReceived = 3,
+                BoostTokensGiven = 2,
+                BoostTokensSpent = 1,
+                CashEarned = 5000.5,
+                CashSpent = 1200.25,
+                TimeCheatsDetected = 1,
+                LastStepTime = 3.5,
+                CommonResearch = { new Ei.Backup.Types.ResearchItem { Id = "hab_capacity", Level = 6 } },
+                TrainLength = { 5u, 6u, 7u },
+                Habs = { 10u, 20u, 30u, 40u },
+                HabPopulation = { 111u, 222u, 333u, 444u }
+            };
+
+            var backup = new Ei.Backup {
+                Game = new Ei.Backup.Types.Game(),
+                Artifacts = new Ei.Backup.Types.Artifacts(),
+                Contracts = new Ei.MyContracts { Contracts = { localContract } },
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+            backup.Farms.Add(simulation);
+
+            return (backup, new List<Ei.Contract> { contract }.ToFrozenSet());
+        }
+
+        private static Ei.Contract.Types.Goal NewGoal(double targetAmount) {
+            return new Ei.Contract.Types.Goal {
+                Type = Ei.GoalType.EggsLaid,
+                TargetAmount = targetAmount,
+                RewardType = Ei.RewardType.Cash,
+                RewardAmount = 1
+            };
+        }
+
+        [TestMethod]
+        public void CustomFarm_BackCompat_ConvertedMembers_ReturnLegacyValues_WhenBytesNull() {
+            var farm = new CustomFarm {
+                FarmType = Ei.FarmType.Contract,
+                ContractId = "legacy-contract",
+                EggsPaidFor = 12.5,
+                CommonResearch = [new CustomResearch { Id = "hab_capacity", Level = 3 }],
+                NumChickens = 4000,
+                EggType = Ei.Egg.Tachyon,
+                TrainLength = [1u, 2u, 3u],
+                SilosOwned = 2,
+                BoostTokensReceived = 5,
+                BoostTokensGiven = 6,
+                BoostTokensSpent = 1,
+                CashEarned = 999.5,
+                CashSpent = 250.25,
+                TimeCheatDebt = 42,
+                TimeCheatsDetected = 3,
+                Habs = [1, 2, 3, 4],
+                LastStepTime = 1.5f,
+                League = 2,
+                CoopId = "legacy-coop",
+                Cancelled = true,
+                TimeAccepted = 1_600_000_000,
+                CoopSharedEndTime = 1_600_100_000,
+                BoostsUsed = 7,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+                EvaluationCxp = 88.5,
+                ContributionFinalized = true,
+                CoopSimulationEndTime = 1_600_200_000,
+                NumGoalsAchieved = 4
+            };
+
+            var bytes = MessagePackSerializer.Serialize(farm, Lz4);
+            var back = MessagePackSerializer.Deserialize<CustomFarm>(bytes, Lz4);
+
+            Assert.IsNull(back.SimulationBytes);
+            Assert.IsNull(back.LocalContractBytes);
+            Assert.AreEqual(Ei.FarmType.Contract, back.FarmType);
+            Assert.AreEqual("legacy-contract", back.ContractId);
+            Assert.AreEqual(12.5, back.EggsPaidFor);
+            Assert.AreEqual(1, back.CommonResearch.Count);
+            Assert.AreEqual("hab_capacity", back.CommonResearch[0].Id);
+            Assert.AreEqual(4000UL, back.NumChickens);
+            Assert.AreEqual(Ei.Egg.Tachyon, back.EggType);
+            CollectionAssert.AreEqual(new List<uint> { 1u, 2u, 3u }, back.TrainLength);
+            Assert.AreEqual(2u, back.SilosOwned);
+            Assert.AreEqual((ushort)5, back.BoostTokensReceived);
+            Assert.AreEqual((ushort)6, back.BoostTokensGiven);
+            Assert.AreEqual((ushort)1, back.BoostTokensSpent);
+            Assert.AreEqual(999.5, back.CashEarned);
+            Assert.AreEqual(250.25, back.CashSpent);
+            Assert.AreEqual(42L, back.TimeCheatDebt);
+            Assert.AreEqual((ushort)3, back.TimeCheatsDetected);
+            CollectionAssert.AreEqual(new List<ushort> { 1, 2, 3, 4 }, back.Habs);
+            Assert.AreEqual(1.5f, back.LastStepTime);
+            Assert.AreEqual((uint?)2, back.League);
+            Assert.AreEqual("legacy-coop", back.CoopId);
+            Assert.IsTrue(back.Cancelled);
+            Assert.AreEqual(1_600_000_000L, back.TimeAccepted);
+            Assert.AreEqual(1_600_100_000L, back.CoopSharedEndTime);
+            Assert.AreEqual((ushort)7, back.BoostsUsed);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeAa, back.Grade);
+            Assert.AreEqual(88.5, back.EvaluationCxp);
+            Assert.IsTrue(back.ContributionFinalized);
+            Assert.AreEqual(1_600_200_000d, back.CoopSimulationEndTime);
+            Assert.AreEqual((byte)4, back.NumGoalsAchieved);
+        }
+
+        [TestMethod]
+        public void CustomFarm_Derivation_PrefersDerivedOverLegacyFields() {
+            var (backup, contracts) = BuildBackupWithFarm("contract-derive", 1, 1_650_000_000);
+
+            var result = new CustomBackup(backup, contracts);
+            var farm = result.Farms.Single();
+
+            Assert.AreEqual(Ei.FarmType.Contract, farm.FarmType);
+            Assert.AreEqual("contract-derive", farm.ContractId);
+            Assert.AreEqual(55.5, farm.EggsPaidFor);
+            Assert.AreEqual(1, farm.CommonResearch.Count);
+            Assert.AreEqual("hab_capacity", farm.CommonResearch[0].Id);
+            Assert.AreEqual(12345UL, farm.NumChickens);
+            Assert.AreEqual(Ei.Egg.RocketFuel, farm.EggType);
+            CollectionAssert.AreEqual(new List<uint> { 5u, 6u, 7u }, farm.TrainLength);
+            Assert.AreEqual(4u, farm.SilosOwned);
+            Assert.AreEqual((ushort)3, farm.BoostTokensReceived);
+            Assert.AreEqual((ushort)2, farm.BoostTokensGiven);
+            Assert.AreEqual((ushort)1, farm.BoostTokensSpent);
+            Assert.AreEqual(5000.5, farm.CashEarned);
+            Assert.AreEqual(1200.25, farm.CashSpent);
+            Assert.AreEqual((ushort)1, farm.TimeCheatsDetected);
+            CollectionAssert.AreEqual(new List<ushort> { 10, 20, 30, 40 }, farm.Habs);
+            Assert.AreEqual(3.5f, farm.LastStepTime);
+            Assert.AreEqual((uint?)1, farm.League);
+            Assert.AreEqual("coop-xyz", farm.CoopId);
+            Assert.IsTrue(farm.Cancelled);
+            Assert.AreEqual(1_650_000_000L, farm.TimeAccepted);
+            Assert.AreEqual(1_650_500_000L, farm.CoopSharedEndTime);
+            Assert.AreEqual((ushort)3, farm.BoostsUsed);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeAa, farm.Grade);
+            Assert.IsTrue(farm.ContributionFinalized);
+            Assert.AreEqual(1_650_600_000d, farm.CoopSimulationEndTime);
+            Assert.AreEqual((byte)2, farm.NumGoalsAchieved);
+
+            farm.NumChickens = 999999;
+            farm.League = 99;
+            farm.Habs = [1, 2, 3];
+
+            Assert.AreEqual(12345UL, farm.NumChickens);
+            Assert.AreEqual((uint?)1, farm.League);
+            CollectionAssert.AreEqual(new List<ushort> { 10, 20, 30, 40 }, farm.Habs);
+        }
+
+        [TestMethod]
+        public void CustomFarm_SimulationBytes_ClearsHabPopulation_KeepsHabs() {
+            var (backup, contracts) = BuildBackupWithFarm("contract-trim-sim", 0, 1_600_000_000);
+            var result = new CustomBackup(backup, contracts);
+            var farm = result.Farms.Single();
+
+            var simulation = Ei.Backup.Types.Simulation.Parser.ParseFrom(farm.SimulationBytes);
+
+            Assert.AreEqual(0, simulation.HabPopulation.Count);
+            CollectionAssert.AreEqual(new List<uint> { 10u, 20u, 30u, 40u }, simulation.Habs);
+            Assert.AreEqual("contract-trim-sim", simulation.ContractId);
+            Assert.AreEqual(12345UL, simulation.NumChickens);
+        }
+
+        [TestMethod]
+        public void CustomFarm_LocalContractBytes_ClearsEmbeddedContract() {
+            var (backup, contracts) = BuildBackupWithFarm("contract-trim-lc", 0, 1_600_000_000);
+            var result = new CustomBackup(backup, contracts);
+            var farm = result.Farms.Single();
+
+            var localContract = Ei.LocalContract.Parser.ParseFrom(farm.LocalContractBytes);
+
+            Assert.IsNull(localContract.Contract);
+            Assert.AreEqual("contract-trim-lc", localContract.ContractIdentifier);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_BackCompat_ConvertedMembers_ReturnLegacyValues_WhenBytesNull() {
+            var archived = new CustomArchivedFarms {
+                CoopId = "legacy-coop",
+                ContractId = "legacy-contract-id",
+                TimeAccepted = 1_580_000_000f,
+                League = 4,
+                ContributionAmount = 321.25f,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeA,
+                EvaluationCxp = 15.5f,
+                NumGoalsAchieved = 3,
+                ReportedUUIDs = ["uuid-a", "uuid-b"]
+            };
+
+            var bytes = MessagePackSerializer.Serialize(archived, Lz4);
+            var back = MessagePackSerializer.Deserialize<CustomArchivedFarms>(bytes, Lz4);
+
+            Assert.IsNull(back.LocalContractBytes);
+            Assert.AreEqual("legacy-coop", back.CoopId);
+            Assert.AreEqual("legacy-contract-id", back.ContractId);
+            Assert.AreEqual(1_580_000_000f, back.TimeAccepted);
+            Assert.AreEqual((byte?)4, back.League);
+            Assert.AreEqual(321.25f, back.ContributionAmount);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeA, back.Grade);
+            Assert.AreEqual(15.5f, back.EvaluationCxp);
+            Assert.AreEqual((byte)3, back.NumGoalsAchieved);
+            CollectionAssert.AreEqual(new List<string> { "uuid-a", "uuid-b" }, back.ReportedUUIDs);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_Derivation_PrefersDerivedOverLegacyFields() {
+            var contract = new Ei.Contract { Identifier = "contract-archived-derive" };
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                ContractIdentifier = "contract-archived-derive",
+                CoopIdentifier = "coop-archived",
+                TimeAccepted = 1_640_000_000,
+                League = 3,
+                CoopLastUploadedContribution = 4321.5,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeB,
+                Evaluation = new Ei.ContractEvaluation { Cxp = 12.75 },
+                NumGoalsAchieved = 2,
+                ReportedUuids = { "uuid-1", "uuid-2" }
+            };
+
+            var archived = new CustomArchivedFarms(localContract);
+
+            Assert.AreEqual("coop-archived", archived.CoopId);
+            Assert.AreEqual("contract-archived-derive", archived.ContractId);
+            Assert.AreEqual(1_640_000_000f, archived.TimeAccepted);
+            Assert.AreEqual((byte?)3, archived.League);
+            Assert.AreEqual(4321.5f, archived.ContributionAmount);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeB, archived.Grade);
+            Assert.AreEqual(12.75f, archived.EvaluationCxp);
+            Assert.AreEqual((byte)2, archived.NumGoalsAchieved);
+            CollectionAssert.AreEqual(new List<string> { "uuid-1", "uuid-2" }, archived.ReportedUUIDs);
+
+            archived.CoopId = "overridden";
+            archived.Grade = Ei.Contract.Types.PlayerGrade.GradeAaa;
+
+            Assert.AreEqual("coop-archived", archived.CoopId);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeB, archived.Grade);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_LocalContractBytes_ClearsEmbeddedContract() {
+            var contract = new Ei.Contract { Identifier = "contract-archived-trim" };
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                ContractIdentifier = "contract-archived-trim",
+                League = 0
+            };
+
+            var archived = new CustomArchivedFarms(localContract);
+            var parsed = Ei.LocalContract.Parser.ParseFrom(archived.LocalContractBytes);
+
+            Assert.IsNull(parsed.Contract);
+            Assert.AreEqual("contract-archived-trim", parsed.ContractIdentifier);
+        }
+
+        [TestMethod]
+        public void CustomBackup_Completed_AgreesBetweenLiveAndArchivedFarms_ForGoalSetsAtLeagueIndex() {
+            var contractId = "contract-completed-agree";
+            var contract = new Ei.Contract { Identifier = contractId };
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(100) } });
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(100), NewGoal(200) } });
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(100), NewGoal(200), NewGoal(300) } });
+
+            Assert.AreNotEqual(contract.GoalSets[0].Goals.Count, contract.GoalSets[2].Goals.Count);
+
+            var localContract = new Ei.LocalContract {
+                ContractIdentifier = contractId,
+                League = 2,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeUnset,
+                NumGoalsAchieved = (uint)contract.GoalSets[2].Goals.Count
+            };
+            var simulation = new Ei.Backup.Types.Simulation {
+                ContractId = contractId,
+                FarmType = Ei.FarmType.Contract
+            };
+
+            var backup = new Ei.Backup {
+                Game = new Ei.Backup.Types.Game(),
+                Artifacts = new Ei.Backup.Types.Artifacts(),
+                Contracts = new Ei.MyContracts { Contracts = { localContract } },
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+            backup.Farms.Add(simulation);
+
+            var contracts = new List<Ei.Contract> { contract }.ToFrozenSet();
+            var result = new CustomBackup(backup, contracts);
+
+            Assert.IsTrue(result.Farms.Single().Completed);
+            Assert.IsTrue(result.ArchivedFarms.Single().Completed);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_Completed_UsesGoalSetsAtLeagueIndex_NotGoalSetsZero() {
+            var contract = new Ei.Contract { Identifier = "contract-league-goals" };
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(100) } });
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(100), NewGoal(200) } });
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(100), NewGoal(200), NewGoal(300) } });
+
+            Assert.AreEqual(1, contract.GoalSets[0].Goals.Count);
+            Assert.AreEqual(3, contract.GoalSets[2].Goals.Count);
+
+            var completedContract = new Ei.LocalContract {
+                Contract = contract,
+                League = 2,
+                NumGoalsAchieved = 3
+            };
+            Assert.AreEqual(3, contract.GetGoals(completedContract).Count);
+            Assert.IsTrue(new CustomArchivedFarms(completedContract).Completed);
+
+            var underAchievedContract = new Ei.LocalContract {
+                Contract = contract,
+                League = 2,
+                NumGoalsAchieved = 1
+            };
+            Assert.IsFalse(new CustomArchivedFarms(underAchievedContract).Completed);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_Completed_UsesGradeSpecs_WhenGradeSet() {
+            var contract = new Ei.Contract { Identifier = "contract-grade-goals" };
+            contract.GradeSpecs.Add(new Ei.Contract.Types.GradeSpec {
+                Grade = Ei.Contract.Types.PlayerGrade.GradeC,
+                Goals = { NewGoal(100), NewGoal(200) }
+            });
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(999) } });
+
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeC,
+                League = 0,
+                NumGoalsAchieved = 2
+            };
+
+            Assert.AreEqual(2, contract.GetGoals(localContract).Count);
+            Assert.IsTrue(new CustomArchivedFarms(localContract).Completed);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_Completed_FallsBackToGoalSets_WhenGradeSetButNoGradeSpecs() {
+            var contract = new Ei.Contract { Identifier = "contract-no-gradespecs" };
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(1) } });
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(1), NewGoal(2) } });
+
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeB,
+                League = 1,
+                NumGoalsAchieved = 2
+            };
+
+            var goals = contract.GetGoals(localContract);
+            Assert.AreEqual(2, goals.Count);
+
+            var archived = new CustomArchivedFarms(localContract);
+            Assert.IsTrue(archived.Completed);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_Completed_FallsBackToTopLevelGoals_WhenLeagueOutOfRange() {
+            var contract = new Ei.Contract { Identifier = "contract-league-oob" };
+            contract.Goals.Add(NewGoal(1));
+            contract.Goals.Add(NewGoal(2));
+            contract.GoalSets.Add(new Ei.Contract.Types.GoalSet { Goals = { NewGoal(1) } });
+
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                League = 5,
+                NumGoalsAchieved = 2
+            };
+
+            var goals = contract.GetGoals(localContract);
+            Assert.AreEqual(2, goals.Count);
+
+            var archived = new CustomArchivedFarms(localContract);
+            Assert.IsTrue(archived.Completed);
+        }
+    }
+}

--- a/EGG9000.Test/CustomFarmParentDerivationTests.cs
+++ b/EGG9000.Test/CustomFarmParentDerivationTests.cs
@@ -185,14 +185,15 @@ namespace EGG9000.Test {
         }
 
         [TestMethod]
-        public void CustomFarm_SimulationBytes_ClearsHabPopulation_KeepsHabs() {
+        public void CustomFarm_SimulationBytes_StoresWholeSimulation() {
             var (backup, contracts) = BuildBackupWithFarm("contract-trim-sim", 0, 1_600_000_000);
             var result = new CustomBackup(backup, contracts);
             var farm = result.Farms.Single();
 
             var simulation = Ei.Backup.Types.Simulation.Parser.ParseFrom(farm.SimulationBytes);
 
-            Assert.AreEqual(0, simulation.HabPopulation.Count);
+            Assert.AreEqual(backup.Farms[0], simulation);
+            Assert.AreEqual(4, simulation.HabPopulation.Count);
             CollectionAssert.AreEqual(new List<uint> { 10u, 20u, 30u, 40u }, simulation.Habs);
             Assert.AreEqual("contract-trim-sim", simulation.ContractId);
             Assert.AreEqual(12345UL, simulation.NumChickens);

--- a/EGG9000.Test/CustomFarmParentDerivationTests.cs
+++ b/EGG9000.Test/CustomFarmParentDerivationTests.cs
@@ -185,15 +185,14 @@ namespace EGG9000.Test {
         }
 
         [TestMethod]
-        public void CustomFarm_SimulationBytes_StoresWholeSimulation() {
+        public void CustomFarm_SimulationBytes_ClearsHabPopulation_KeepsHabs() {
             var (backup, contracts) = BuildBackupWithFarm("contract-trim-sim", 0, 1_600_000_000);
             var result = new CustomBackup(backup, contracts);
             var farm = result.Farms.Single();
 
             var simulation = Ei.Backup.Types.Simulation.Parser.ParseFrom(farm.SimulationBytes);
 
-            Assert.AreEqual(backup.Farms[0], simulation);
-            Assert.AreEqual(4, simulation.HabPopulation.Count);
+            Assert.AreEqual(0, simulation.HabPopulation.Count);
             CollectionAssert.AreEqual(new List<uint> { 10u, 20u, 30u, 40u }, simulation.Habs);
             Assert.AreEqual("contract-trim-sim", simulation.ContractId);
             Assert.AreEqual(12345UL, simulation.NumChickens);
@@ -228,7 +227,6 @@ namespace EGG9000.Test {
             var bytes = MessagePackSerializer.Serialize(archived, Lz4);
             var back = MessagePackSerializer.Deserialize<CustomArchivedFarms>(bytes, Lz4);
 
-            Assert.IsNull(back.LocalContractBytes);
             Assert.AreEqual("legacy-coop", back.CoopId);
             Assert.AreEqual("legacy-contract-id", back.ContractId);
             Assert.AreEqual(1_580_000_000f, back.TimeAccepted);
@@ -241,7 +239,7 @@ namespace EGG9000.Test {
         }
 
         [TestMethod]
-        public void CustomArchivedFarms_Derivation_PrefersDerivedOverLegacyFields() {
+        public void CustomArchivedFarms_Construction_SetsMembersFromLocalContract() {
             var contract = new Ei.Contract { Identifier = "contract-archived-derive" };
             var localContract = new Ei.LocalContract {
                 Contract = contract,
@@ -267,28 +265,6 @@ namespace EGG9000.Test {
             Assert.AreEqual(12.75f, archived.EvaluationCxp);
             Assert.AreEqual((byte)2, archived.NumGoalsAchieved);
             CollectionAssert.AreEqual(new List<string> { "uuid-1", "uuid-2" }, archived.ReportedUUIDs);
-
-            archived.CoopId = "overridden";
-            archived.Grade = Ei.Contract.Types.PlayerGrade.GradeAaa;
-
-            Assert.AreEqual("coop-archived", archived.CoopId);
-            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeB, archived.Grade);
-        }
-
-        [TestMethod]
-        public void CustomArchivedFarms_LocalContractBytes_ClearsEmbeddedContract() {
-            var contract = new Ei.Contract { Identifier = "contract-archived-trim" };
-            var localContract = new Ei.LocalContract {
-                Contract = contract,
-                ContractIdentifier = "contract-archived-trim",
-                League = 0
-            };
-
-            var archived = new CustomArchivedFarms(localContract);
-            var parsed = Ei.LocalContract.Parser.ParseFrom(archived.LocalContractBytes);
-
-            Assert.IsNull(parsed.Contract);
-            Assert.AreEqual("contract-archived-trim", parsed.ContractIdentifier);
         }
 
         [TestMethod]

--- a/EGG9000.Test/DerivedSlotFormatterTests.cs
+++ b/EGG9000.Test/DerivedSlotFormatterTests.cs
@@ -1,0 +1,330 @@
+using EGG9000.Common.Database;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class DerivedSlotFormatterTests {
+        private static readonly MessagePackSerializerOptions Lz4 =
+            MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4BlockArray);
+
+        private const string ContractId = "contract-derived-slot";
+
+        private static (Ei.Backup Backup, FrozenSet<Ei.Contract> Contracts) BuildBackup(string userName = "ProtoName") {
+            var contract = new Ei.Contract { Identifier = ContractId };
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                ContractIdentifier = ContractId,
+                CoopIdentifier = "coop-derived-slot",
+                League = 1,
+                TimeAccepted = 1_650_000_000,
+                Cancelled = true,
+                CoopSharedEndTime = 1_650_500_000,
+                BoostsUsed = 3,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+                CoopContributionFinalized = true,
+                CoopSimulationEndTime = 1_650_600_000,
+                NumGoalsAchieved = 2,
+                Evaluation = new Ei.ContractEvaluation { Cxp = 44 }
+            };
+            var simulation = new Ei.Backup.Types.Simulation {
+                ContractId = ContractId,
+                FarmType = Ei.FarmType.Contract,
+                EggsPaidFor = 55.5,
+                NumChickens = 12345,
+                EggType = Ei.Egg.RocketFuel,
+                SilosOwned = 4,
+                BoostTokensReceived = 3,
+                BoostTokensGiven = 2,
+                BoostTokensSpent = 1,
+                CashEarned = 5000.5,
+                CashSpent = 1200.25,
+                TimeCheatDebtDEP = 42,
+                TimeCheatsDetected = 1,
+                LastStepTime = 3.5,
+                CommonResearch = { new Ei.Backup.Types.ResearchItem { Id = "hab_capacity", Level = 6 } },
+                TrainLength = { 5u, 6u, 7u },
+                Habs = { 10u, 20u, 30u, 40u },
+                Vehicles = { 8u, 9u }
+            };
+
+            var backup = new Ei.Backup {
+                UserId = "backup-user-1",
+                EiUserId = "EI0000000000012345",
+                UserName = userName,
+                DeviceId = "device-proto-1",
+                Version = 41,
+                Game = new Ei.Backup.Types.Game {
+                    PermitLevel = 3,
+                    EggsOfProphecy = 11,
+                    SoulEggsD = 5432.25,
+                    CurrentMultiplier = 1.75,
+                    NumDailyGiftsCollected = 12,
+                    GoldenEggsEarned = 500,
+                    GoldenEggsSpent = 200,
+                    PiggyBank = 33,
+                    HyperloopStation = true,
+                    MaxEggReached = Ei.Egg.Medical,
+                    EpicResearch = { new Ei.Backup.Types.ResearchItem { Id = "soul_eggs", Level = 8 } },
+                    EggMedalLevel = { 1u, 2u, 3u },
+                    MaxFarmSizeReached = { 10UL, 0UL, 20UL }
+                },
+                Settings = new Ei.Backup.Types.Settings { LastBackupTime = 1_700_000_500 },
+                Stats = new Ei.Backup.Types.Stats {
+                    NumPrestiges = 6,
+                    DroneTakedowns = 9,
+                    DroneTakedownsElite = 3,
+                    NumPiggyBreaks = 2
+                },
+                Artifacts = new Ei.Backup.Types.Artifacts { CraftingXp = 77.5 },
+                Virtue = new Ei.Backup.Types.Virtue {
+                    Resets = 5,
+                    ShiftCount = 9,
+                    EggsDelivered = { 1.5, 2.5 },
+                    EovEarned = { 4u, 6u }
+                },
+                Contracts = new Ei.MyContracts { Contracts = { localContract } },
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+            backup.Farms.Add(simulation);
+
+            return (backup, new List<Ei.Contract> { contract }.ToFrozenSet());
+        }
+
+        private static CustomBackup RoundTrip(CustomBackup source, MessagePackSerializerOptions write, MessagePackSerializerOptions read) {
+            return MessagePackSerializer.Deserialize<CustomBackup>(MessagePackSerializer.Serialize(source, write), read);
+        }
+
+        [TestMethod]
+        public void Suppression_DerivedSlots_HoldDefaults_AfterEiBackupBytesCleared() {
+            var (proto, contracts) = BuildBackup();
+            var back = RoundTrip(new CustomBackup(proto, contracts), StorageMessagePack.Options, StorageMessagePack.Options);
+
+            Assert.AreEqual("EI0000000000012345", back.EggIncId);
+            Assert.AreEqual(1_700_000_500L, back.LastBackupTime);
+            Assert.AreEqual("soul_eggs", back.EpicResearch.Single().Id);
+            Assert.AreEqual((ushort)3, back.PermitLevel);
+            Assert.AreEqual(5432.25, back.SoulEggs);
+            Assert.AreEqual(6UL, back.NumPrestiges);
+            Assert.AreEqual(Ei.Egg.Medical, back.MaxEggReached);
+            Assert.AreEqual("device-proto-1", back.DeviceId);
+            Assert.AreEqual(77.5, back.CraftingXP);
+            Assert.IsTrue(back.HyperloopPurchased);
+
+            back.EiBackupBytes = null;
+
+            Assert.AreEqual(string.Empty, back.EggIncId);
+            Assert.AreEqual(0L, back.LastBackupTime);
+            Assert.IsNull(back.EpicResearch);
+            Assert.AreEqual((ushort)0, back.PermitLevel);
+            Assert.AreEqual((ushort)0, back.EggsOfProphecy);
+            Assert.AreEqual(0d, back.SoulEggs);
+            Assert.AreEqual(0d, back.CurrentMultiplier);
+            Assert.AreEqual(0UL, back.NumPrestiges);
+            Assert.AreEqual(0u, back.NumDailyGiftsCollected);
+            Assert.IsNull(back.EggMedalLevel);
+            Assert.AreEqual(0UL, back.GoldenEggsEarned);
+            Assert.AreEqual(0UL, back.GoldenEggsSpent);
+            Assert.AreEqual(0UL, back.PiggyBank);
+            Assert.AreEqual(0UL, back.DroneTakedowns);
+            Assert.AreEqual(0UL, back.DroneTakedownsElite);
+            Assert.AreEqual(0UL, back.NumPiggyBreaks);
+            Assert.IsFalse(back.HyperloopPurchased);
+            Assert.AreEqual((byte)0, back.ClientVersion);
+            Assert.AreEqual(default(Ei.Egg), back.MaxEggReached);
+            Assert.IsNull(back.MaxFarmSizeReached);
+            Assert.IsFalse(back.HasDeviceId);
+            Assert.AreEqual(string.Empty, back.DeviceId);
+            Assert.AreEqual(0d, back.CraftingXP);
+            Assert.AreEqual(0, back.VirtueEggsDelivered.Length);
+            Assert.AreEqual(0u, back.Resets);
+            Assert.AreEqual(0u, back.ShiftCount);
+            Assert.AreEqual(0, back.EovEarned.Length);
+            Assert.IsFalse(back.NoAliasInLatestBackup);
+
+            Assert.IsFalse(back.EmptyBackup);
+            Assert.AreEqual("coop-derived-slot", back.ArchivedFarms.Single().CoopId);
+            Assert.IsNotNull(back.CustomEggMaxFarmSizeReached);
+        }
+
+        private static CustomBackup BuildLegacyBackup() {
+            return new CustomBackup {
+                EggIncId = "EI-legacy-0001",
+                UserName = "LegacyName",
+                LastBackupTime = 1_650_000_000,
+                EpicResearch = [new CustomResearch { Id = "soul_eggs", Level = 4 }],
+                PermitLevel = 2,
+                EggsOfProphecy = 6,
+                SoulEggs = 999.5,
+                CurrentMultiplier = 1.2,
+                NumPrestiges = 3,
+                NumDailyGiftsCollected = 7,
+                EggMedalLevel = [9u, 8u],
+                GoldenEggsEarned = 44,
+                GoldenEggsSpent = 11,
+                PiggyBank = 5,
+                DroneTakedowns = 2,
+                DroneTakedownsElite = 1,
+                NumPiggyBreaks = 3,
+                HyperloopPurchased = true,
+                ClientVersion = 12,
+                MaxEggReached = Ei.Egg.Tachyon,
+                MaxFarmSizeReached = new Dictionary<Ei.Egg, ulong> { [Ei.Egg.Tachyon] = 55 },
+                HasDeviceId = true,
+                DeviceId = "legacy-device",
+                CraftingXP = 21.5,
+                VirtueEggsDelivered = [3.3, 4.4],
+                Resets = 8,
+                ShiftCount = 2,
+                EovEarned = [1u, 2u],
+                NoAliasInLatestBackup = true
+            };
+        }
+
+        private static void AssertLegacyValues(CustomBackup back) {
+            Assert.IsNull(back.EiBackupBytes);
+            Assert.AreEqual("EI-legacy-0001", back.EggIncId);
+            Assert.AreEqual("LegacyName", back.UserName);
+            Assert.AreEqual(1_650_000_000L, back.LastBackupTime);
+            Assert.AreEqual("soul_eggs", back.EpicResearch.Single().Id);
+            Assert.AreEqual((ushort)2, back.PermitLevel);
+            Assert.AreEqual((ushort)6, back.EggsOfProphecy);
+            Assert.AreEqual(999.5, back.SoulEggs);
+            Assert.AreEqual(1.2, back.CurrentMultiplier);
+            Assert.AreEqual(3UL, back.NumPrestiges);
+            Assert.AreEqual(7u, back.NumDailyGiftsCollected);
+            CollectionAssert.AreEqual(new List<uint> { 9u, 8u }, back.EggMedalLevel);
+            Assert.AreEqual(44UL, back.GoldenEggsEarned);
+            Assert.AreEqual(11UL, back.GoldenEggsSpent);
+            Assert.AreEqual(5UL, back.PiggyBank);
+            Assert.AreEqual(2UL, back.DroneTakedowns);
+            Assert.AreEqual(1UL, back.DroneTakedownsElite);
+            Assert.AreEqual(3UL, back.NumPiggyBreaks);
+            Assert.IsTrue(back.HyperloopPurchased);
+            Assert.AreEqual((byte)12, back.ClientVersion);
+            Assert.AreEqual(Ei.Egg.Tachyon, back.MaxEggReached);
+            Assert.AreEqual(55UL, back.MaxFarmSizeReached[Ei.Egg.Tachyon]);
+            Assert.IsTrue(back.HasDeviceId);
+            Assert.AreEqual("legacy-device", back.DeviceId);
+            Assert.AreEqual(21.5, back.CraftingXP);
+            CollectionAssert.AreEqual(new double[] { 3.3, 4.4 }, back.VirtueEggsDelivered);
+            Assert.AreEqual(8u, back.Resets);
+            Assert.AreEqual(2u, back.ShiftCount);
+            CollectionAssert.AreEqual(new uint[] { 1u, 2u }, back.EovEarned);
+            Assert.IsTrue(back.NoAliasInLatestBackup);
+        }
+
+        [TestMethod]
+        public void NonSuppression_LegacyValues_SurviveRoundTrip_WhenNoBlobPresent() {
+            AssertLegacyValues(RoundTrip(BuildLegacyBackup(), StorageMessagePack.Options, StorageMessagePack.Options));
+        }
+
+        [TestMethod]
+        public void UpgradePath_LegacyRowWrittenWithPlainOptions_ReadsIntactWithStorageOptions() {
+            AssertLegacyValues(RoundTrip(BuildLegacyBackup(), Lz4, StorageMessagePack.Options));
+        }
+
+        [TestMethod]
+        public void UserName_IsNotSuppressed_SoCarriedForwardAliasSurvives() {
+            var (proto, contracts) = BuildBackup("");
+            var lastBackup = new CustomBackup { UserName = "CarriedAlias" };
+
+            var backup = new CustomBackup(proto, contracts, lastBackup);
+            Assert.AreEqual("CarriedAlias", backup.UserName);
+            Assert.IsTrue(backup.NoAliasInLatestBackup);
+
+            var back = RoundTrip(backup, StorageMessagePack.Options, StorageMessagePack.Options);
+            Assert.AreEqual("CarriedAlias", back.UserName);
+
+            back.EiBackupBytes = null;
+            Assert.AreEqual("CarriedAlias", back.UserName);
+        }
+
+        [TestMethod]
+        public void NestedFarm_DerivedSlots_HoldDefaults_AfterFarmBlobsCleared() {
+            var (proto, contracts) = BuildBackup();
+            var back = RoundTrip(new CustomBackup(proto, contracts), StorageMessagePack.Options, StorageMessagePack.Options);
+            var farm = back.Farms.Single();
+
+            Assert.AreEqual(Ei.FarmType.Contract, farm.FarmType);
+            Assert.AreEqual(ContractId, farm.ContractId);
+            Assert.AreEqual((uint?)1, farm.League);
+            Assert.AreEqual("coop-derived-slot", farm.CoopId);
+            CollectionAssert.AreEqual(new List<uint> { 8u, 9u }, farm.Vehicles);
+
+            farm.SimulationBytes = null;
+            farm.LocalContractBytes = null;
+
+            Assert.AreEqual(default(Ei.FarmType), farm.FarmType);
+            Assert.IsNull(farm.ContractId);
+            Assert.AreEqual(0d, farm.EggsPaidFor);
+            Assert.IsNull(farm.CommonResearch);
+            Assert.AreEqual(0UL, farm.NumChickens);
+            Assert.AreEqual(default(Ei.Egg), farm.EggType);
+            Assert.IsNull(farm.TrainLength);
+            Assert.AreEqual(0u, farm.SilosOwned);
+            Assert.AreEqual((ushort)0, farm.BoostTokensReceived);
+            Assert.AreEqual((ushort)0, farm.BoostTokensGiven);
+            Assert.AreEqual((ushort)0, farm.BoostTokensSpent);
+            Assert.AreEqual(0d, farm.CashEarned);
+            Assert.AreEqual(0d, farm.CashSpent);
+            Assert.AreEqual(0L, farm.TimeCheatDebt);
+            Assert.AreEqual((ushort)0, farm.TimeCheatsDetected);
+            Assert.IsNull(farm.Habs);
+            Assert.AreEqual(0f, farm.LastStepTime);
+
+            Assert.IsNull(farm.League);
+            Assert.IsNull(farm.CoopId);
+            Assert.IsFalse(farm.Cancelled);
+            Assert.AreEqual(0L, farm.TimeAccepted);
+            Assert.AreEqual(0L, farm.CoopSharedEndTime);
+            Assert.AreEqual((ushort)0, farm.BoostsUsed);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeUnset, farm.Grade);
+            Assert.AreEqual(0d, farm.EvaluationCxp);
+            Assert.IsFalse(farm.ContributionFinalized);
+            Assert.AreEqual(0d, farm.CoopSimulationEndTime);
+            Assert.AreEqual((byte)0, farm.NumGoalsAchieved);
+
+            CollectionAssert.AreEqual(new List<uint> { 8u, 9u }, farm.Vehicles);
+            Assert.IsNotNull(farm.Artifacts);
+        }
+
+        [TestMethod]
+        public void Suppression_ShrinksSerializedPayload_ComparedToPlainOptions() {
+            var (proto, contracts) = BuildBackup();
+            var backup = new CustomBackup(proto, contracts);
+
+            var suppressed = MessagePackSerializer.Serialize(backup, StorageMessagePack.Options);
+            var plain = MessagePackSerializer.Serialize(backup, Lz4);
+
+            Assert.IsTrue(suppressed.Length < plain.Length, $"suppressed {suppressed.Length} bytes was not smaller than plain {plain.Length} bytes");
+        }
+
+        [TestMethod]
+        public void SuppressedPayload_StillReadableByPlainOptions() {
+            var (proto, contracts) = BuildBackup();
+            var source = new CustomBackup(proto, contracts);
+
+            var back = RoundTrip(source, StorageMessagePack.Options, Lz4);
+
+            CollectionAssert.AreEqual(source.EiBackupBytes, back.EiBackupBytes);
+            Assert.AreEqual("EI0000000000012345", back.EggIncId);
+            Assert.AreEqual("ProtoName", back.UserName);
+            Assert.AreEqual(5432.25, back.SoulEggs);
+            Assert.AreEqual(Ei.Egg.Medical, back.MaxEggReached);
+
+            var farm = back.Farms.Single();
+            Assert.AreEqual(ContractId, farm.ContractId);
+            Assert.AreEqual(12345UL, farm.NumChickens);
+            Assert.AreEqual((uint?)1, farm.League);
+            CollectionAssert.AreEqual(new List<uint> { 8u, 9u }, farm.Vehicles);
+        }
+    }
+}

--- a/EGG9000.Test/MessagePackKeyMapTests.cs
+++ b/EGG9000.Test/MessagePackKeyMapTests.cs
@@ -1,0 +1,248 @@
+using EGG9000.Common.Database;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class MessagePackKeyMapTests {
+        private static readonly Dictionary<int, string> CustomBackupKeys = new() {
+            [0] = "Farms",
+            [1] = "EggIncId",
+            [2] = "UserName",
+            [4] = "LastBackupTime",
+            [5] = "EpicResearch",
+            [6] = "PermitLevel",
+            [7] = "CacheAdded",
+            [8] = "EggsOfProphecy",
+            [9] = "SoulEggs",
+            [10] = "CurrentMultiplier",
+            [12] = "EmptyBackup",
+            [13] = "ArchivedFarms",
+            [14] = "NumPrestiges",
+            [15] = "SpaceMissions",
+            [16] = "NumDailyGiftsCollected",
+            [17] = "EggMedalLevel",
+            [18] = "GoldenEggsEarned",
+            [19] = "GoldenEggsSpent",
+            [20] = "PiggyBank",
+            [21] = "DroneTakedowns",
+            [22] = "DroneTakedownsElite",
+            [23] = "NumPiggyBreaks",
+            [24] = "ArtifactHall",
+            [25] = "HyperloopPurchased",
+            [26] = "TankLevel",
+            [28] = "ClientVersion",
+            [29] = "FuelAmounts",
+            [31] = "MaxEggReached",
+            [32] = "MaxFarmSizeReached",
+            [33] = "HasDeviceId",
+            [34] = "DeviceId",
+            [36] = "ShipsSent",
+            [37] = "SeasonCS",
+            [38] = "TotalCS",
+            [39] = "ArtifactSets",
+            [40] = "CraftingXP",
+            [41] = "FuelingMission",
+            [42] = "CustomEggMaxFarmSizeReached",
+            [44] = "VirtueEggsDelivered",
+            [45] = "Resets",
+            [46] = "ShiftCount",
+            [47] = "EovEarned",
+            [48] = "SubscriptionEnds",
+            [49] = "SubscriptionLevel",
+            [50] = "NoAliasInLatestBackup",
+            [51] = "LastContractPlayerInfoBytes",
+            [52] = "EiBackupBytes"
+        };
+
+        private static readonly Dictionary<int, string> CustomFarmKeys = new() {
+            [0] = "FarmType",
+            [1] = "ContractId",
+            [2] = "EggsPaidFor",
+            [3] = "League",
+            [4] = "CoopId",
+            [5] = "Cancelled",
+            [6] = "Completed",
+            [7] = "CommonResearch",
+            [8] = "NumChickens",
+            [10] = "EggType",
+            [11] = "TrainLength",
+            [12] = "Vehicles",
+            [13] = "Artifacts",
+            [14] = "SilosOwned",
+            [15] = "TimeAccepted",
+            [16] = "CoopAllowed",
+            [17] = "CoopSharedEndTime",
+            [18] = "BoostTokensReceived",
+            [19] = "BoostTokensGiven",
+            [20] = "BoostTokensSpent",
+            [21] = "CashEarned",
+            [22] = "CashSpent",
+            [23] = "TimeCheatDebt",
+            [24] = "BoostsUsed",
+            [25] = "TimeCheatsDetected",
+            [32] = "Habs",
+            [33] = "LastStepTime",
+            [34] = "ReportedUUIDs",
+            [35] = "Grade",
+            [36] = "EvaluationCxp",
+            [37] = "ContributionFinalized",
+            [38] = "CoopSimulationEndTime",
+            [39] = "NumGoalsAchieved",
+            [40] = "Creator",
+            [41] = "SimulationBytes",
+            [42] = "LocalContractBytes"
+        };
+
+        private static readonly Dictionary<int, string> CustomArchivedFarmsKeys = new() {
+            [0] = "CoopId",
+            [1] = "ContractId",
+            [2] = "TimeAccepted",
+            [3] = "Completed",
+            [4] = "League",
+            [5] = "PEPossible",
+            [6] = "PEGained",
+            [7] = "ContributionAmount",
+            [8] = "Grade",
+            [9] = "EvaluationCxp",
+            [10] = "NumGoalsAchieved",
+            [11] = "ReportedUUIDs"
+        };
+
+        private static readonly Dictionary<int, string> CustomResearchKeys = new() {
+            [0] = "Id",
+            [1] = "Level"
+        };
+
+        private static readonly Dictionary<int, string> SpaceMissionKeys = new() {
+            [0] = "Ship",
+            [1] = "Duration",
+            [2] = "Status",
+            [3] = "Fuels",
+            [4] = "DurationSeconds",
+            [5] = "StartTime",
+            [6] = "Targeting",
+            [7] = "Capacity",
+            [8] = "Stars"
+        };
+
+        private static readonly Dictionary<int, string> SpaceMissionFuelKeys = new() {
+            [0] = "Egg",
+            [1] = "Amount"
+        };
+
+        private static readonly int[] CustomBackupRetiredKeys = [3, 11, 27, 30, 35, 43];
+
+        private static readonly int[] CustomFarmRetiredKeys = [9, 26, 27, 28, 29, 30, 31];
+
+        private static List<(int Key, string Member)> KeyedMembers(Type type) {
+            var members = new List<(int Key, string Member)>();
+            foreach(var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)) {
+                if(property.GetCustomAttribute<KeyAttribute>()?.IntKey is { } key)
+                    members.Add((key, property.Name));
+            }
+            foreach(var fieldMember in type.GetFields(BindingFlags.Public | BindingFlags.Instance)) {
+                if(fieldMember.GetCustomAttribute<KeyAttribute>()?.IntKey is { } key)
+                    members.Add((key, fieldMember.Name));
+            }
+            return members;
+        }
+
+        private static Dictionary<int, string> KeyMap(Type type) {
+            return KeyedMembers(type).ToDictionary(x => x.Key, x => x.Member);
+        }
+
+        private static void AssertKeyMap(Type type, Dictionary<int, string> expected) {
+            var actual = KeyMap(type);
+            foreach(var pair in expected) {
+                Assert.IsTrue(actual.TryGetValue(pair.Key, out var name), $"{type.Name} lost [Key({pair.Key})] {pair.Value}");
+                Assert.AreEqual(pair.Value, name, $"{type.Name} [Key({pair.Key})]");
+            }
+            var unpinned = actual.Keys.Except(expected.Keys).OrderBy(x => x).ToList();
+            Assert.AreEqual(0, unpinned.Count, $"{type.Name} has keys not in the pinned map: {string.Join(", ", unpinned)}");
+        }
+
+        private static void AssertRetiredKeysAbsent(Type type, int[] retired) {
+            var actual = KeyMap(type);
+            foreach(var key in retired)
+                Assert.IsFalse(actual.ContainsKey(key), $"{type.Name} reuses retired [Key({key})] on {actual.GetValueOrDefault(key)}");
+        }
+
+        private static IEnumerable<Type> LoadableTypes(Assembly assembly) {
+            try {
+                return assembly.GetTypes();
+            } catch(ReflectionTypeLoadException e) {
+                return e.Types.Where(t => t is not null).Select(t => t!);
+            }
+        }
+
+        [TestMethod]
+        public void CustomBackup_KeyMap_MatchesPinnedLayout() {
+            AssertKeyMap(typeof(CustomBackup), CustomBackupKeys);
+        }
+
+        [TestMethod]
+        public void CustomFarm_KeyMap_MatchesPinnedLayout() {
+            AssertKeyMap(typeof(CustomFarm), CustomFarmKeys);
+        }
+
+        [TestMethod]
+        public void CustomArchivedFarms_KeyMap_MatchesPinnedLayout() {
+            AssertKeyMap(typeof(CustomArchivedFarms), CustomArchivedFarmsKeys);
+        }
+
+        [TestMethod]
+        public void CustomResearch_KeyMap_MatchesPinnedLayout() {
+            AssertKeyMap(typeof(CustomResearch), CustomResearchKeys);
+        }
+
+        [TestMethod]
+        public void SpaceMission_KeyMap_MatchesPinnedLayout() {
+            AssertKeyMap(typeof(SpaceMission), SpaceMissionKeys);
+        }
+
+        [TestMethod]
+        public void SpaceMissionFuel_KeyMap_MatchesPinnedLayout() {
+            AssertKeyMap(typeof(SpaceMissionFuel), SpaceMissionFuelKeys);
+        }
+
+        [TestMethod]
+        public void CustomBackup_RetiredKeys_AreAbsent() {
+            AssertRetiredKeysAbsent(typeof(CustomBackup), CustomBackupRetiredKeys);
+        }
+
+        [TestMethod]
+        public void CustomFarm_RetiredKeys_AreAbsent() {
+            AssertRetiredKeysAbsent(typeof(CustomFarm), CustomFarmRetiredKeys);
+        }
+
+        [TestMethod]
+        public void DatabaseMessagePackTypes_HaveNoDuplicateIntKeys() {
+            var types = LoadableTypes(typeof(CustomBackup).Assembly)
+                .Where(t => t.Namespace?.StartsWith("EGG9000.Common.Database", StringComparison.Ordinal) == true)
+                .Where(t => t.GetCustomAttribute<MessagePackObjectAttribute>() is not null)
+                .ToList();
+
+            CollectionAssert.Contains(types, typeof(CustomBackup));
+            CollectionAssert.Contains(types, typeof(CustomFarm));
+            CollectionAssert.Contains(types, typeof(CustomArchivedFarms));
+
+            foreach(var type in types) {
+                var duplicates = KeyedMembers(type)
+                    .GroupBy(x => x.Key)
+                    .Where(g => g.Count() > 1)
+                    .Select(g => $"{g.Key} ({string.Join(", ", g.Select(x => x.Member))})")
+                    .ToList();
+                Assert.AreEqual(0, duplicates.Count, $"{type.FullName} has duplicate int keys: {string.Join("; ", duplicates)}");
+            }
+        }
+    }
+}

--- a/EGG9000.Test/StorageRoundTripTests.cs
+++ b/EGG9000.Test/StorageRoundTripTests.cs
@@ -1,0 +1,258 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Proto;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class StorageRoundTripTests {
+        private const string ContractId = "contract-storage-roundtrip";
+
+        private static (Ei.Backup Backup, FrozenSet<Ei.Contract> Contracts) BuildBackup() {
+            var contract = new Ei.Contract { Identifier = ContractId };
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                ContractIdentifier = ContractId,
+                CoopIdentifier = "coop-storage-roundtrip",
+                League = 1,
+                TimeAccepted = 1_650_000_000,
+                CoopSharedEndTime = 1_650_500_000,
+                BoostsUsed = 3,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+                NumGoalsAchieved = 2
+            };
+            var simulation = new Ei.Backup.Types.Simulation {
+                ContractId = ContractId,
+                FarmType = Ei.FarmType.Contract,
+                EggsPaidFor = 55.5,
+                NumChickens = 12345,
+                EggType = Ei.Egg.RocketFuel,
+                SilosOwned = 4
+            };
+
+            var backup = new Ei.Backup {
+                UserId = "backup-user-1",
+                EiUserId = "EI0000000000012345",
+                UserName = "ProtoName",
+                DeviceId = "device-proto-1",
+                Version = 41,
+                Game = new Ei.Backup.Types.Game {
+                    PermitLevel = 3,
+                    EggsOfProphecy = 11,
+                    SoulEggsD = 5432.25,
+                    CurrentMultiplier = 1.75,
+                    GoldenEggsEarned = 500,
+                    HyperloopStation = true,
+                    MaxEggReached = Ei.Egg.Medical,
+                    EpicResearch = { new Ei.Backup.Types.ResearchItem { Id = "soul_eggs", Level = 8 } }
+                },
+                Settings = new Ei.Backup.Types.Settings { LastBackupTime = 1_700_000_500 },
+                Stats = new Ei.Backup.Types.Stats { NumPrestiges = 6, DroneTakedowns = 9 },
+                Artifacts = new Ei.Backup.Types.Artifacts { CraftingXp = 77.5 },
+                Contracts = new Ei.MyContracts { Contracts = { localContract } },
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+            backup.Farms.Add(simulation);
+
+            return (backup, new List<Ei.Contract> { contract }.ToFrozenSet());
+        }
+
+        private static CustomBackup BuildLegacyBackup() {
+            return new CustomBackup {
+                EggIncId = "EI-legacy-0001",
+                UserName = "LegacyName",
+                LastBackupTime = 1_650_000_000,
+                EpicResearch = [new CustomResearch { Id = "soul_eggs", Level = 4 }],
+                PermitLevel = 2,
+                SoulEggs = 999.5,
+                NumPrestiges = 3,
+                HyperloopPurchased = true,
+                MaxEggReached = Ei.Egg.Tachyon,
+                Resets = 8
+            };
+        }
+
+        [TestMethod]
+        public void DBUser_BlobBackedAccount_SurvivesProductionStoragePath() {
+            var (proto, contracts) = BuildBackup();
+            var user = new DBUser();
+            user.EggIncAccounts = [new EggIncAccount { Id = "EI0000000000012345", Backup = new CustomBackup(proto, contracts) }];
+
+            Assert.IsNotNull(user._contractRegistrationByte);
+
+            var rehydrated = new DBUser { _contractRegistrationByte = user._contractRegistrationByte };
+            var accounts = rehydrated.EggIncAccounts;
+
+            Assert.AreEqual(1, accounts.Count);
+            var account = accounts.Single();
+            Assert.AreEqual("EI0000000000012345", account.Id);
+            Assert.IsNotNull(account.Backup);
+            Assert.IsNotNull(account.Backup.EiBackupBytes);
+            Assert.AreEqual("EI0000000000012345", account.Backup.EggIncId);
+            Assert.AreEqual("ProtoName", account.Backup.UserName);
+            Assert.AreEqual(1_700_000_500L, account.Backup.LastBackupTime);
+            Assert.AreEqual(5432.25, account.Backup.SoulEggs);
+            Assert.AreEqual((ushort)3, account.Backup.PermitLevel);
+            Assert.AreEqual(6UL, account.Backup.NumPrestiges);
+            Assert.AreEqual(Ei.Egg.Medical, account.Backup.MaxEggReached);
+            Assert.IsTrue(account.Backup.HyperloopPurchased);
+            Assert.AreEqual(77.5, account.Backup.CraftingXP);
+
+            var farm = account.Backup.Farms.Single();
+            Assert.AreEqual(ContractId, farm.ContractId);
+            Assert.AreEqual(12345UL, farm.NumChickens);
+            Assert.AreEqual("coop-storage-roundtrip", farm.CoopId);
+            Assert.AreEqual((uint?)1, farm.League);
+
+            Assert.AreEqual("device-proto-1", account.DeviceID);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeAa, account.LastGrade);
+        }
+
+        [TestMethod]
+        public void DBUser_CorruptStorageBytes_YieldEmptyAccountsWithoutThrowing() {
+            var user = new DBUser { _contractRegistrationByte = [0xC1, 0xFF, 0x00] };
+
+            var accounts = user.EggIncAccounts;
+
+            Assert.IsNotNull(accounts);
+            Assert.AreEqual(0, accounts.Count);
+        }
+
+        [TestMethod]
+        public void SoloFarm_SimulationGateSuppresses_WhileLegacyLocalContractValuesSurvive() {
+            var simulation = new Ei.Backup.Types.Simulation {
+                FarmType = Ei.FarmType.Home,
+                EggsPaidFor = 42.5,
+                NumChickens = 4242,
+                EggType = Ei.Egg.Tachyon,
+                SilosOwned = 3
+            };
+            var farm = new CustomFarm {
+                SimulationBytes = StorageTrimmer.TrimmedBytes(simulation),
+                LocalContractBytes = null,
+                League = 2,
+                CoopId = "legacy-coop",
+                TimeAccepted = 1_600_000_000,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeA,
+                BoostsUsed = 4
+            };
+            var backup = new CustomBackup { Farms = [farm] };
+
+            var bytes = MessagePackSerializer.Serialize(backup, StorageMessagePack.Options);
+            var back = MessagePackSerializer.Deserialize<CustomBackup>(bytes, StorageMessagePack.Options);
+            var soloFarm = back.Farms.Single();
+
+            Assert.IsNotNull(soloFarm.SimulationBytes);
+            Assert.IsNull(soloFarm.LocalContractBytes);
+            Assert.AreEqual(Ei.FarmType.Home, soloFarm.FarmType);
+            Assert.AreEqual(42.5, soloFarm.EggsPaidFor);
+            Assert.AreEqual(4242UL, soloFarm.NumChickens);
+            Assert.AreEqual(Ei.Egg.Tachyon, soloFarm.EggType);
+            Assert.AreEqual(3u, soloFarm.SilosOwned);
+            Assert.AreEqual((uint?)2, soloFarm.League);
+            Assert.AreEqual("legacy-coop", soloFarm.CoopId);
+            Assert.AreEqual(1_600_000_000L, soloFarm.TimeAccepted);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeA, soloFarm.Grade);
+            Assert.AreEqual((ushort)4, soloFarm.BoostsUsed);
+
+            soloFarm.SimulationBytes = null;
+
+            Assert.AreEqual(default(Ei.FarmType), soloFarm.FarmType);
+            Assert.AreEqual(0d, soloFarm.EggsPaidFor);
+            Assert.AreEqual(0UL, soloFarm.NumChickens);
+            Assert.AreEqual(default(Ei.Egg), soloFarm.EggType);
+            Assert.AreEqual(0u, soloFarm.SilosOwned);
+            Assert.AreEqual((uint?)2, soloFarm.League);
+            Assert.AreEqual("legacy-coop", soloFarm.CoopId);
+            Assert.AreEqual(1_600_000_000L, soloFarm.TimeAccepted);
+            Assert.AreEqual(Ei.Contract.Types.PlayerGrade.GradeA, soloFarm.Grade);
+            Assert.AreEqual((ushort)4, soloFarm.BoostsUsed);
+        }
+
+        [TestMethod]
+        public void MixedList_LegacyAndBlobBacked_SurviveTwoRoundTrips() {
+            var (proto, contracts) = BuildBackup();
+            var list = new List<CustomBackup> { BuildLegacyBackup(), new CustomBackup(proto, contracts) };
+
+            var first = MessagePackSerializer.Deserialize<List<CustomBackup>>(
+                MessagePackSerializer.Serialize(list, StorageMessagePack.Options), StorageMessagePack.Options);
+            AssertMixedListShape(first);
+
+            var second = MessagePackSerializer.Deserialize<List<CustomBackup>>(
+                MessagePackSerializer.Serialize(first, StorageMessagePack.Options), StorageMessagePack.Options);
+            AssertMixedListShape(second);
+        }
+
+        private static void AssertMixedListShape(List<CustomBackup> list) {
+            Assert.AreEqual(2, list.Count);
+
+            var legacy = list[0];
+            Assert.IsNull(legacy.EiBackupBytes);
+            Assert.AreEqual("EI-legacy-0001", legacy.EggIncId);
+            Assert.AreEqual("LegacyName", legacy.UserName);
+            Assert.AreEqual(1_650_000_000L, legacy.LastBackupTime);
+            Assert.AreEqual("soul_eggs", legacy.EpicResearch.Single().Id);
+            Assert.AreEqual((ushort)2, legacy.PermitLevel);
+            Assert.AreEqual(999.5, legacy.SoulEggs);
+            Assert.AreEqual(3UL, legacy.NumPrestiges);
+            Assert.IsTrue(legacy.HyperloopPurchased);
+            Assert.AreEqual(Ei.Egg.Tachyon, legacy.MaxEggReached);
+            Assert.AreEqual(8u, legacy.Resets);
+
+            var derived = list[1];
+            Assert.IsNotNull(derived.EiBackupBytes);
+            Assert.AreEqual("EI0000000000012345", derived.EggIncId);
+            Assert.AreEqual("ProtoName", derived.UserName);
+            Assert.AreEqual(1_700_000_500L, derived.LastBackupTime);
+            Assert.AreEqual("soul_eggs", derived.EpicResearch.Single().Id);
+            Assert.AreEqual((ushort)3, derived.PermitLevel);
+            Assert.AreEqual(5432.25, derived.SoulEggs);
+            Assert.AreEqual(6UL, derived.NumPrestiges);
+            Assert.IsTrue(derived.HyperloopPurchased);
+            Assert.AreEqual(Ei.Egg.Medical, derived.MaxEggReached);
+        }
+
+        [TestMethod]
+        public void EveryDerivedSlotType_ResolvesToDerivedSlotFormatter_InStorageOptions() {
+            var derivedSlotTypes = LoadableTypes(typeof(CustomBackup).Assembly)
+                .Where(t => t.IsClass && !t.IsAbstract)
+                .Where(t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                    .Any(p => p.GetCustomAttribute<DerivedSlotAttribute>() is not null))
+                .ToList();
+
+            CollectionAssert.Contains(derivedSlotTypes, typeof(CustomBackup));
+            CollectionAssert.Contains(derivedSlotTypes, typeof(CustomFarm));
+
+            var getFormatter = typeof(FormatterResolverExtensions)
+                .GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Single(m => m.Name == "GetFormatterWithVerify" && m.IsGenericMethodDefinition);
+
+            foreach(var type in derivedSlotTypes) {
+                var formatter = getFormatter.MakeGenericMethod(type).Invoke(null, [StorageMessagePack.Options.Resolver]);
+                Assert.IsNotNull(formatter, type.FullName);
+                var formatterType = formatter.GetType();
+                Assert.IsTrue(formatterType.IsGenericType && formatterType.GetGenericTypeDefinition() == typeof(DerivedSlotFormatter<>),
+                    $"{type.FullName} resolved {formatterType.FullName} instead of DerivedSlotFormatter");
+                Assert.AreEqual(type, formatterType.GetGenericArguments()[0], type.FullName);
+            }
+        }
+
+        private static IEnumerable<Type> LoadableTypes(Assembly assembly) {
+            try {
+                return assembly.GetTypes();
+            } catch(ReflectionTypeLoadException e) {
+                return e.Types.Where(t => t is not null).Select(t => t!);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because we ideally want to be able to query on any attribute we might have from a user, it makes sense to arrange our db objects as physical extensions of the EI proto objects they're "extending".

This sets up the framework for that, and uses it to clean up the implementation of CustomBackup.
This functionally decorates the `MessagePackObject` with our own intermediary layer to construct based on game defs.

I love modern .NET.