### PR TITLE
Chore: Swap DB Codec from LZ4 to GZip-Optimal

### DIFF
--- a/EGG9000.Common/Database/Entities/User.cs
+++ b/EGG9000.Common/Database/Entities/User.cs
@@ -157,7 +157,7 @@ namespace EGG9000.Common.Database.Entities {
                         return _accounts;
                     } else {
                         try {
-                            _accounts = MessagePackSerializer.Deserialize<List<EggIncAccount>>(_contractRegistrationByte, lz4Options);
+                            _accounts = StorageCodec.Unpack<List<EggIncAccount>>(_contractRegistrationByte);
                         } catch(MessagePackSerializationException) {
                             _accounts = [];
                             return _accounts;
@@ -238,7 +238,7 @@ namespace EGG9000.Common.Database.Entities {
         public bool UpdateAccounts() {
             if(_eggIncIds is not null)
                 _eggIncIds = null;
-            var compressedAccounts = MessagePackSerializer.Serialize(_accounts, lz4Options);
+            var compressedAccounts = StorageCodec.Pack(_accounts);
             var changed = compressedAccounts != _contractRegistrationByte;
             _contractRegistrationByte = compressedAccounts;
             Usernames = string.Join(",", _accounts?.Where(a => a.Backup != null).Select(a => a.Backup.UserName) ?? []);

--- a/EGG9000.Common/Database/StorageCodec.cs
+++ b/EGG9000.Common/Database/StorageCodec.cs
@@ -1,0 +1,43 @@
+using MessagePack;
+
+using System;
+using System.IO;
+using System.IO.Compression;
+
+namespace EGG9000.Common.Database {
+    public static class StorageCodec {
+        public static bool GZipWriteEnabled { get; set; }
+
+        private static readonly MessagePackSerializerOptions PlainOptions = StorageMessagePack.Options.WithCompression(MessagePackCompression.None);
+
+        static StorageCodec() {
+            var raw = Environment.GetEnvironmentVariable("EGG9000_STORAGE_GZIP");
+            GZipWriteEnabled = string.Equals(raw, "1", StringComparison.OrdinalIgnoreCase) || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static byte[] Pack<T>(T value) {
+            if(!GZipWriteEnabled)
+                return MessagePackSerializer.Serialize(value, StorageMessagePack.Options);
+            var plain = MessagePackSerializer.Serialize(value, PlainOptions);
+            using var output = new MemoryStream();
+            using(var gzip = new GZipStream(output, CompressionLevel.Optimal))
+                gzip.Write(plain, 0, plain.Length);
+            return output.ToArray();
+        }
+
+        public static T Unpack<T>(byte[] stored) {
+            if(stored is { Length: >= 2 } && stored[0] == 0x1F && stored[1] == 0x8B) {
+                try {
+                    using var input = new MemoryStream(stored, writable: false);
+                    using var gzip = new GZipStream(input, CompressionMode.Decompress);
+                    return MessagePackSerializer.Deserialize<T>(gzip, PlainOptions);
+                } catch(MessagePackSerializationException) {
+                    throw;
+                } catch(Exception e) {
+                    throw new MessagePackSerializationException("Failed to read gzip storage payload.", e);
+                }
+            }
+            return MessagePackSerializer.Deserialize<T>(stored, StorageMessagePack.Options);
+        }
+    }
+}

--- a/EGG9000.Test/StorageCodecTests.cs
+++ b/EGG9000.Test/StorageCodecTests.cs
@@ -1,0 +1,219 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class StorageCodecTests {
+        private const string ContractId = "contract-storage-codec";
+
+        private static readonly MessagePackSerializerOptions Plain =
+            StorageMessagePack.Options.WithCompression(MessagePackCompression.None);
+
+        private static (Ei.Backup Backup, FrozenSet<Ei.Contract> Contracts) BuildBackup() {
+            var contract = new Ei.Contract { Identifier = ContractId };
+            var localContract = new Ei.LocalContract {
+                Contract = contract,
+                ContractIdentifier = ContractId,
+                CoopIdentifier = "coop-storage-codec",
+                League = 1,
+                TimeAccepted = 1_650_000_000,
+                CoopSharedEndTime = 1_650_500_000,
+                BoostsUsed = 3,
+                Grade = Ei.Contract.Types.PlayerGrade.GradeAa,
+                NumGoalsAchieved = 2
+            };
+            var simulation = new Ei.Backup.Types.Simulation {
+                ContractId = ContractId,
+                FarmType = Ei.FarmType.Contract,
+                EggsPaidFor = 55.5,
+                NumChickens = 12345,
+                EggType = Ei.Egg.RocketFuel,
+                SilosOwned = 4
+            };
+
+            var backup = new Ei.Backup {
+                UserId = "backup-user-1",
+                EiUserId = "EI0000000000012345",
+                UserName = "ProtoName",
+                DeviceId = "device-proto-1",
+                Version = 41,
+                Game = new Ei.Backup.Types.Game {
+                    PermitLevel = 3,
+                    EggsOfProphecy = 11,
+                    SoulEggsD = 5432.25,
+                    CurrentMultiplier = 1.75,
+                    GoldenEggsEarned = 500,
+                    HyperloopStation = true,
+                    MaxEggReached = Ei.Egg.Medical,
+                    EpicResearch = { new Ei.Backup.Types.ResearchItem { Id = "soul_eggs", Level = 8 } }
+                },
+                Settings = new Ei.Backup.Types.Settings { LastBackupTime = 1_700_000_500 },
+                Stats = new Ei.Backup.Types.Stats { NumPrestiges = 6, DroneTakedowns = 9 },
+                Artifacts = new Ei.Backup.Types.Artifacts { CraftingXp = 77.5 },
+                Contracts = new Ei.MyContracts { Contracts = { localContract } },
+                ArtifactsDb = new Ei.ArtifactsDB()
+            };
+            backup.Farms.Add(simulation);
+
+            return (backup, new List<Ei.Contract> { contract }.ToFrozenSet());
+        }
+
+        private static CustomBackup BuildLegacyBackup() {
+            return new CustomBackup {
+                EggIncId = "EI-legacy-0001",
+                UserName = "LegacyName",
+                LastBackupTime = 1_650_000_000,
+                EpicResearch = [new CustomResearch { Id = "soul_eggs", Level = 4 }],
+                PermitLevel = 2,
+                SoulEggs = 999.5,
+                NumPrestiges = 3,
+                HyperloopPurchased = true,
+                MaxEggReached = Ei.Egg.Tachyon,
+                Resets = 8
+            };
+        }
+
+        private static List<EggIncAccount> BuildAccounts() {
+            var (proto, contracts) = BuildBackup();
+            return [
+                new EggIncAccount { Id = "EI-legacy-0001", Backup = BuildLegacyBackup() },
+                new EggIncAccount { Id = "EI0000000000012345", Backup = new CustomBackup(proto, contracts) }
+            ];
+        }
+
+        private static void AssertAccountsShape(List<EggIncAccount> accounts) {
+            Assert.AreEqual(2, accounts.Count);
+
+            var legacy = accounts[0].Backup;
+            Assert.IsNull(legacy.EiBackupBytes);
+            Assert.AreEqual("EI-legacy-0001", legacy.EggIncId);
+            Assert.AreEqual("LegacyName", legacy.UserName);
+            Assert.AreEqual(999.5, legacy.SoulEggs);
+            Assert.AreEqual(Ei.Egg.Tachyon, legacy.MaxEggReached);
+
+            var derived = accounts[1].Backup;
+            Assert.IsNotNull(derived.EiBackupBytes);
+            Assert.AreEqual("EI0000000000012345", derived.EggIncId);
+            Assert.AreEqual("ProtoName", derived.UserName);
+            Assert.AreEqual(5432.25, derived.SoulEggs);
+            Assert.AreEqual(ContractId, derived.Farms.Single().ContractId);
+            Assert.AreEqual(1, derived.ArchivedFarms.Count);
+        }
+
+        private static void AssertGzipMagic(byte[] bytes) {
+            Assert.IsNotNull(bytes);
+            Assert.IsTrue(bytes.Length >= 2);
+            Assert.AreEqual((byte)0x1F, bytes[0]);
+            Assert.AreEqual((byte)0x8B, bytes[1]);
+        }
+
+        [TestMethod]
+        public void Pack_DefaultOff_IsByteIdenticalToLegacyLz4_AndUnpacks() {
+            var prior = StorageCodec.GZipWriteEnabled;
+            StorageCodec.GZipWriteEnabled = false;
+            try {
+                var accounts = BuildAccounts();
+                var packed = StorageCodec.Pack(accounts);
+                var expected = MessagePackSerializer.Serialize(accounts, DBUser.lz4Options);
+                CollectionAssert.AreEqual(expected, packed);
+                AssertAccountsShape(StorageCodec.Unpack<List<EggIncAccount>>(packed));
+            } finally {
+                StorageCodec.GZipWriteEnabled = prior;
+            }
+        }
+
+        [TestMethod]
+        public void Pack_ToggleOn_WritesGzipMagic_AndRoundTrips() {
+            var prior = StorageCodec.GZipWriteEnabled;
+            StorageCodec.GZipWriteEnabled = true;
+            try {
+                var accounts = BuildAccounts();
+                var packed = StorageCodec.Pack(accounts);
+                AssertGzipMagic(packed);
+                AssertAccountsShape(StorageCodec.Unpack<List<EggIncAccount>>(packed));
+            } finally {
+                StorageCodec.GZipWriteEnabled = prior;
+            }
+        }
+
+        [TestMethod]
+        public void Unpack_LegacyLz4Bytes_ReadsIntact() {
+            var accounts = BuildAccounts();
+            var stored = MessagePackSerializer.Serialize(accounts, DBUser.lz4Options);
+            AssertAccountsShape(StorageCodec.Unpack<List<EggIncAccount>>(stored));
+        }
+
+        [TestMethod]
+        public void Unpack_PlainMsgpackBytes_ReadsIntact() {
+            var accounts = BuildAccounts();
+            var stored = MessagePackSerializer.Serialize(accounts, Plain);
+            AssertAccountsShape(StorageCodec.Unpack<List<EggIncAccount>>(stored));
+        }
+
+        [TestMethod]
+        public void Unpack_GzipMagicFollowedByGarbage_ThrowsMessagePackSerializationException() {
+            var corrupt = new byte[] { 0x1F, 0x8B, 0x99, 0x11, 0x22, 0x33, 0x44 };
+            Assert.ThrowsExactly<MessagePackSerializationException>(() => StorageCodec.Unpack<List<EggIncAccount>>(corrupt));
+        }
+
+        [TestMethod]
+        public void DBUser_ToggleOn_WritesGzipColumn_SecondUserRehydrates() {
+            var prior = StorageCodec.GZipWriteEnabled;
+            StorageCodec.GZipWriteEnabled = true;
+            try {
+                var (proto, contracts) = BuildBackup();
+                var user = new DBUser();
+                user.EggIncAccounts = [new EggIncAccount { Id = "EI0000000000012345", Backup = new CustomBackup(proto, contracts) }];
+
+                AssertGzipMagic(user._contractRegistrationByte);
+
+                var rehydrated = new DBUser { _contractRegistrationByte = user._contractRegistrationByte };
+                var accounts = rehydrated.EggIncAccounts;
+
+                Assert.AreEqual(1, accounts.Count);
+                var account = accounts.Single();
+                Assert.AreEqual("EI0000000000012345", account.Id);
+                Assert.IsNotNull(account.Backup);
+                Assert.AreEqual("EI0000000000012345", account.Backup.EggIncId);
+                Assert.AreEqual(5432.25, account.Backup.SoulEggs);
+                Assert.AreEqual(ContractId, account.Backup.Farms.Single().ContractId);
+                Assert.AreEqual(1, account.Backup.ArchivedFarms.Count);
+                Assert.AreEqual("device-proto-1", account.DeviceID);
+            } finally {
+                StorageCodec.GZipWriteEnabled = prior;
+            }
+        }
+
+        [TestMethod]
+        public void DBUser_ToggleOn_LegacyLz4Row_StillReads() {
+            var prior = StorageCodec.GZipWriteEnabled;
+            StorageCodec.GZipWriteEnabled = true;
+            try {
+                var stored = MessagePackSerializer.Serialize(BuildAccounts(), DBUser.lz4Options);
+                var user = new DBUser { _contractRegistrationByte = stored };
+                AssertAccountsShape(user.EggIncAccounts);
+            } finally {
+                StorageCodec.GZipWriteEnabled = prior;
+            }
+        }
+
+        [TestMethod]
+        public void DBUser_CorruptGzipColumn_YieldsEmptyAccountsWithoutThrowing() {
+            var user = new DBUser { _contractRegistrationByte = [0x1F, 0x8B, 0x99, 0x11, 0x22] };
+
+            var accounts = user.EggIncAccounts;
+
+            Assert.IsNotNull(accounts);
+            Assert.AreEqual(0, accounts.Count);
+        }
+    }
+}


### PR DESCRIPTION
See here:
https://discord.com/channels/1108127105088241746/1510778079168041161/1540491829177360435

GZip saves us ~30% of storage space, at the cost of ~40-50ms per minute (really hard to estimate this).
LZ4 is laughably bad when it comes to proto compression, seemingly fundamentally, due to the way the algorithm collides with bitpacks from protobuf...

Once this is merged, `EGG9000_STORAGE_GZIP` will need to be set to `1`/`true` to in-place-migrate the DB from LZ4 to GZip during next run. Once that migration has happened, we can remove all references to LZ4, and "adopt GZip as standard."