### PR TITLE
Fix + Chore: Xref State Matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+[Dd]ist/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/EGG9000.Bot/Automated/ContractUpdater.cs
+++ b/EGG9000.Bot/Automated/ContractUpdater.cs
@@ -103,7 +103,7 @@ namespace EGG9000.Bot.Automated {
                     _logger.LogInformation("Adding co-op {coopname} from backups", coopname);
                     var coop = new Coop {
                         ContractID = contractid, Created = DateTimeOffset.UtcNow, GuildId = guildid, Name = coopname,
-                        MaxUsers = contract.MaxUsers, Status = CoopStatusEnum.WaitingOnThread, League = grade,
+                        MaxUsers = contract.MaxUsers, Status = CoopStatus.WaitingOnThread, League = grade,
                         CoopEnds = DateTimeOffset.FromUnixTimeSeconds(endtime),
                         AddedFromBackup = true,
                     };

--- a/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopThreads.cs
@@ -45,7 +45,7 @@ namespace EGG9000.Bot.Automated.Coops {
             Dictionary<(ulong guildid, string contractid, ulong bggroup), (int successes, int failures, bool changed)> guildStats = [];
 
             while(
-                (allCoops = await _db.Coops.Include(c => c.Contract).AsQueryable().Where(x => x.Status == CoopStatusEnum.WaitingOnThread && x.ContractID != "first-contract").OrderByDescending(x => x.MaxUsers).ToListAsync(CancellationToken.None))
+                (allCoops = await _db.Coops.Include(c => c.Contract).AsQueryable().Where(x => x.Status == CoopStatus.WaitingOnThread && x.ContractID != "first-contract").OrderByDescending(x => x.MaxUsers).ToListAsync(CancellationToken.None))
                 .Count > 0) {
                 if(cancellationToken.IsCancellationRequested) return;
 
@@ -136,7 +136,7 @@ namespace EGG9000.Bot.Automated.Coops {
                             var coopThread = await _queue.EnqueueLowAsync(() => CreateThreadChannelAsync(coop.Name, headerChannel));
                             if(coopThread != null) {
                                 timings.Set("Thread created");
-                                coop.Status = CoopStatusEnum.WaitingOnAssigned;
+                                coop.Status = CoopStatus.WaitingOnAssigned;
                                 coop.ThreadID = coopThread.Id;
                                 coop.ThreadParentChannel = headerChannel.Id;
                                 coop.OverflowGuildId = headerChannel.Guild.Id;

--- a/EGG9000.Bot/Automated/Coops/CreateCoopViaAPI.cs
+++ b/EGG9000.Bot/Automated/Coops/CreateCoopViaAPI.cs
@@ -34,7 +34,7 @@ namespace EGG9000.Bot.Automated.Coops {
             Dictionary<(ulong guildid, string contractid, ulong bggroup), (int successes, int failures, bool changed)> guildStats = [];
 
             while(
-                (allCoops = await _db.Coops.Include(c => c.Contract).AsQueryable().Where(x => x.Status == CoopStatusEnum.WaitingOnCreation).OrderByDescending(x => x.MaxUsers).ToListAsync(CancellationToken.None))
+                (allCoops = await _db.Coops.Include(c => c.Contract).AsQueryable().Where(x => x.Status == CoopStatus.WaitingOnCreation).OrderByDescending(x => x.MaxUsers).ToListAsync(CancellationToken.None))
                 .Count > 0) {
                 if(cancellationToken.IsCancellationRequested) return;
 
@@ -85,7 +85,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
 
 
-                            coop.Status = CoopStatusEnum.WaitingOnThread;
+                            coop.Status = CoopStatus.WaitingOnThread;
                             using var writeScope = _provider.CreateScope();
                             var writeDb = writeScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
                             await writeDb.Coops.Where(c => c.Id == coop.Id).ExecuteUpdateAsync(s => s

--- a/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.ProcessCoop.cs
+++ b/EGG9000.Bot/Automated/Coops/ThreadsCoopStatusUpdater.ProcessCoop.cs
@@ -334,11 +334,11 @@ namespace EGG9000.Bot.Automated.Coops {
 
                 if(!ctx.Coop.Finished && ctx.Status.Finished()) {
                     if(ctx.WaitingOn.Any()) {
-                        ctx.Coop.Status = CoopStatusEnum.Completed;
+                        ctx.Coop.Status = CoopStatus.Completed;
                         _queue.EnqueueLow(() => ctx.CoopThread.SendMessageAsync($"Coop {ctx.Coop.Name} is finished, and is waiting for users to check-in!"));
                     } else {
                         ctx.FinalChannelUpdate = true;
-                        ctx.Coop.Status = CoopStatusEnum.CompletedAllCheckIn;
+                        ctx.Coop.Status = CoopStatus.CompletedAllCheckIn;
                         ctx.Coop.ThreadArchived = true;
                         _queue.EnqueueLow(() => ctx.CoopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay));
                         _queue.EnqueueLow(() => ctx.CoopThread.SendMessageAsync($"Coop {ctx.Coop.Name} is finished!"));
@@ -350,9 +350,9 @@ namespace EGG9000.Bot.Automated.Coops {
                     await HandleUnjoins(ctx.UsersNotJoined, ctx.Users, ctx.DbGuild, ctx.Coop, ctx.Db, ctx.CoopThread);
                 }
 
-                if(ctx.Coop.Finished && ctx.Coop.Status != CoopStatusEnum.CompletedAllCheckIn && !ctx.WaitingOn.Any()) {
+                if(ctx.Coop.Finished && ctx.Coop.Status != CoopStatus.CompletedAllCheckIn && !ctx.WaitingOn.Any()) {
                     ctx.FinalChannelUpdate = true;
-                    ctx.Coop.Status = CoopStatusEnum.CompletedAllCheckIn;
+                    ctx.Coop.Status = CoopStatus.CompletedAllCheckIn;
                     ctx.Coop.ThreadArchived = true;
                     _queue.EnqueueLow(() => ctx.CoopThread.ModifyAsync(t => t.AutoArchiveDuration = ThreadArchiveDuration.OneDay));
                     await ctx.Db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None, logger: _logger);
@@ -484,8 +484,8 @@ namespace EGG9000.Bot.Automated.Coops {
         private async Task ProcessUnjoinedParticipants(CoopProcessingContext ctx) {
             ctx.MissingFromServer = false;
             ctx.Timings.Set("5.4");
-            if(ctx.UsersNotJoined.Count == 0 && ctx.Coop.Status != CoopStatusEnum.Completed && ctx.Coop.Status != CoopStatusEnum.Failed && ctx.Coop.Status != CoopStatusEnum.CompletedAllCheckIn) {
-                ctx.Coop.Status = CoopStatusEnum.AllAssignedJoined;
+            if(ctx.UsersNotJoined.Count == 0 && !ctx.Coop.FinishedOrFailed()) {
+                ctx.Coop.Status = CoopStatus.AllAssignedJoined;
             } else {
                 var userList = new List<string>();
                 foreach(var userFarmDetails in ctx.UsersNotJoined) {
@@ -517,7 +517,7 @@ namespace EGG9000.Bot.Automated.Coops {
 
                         userList.Add(mention);
 
-                        if(!ctx.Coop.Finished && ctx.Coop.Status != CoopStatusEnum.Failed && ctx.Coop.CoopEnds > DateTimeOffset.UtcNow) {
+                        if(!ctx.Coop.Finished && ctx.Coop.Status != CoopStatus.Failed && ctx.Coop.CoopEnds > DateTimeOffset.UtcNow) {
                             if(discordUser != null) {
                                 if(!userFarmDetails.Xref.JoinWarning24TillFinish && ctx.TimeRemaining.TotalHours < 24 && userFarmDetails.Xref.CreatedOn < DateTimeOffset.UtcNow.AddHours(-1)) {
                                     userFarmDetails.Xref.JoinWarning24TillFinish = true;
@@ -741,19 +741,19 @@ namespace EGG9000.Bot.Automated.Coops {
         }
 
         private void ApplyFullStatus(CoopProcessingContext ctx) {
-            if(ctx.Status.Contributors.Count == ctx.Coop.MaxUsers && ctx.Coop.Status != CoopStatusEnum.Completed && ctx.Coop.Status != CoopStatusEnum.Failed) {
-                ctx.Coop.Status = CoopStatusEnum.Full;
+            if(ctx.Status.Contributors.Count == ctx.Coop.MaxUsers && ctx.Coop.Status != CoopStatus.Completed && ctx.Coop.Status != CoopStatus.Failed) {
+                ctx.Coop.Status = CoopStatus.Full;
             }
         }
 
         private async Task ApplyFailedStatus(CoopProcessingContext ctx) {
-            if(ctx.Coop.Status != CoopStatusEnum.Failed && ctx.Status.Failed()) {
+            if(ctx.Coop.Status != CoopStatus.Failed && ctx.Status.Failed()) {
                 if(ctx.Coop.Contract.GoodUntil > DateTimeOffset.UtcNow) {
                     _queue.EnqueueLow(() => ctx.CoopThread.SendMessageAsync($"Co-op {ctx.Coop.Name} failed to reach all the goals and the contract is still available for {(ctx.Coop.Contract.GoodUntil - DateTimeOffset.UtcNow).Humanize()} if you want to restart and try again."));
                 } else {
                     _queue.EnqueueLow(() => ctx.CoopThread.SendMessageAsync($"Co-op {ctx.Coop.Name} failed to reach all the goals and the contract is no longer available."));
                 }
-                ctx.Coop.Status = CoopStatusEnum.Failed;
+                ctx.Coop.Status = CoopStatus.Failed;
                 ctx.FinalChannelUpdate = true;
                 ctx.Coop.ThreadArchived = true;
                 await ctx.Db.SaveChangesAsyncRetry(cancellationToken: CancellationToken.None, logger: _logger);
@@ -783,7 +783,7 @@ namespace EGG9000.Bot.Automated.Coops {
         private void BuildEmojisAndColor(CoopProcessingContext ctx) {
             ctx.Emojis = "";
             ctx.EmbedColor = Color.DarkGrey;
-            if(ctx.Coop.Status == CoopStatusEnum.Failed) {
+            if(ctx.Coop.Status == CoopStatus.Failed) {
                 ctx.Emojis += "🚩";
             } else if(ctx.Coop.Finished) {
                 ctx.Emojis += "🏁";
@@ -932,7 +932,7 @@ namespace EGG9000.Bot.Automated.Coops {
                     if(ctx.Status.TotalAmount > goal.TargetAmount) {
                         title += "✅";
                         time = "";
-                    } else if(ctx.Coop.Status == CoopStatusEnum.Failed) {
+                    } else if(ctx.Coop.Status == CoopStatus.Failed) {
                         title += "❌";
                         time = "";
                     } else if(ctx.CoopDetails.PercentProjectedForJoined > goal.TargetAmount) {
@@ -952,7 +952,7 @@ namespace EGG9000.Bot.Automated.Coops {
             }
 
             var totalRatePerHour = ctx.TotalRate * 60 * 60;
-            if(ctx.Coop.Status != CoopStatusEnum.Completed && ctx.Coop.Status != CoopStatusEnum.Failed) {
+            if(ctx.Coop.Status != CoopStatus.Completed && ctx.Coop.Status != CoopStatus.Failed) {
                 ctx.EmbedBuilder.AddField("Co-op Expires", ends, inline: true);
 
                 if(ctx.RemainingAmount > 0) {
@@ -980,10 +980,10 @@ namespace EGG9000.Bot.Automated.Coops {
                 ctx.EmbedBuilder.AddField("Projected Amount", $"{ctx.CoopDetails.Projected.ToEggString()} of {ctx.TargetAmount.ToEggString()} {Math.Round(ctx.CoopDetails.PercentProjectedForJoined)}%", inline: true);
                 ctx.EmbedBuilder.AddField("Current Amount", ctx.Status.TotalAmount.ToEggString(), inline: true);
                 ctx.EmbedBuilder.AddField("Current With Offline", ctx.AmountWithOffline.ToEggString(), inline: true);
-            } else if(ctx.Coop.Status == CoopStatusEnum.Completed) {
+            } else if(ctx.Coop.Status == CoopStatus.Completed) {
                 ctx.EmbedBuilder.AddField("Final Amount", ctx.Status.TotalAmount.ToEggString(), inline: true);
                 ctx.EmbedBuilder.AddField("Final Rate", totalRatePerHour.ToEggString() + "/h", inline: true);
-            } else if(ctx.Coop.Status == CoopStatusEnum.Failed) {
+            } else if(ctx.Coop.Status == CoopStatus.Failed) {
                 ctx.EmbedBuilder.AddField("Final Amount", ctx.Status.TotalAmount.ToEggString(), inline: true);
                 ctx.EmbedBuilder.AddField("Final Rate", totalRatePerHour.ToEggString() + "/h", inline: true);
             }

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -121,10 +121,15 @@ namespace EGG9000.Bot.Commands {
             public Coop FoundCoop { get; set; } = null;
         }
 
+        internal static async Task<List<UserCoopXref>> GetActiveUserCoopXrefsAsync(ApplicationDbContext db, DBUser user) {
+            var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).ThenInclude(x => x.Contract).Where(x => x.User == user).ToListAsync();
+            return [.. xrefs.Where(x => !x.Coop.FinishedOrFailedOrExpired())];
+        }
+
         public static async Task<PotentialCoopResponse> FindPotentialCoopForUser(EggIncAccount account, DBContract contract, Guild guild, DiscordSocketClient _client, ApplicationDbContext db, FindCoopPrioritization priority = FindCoopPrioritization.FinishTimeLow) {
 
             var userXrefs = await db.UserCoopXrefs.Include(x => x.Coop).ThenInclude(x => x.Contract).Include(x => x.Coop).Where(x => x.EggIncId == account.Id).ToListAsync();
-            var existingCoop = userXrefs.FirstOrDefault(r => r.Coop.Contract == contract && (int)r.Coop.Status > 2 && (int)r.Coop.Status < 13 && r.Coop.CoopEnds > DateTimeOffset.UtcNow);
+            var existingCoop = userXrefs.FirstOrDefault(r => r.Coop.Contract == contract && r.Coop.IsOpenForAssignment() && r.Coop.CoopEnds > DateTimeOffset.UtcNow);
 
             if(contract.cc_only && !account.HasActiveSubscription()) {
                 return new() { Response = PotentialCoopCode.NonUltra };
@@ -139,24 +144,21 @@ namespace EGG9000.Bot.Commands {
                 && c.GuildId == guild.Id
                 && (c.League == (uint)account.GetGrade() || c.AnyLeague)
                 && c.CurrentUsers < c.MaxUsers
-                && (int)c.Status > 2 && (int)c.Status < 13
+                && CoopStatusSets.OpenForAssignment.Contains(c.Status)
                 && c.CoopEnds > DateTimeOffset.UtcNow
                 && !c.PseudoExpired
                 && c.ProjectedFinish > DateTimeOffset.UtcNow
             ).ToListAsync();
+            if(coops.Count == 0) return new() { Response = PotentialCoopCode.NoSpots1 };
 
-            if(!coops.Any()) {
-                return new() { Response = PotentialCoopCode.NoSpots1 };
-            }
-
-            _ = priority switch {
-                FindCoopPrioritization.FinishTimeLow => coops = [.. coops.OrderBy(c => c.ProjectedFinish)],
-                FindCoopPrioritization.FinishTimeHigh => coops = [.. coops.OrderByDescending(c => c.ProjectedFinish)],
-                FindCoopPrioritization.LowPlayerCount => coops = [.. coops.OrderBy(c => c.UserCoopsXrefs.Count)],
-                FindCoopPrioritization.HighPlayerCount => coops = [.. coops.OrderByDescending(c => c.UserCoopsXrefs.Count)],
-                FindCoopPrioritization.NeedsHighEB => coops = [.. coops.OrderBy(c => c.UserCoopsXrefs.Max(x => x.SoulPower))],
-                FindCoopPrioritization.HasHighEB => coops = [.. coops.OrderByDescending(c => c.UserCoopsXrefs.Max(x => x.SoulPower))],
-                _ => coops = [.. coops.OrderBy(c => c.ProjectedFinish)],
+            coops = priority switch {
+                FindCoopPrioritization.FinishTimeLow => [.. coops.OrderBy(c => c.ProjectedFinish)],
+                FindCoopPrioritization.FinishTimeHigh => [.. coops.OrderByDescending(c => c.ProjectedFinish)],
+                FindCoopPrioritization.LowPlayerCount => [.. coops.OrderBy(c => c.UserCoopsXrefs.Count)],
+                FindCoopPrioritization.HighPlayerCount => [.. coops.OrderByDescending(c => c.UserCoopsXrefs.Count)],
+                FindCoopPrioritization.NeedsHighEB => [.. coops.OrderBy(c => c.UserCoopsXrefs.Max(x => x.SoulPower))],
+                FindCoopPrioritization.HasHighEB => [.. coops.OrderByDescending(c => c.UserCoopsXrefs.Max(x => x.SoulPower))],
+                _ => [.. coops.OrderBy(c => c.ProjectedFinish)],
             };
 
             var customEggs = await db.GetCustomEggsAsync();
@@ -258,7 +260,7 @@ namespace EGG9000.Bot.Commands {
             }
 
             var coops = await Db.Coops.Include(x => x.UserCoopsXrefs).Where(x => x.GuildId == targetCoop.GuildId && x.ContractID == targetCoop.ContractID && x.League == newgrade
-                && x.CurrentUsers < x.MaxUsers && (int)x.Status > 2 && (int)x.Status < 13 && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
+                && x.CurrentUsers < x.MaxUsers && CoopStatusSets.OpenForAssignment.Contains(x.Status) && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
 
             if(coops.Count == 0) {
                 await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"No open spots found for {PlayerGradeDetails.GetEmoji((PlayerGrade)newgrade)} {targetCoop.Contract.Name}"); });
@@ -418,7 +420,7 @@ namespace EGG9000.Bot.Commands {
                     GuildId = guildContract.GuildID,
                     Name = coopname,
                     MaxUsers = guildContract.Contract.MaxUsers,
-                    Status = CoopStatusEnum.WaitingOnThread,
+                    Status = CoopStatus.WaitingOnThread,
                     League = grade,
                     AnyLeague = anygrade,
                     CoopEnds = DateTimeOffset.UtcNow.AddSeconds(status.SecondsRemaining),
@@ -607,10 +609,10 @@ namespace EGG9000.Bot.Commands {
             var dbguild = await Db.Guilds.FirstAsync(x => x.Id == user.GuildId);
             var guildContract = await Db.GuildContracts.FirstOrDefaultAsync(gc => gc.GuildID == dbguild.Id && gc.Contract == contract);
 
-            var subscriptionAccountsCount = user.EggIncAccounts.Where(x => x.HasActiveSubscription()).Count();
+            var subscriptionAccountsCount = user.EggIncAccounts.Count(x => x.HasActiveSubscription());
 
-            var existContractXrefs = await Db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User == user && x.Coop.Contract == contract && x.Coop.Status != CoopStatusEnum.Failed && x.Coop.Status != CoopStatusEnum.Completed && x.Coop.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
-            var activeXrefs = await Db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User == user && x.Coop.Status != CoopStatusEnum.Failed && x.Coop.Status != CoopStatusEnum.Completed && x.Coop.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
+            var activeXrefs = await ContractCommandsSlash.GetActiveUserCoopXrefsAsync(Db, user);
+            var existContractXrefs = activeXrefs.Where(x => x.Coop.Contract == contract).ToList();
             if(user.EggIncAccounts.Count == 1 || (contract.cc_only && subscriptionAccountsCount == 1)) {
 
                 EggIncAccount subAccountBypass = null;
@@ -625,7 +627,7 @@ namespace EGG9000.Bot.Commands {
 
                 var accountHasUltra = (subAccountBypass ?? user.EggIncAccounts.First()).HasActiveSubscription();
 
-                if(existContractXrefs is not null && existContractXrefs.Any(x => x.EggIncId == (subAccountBypass?.Id ?? user.EggIncAccounts?.First().Id))) {
+                if(existContractXrefs.Any(x => x.EggIncId == (subAccountBypass?.Id ?? user.EggIncAccounts?.First().Id))) {
                     var xref = existContractXrefs.First();
                     await Context.Interaction.ModifyOriginalResponseAsync(x => {
                         x.Content = ""; x.Embed = EmbedError($"You already have an assigned coop for <#{guildContract.DiscordChannelId}>. A new one was not created. Access your existing coop here: " +
@@ -634,7 +636,7 @@ namespace EGG9000.Bot.Commands {
                     return;
                 }
 
-                if(activeXrefs is not null && activeXrefs.Count(x => x.EggIncId == (subAccountBypass?.Id ?? user.EggIncAccounts?.First().Id)) >= 4) {
+                if(activeXrefs.Count(x => x.EggIncId == (subAccountBypass?.Id ?? user.EggIncAccounts?.First().Id)) >= 4) {
                     await Context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"You have 4 active coops, and cannot be assigned a new one at this time. Try again when a current coop finishes."); });
                     return;
                 }
@@ -682,7 +684,7 @@ namespace EGG9000.Bot.Commands {
                     .Where(x => x.UserId == dbUser.Id
                              && !x.JoinedCoop
                              && x.Coop.ContractID == guildContract.ContractID
-                             && (int)x.Coop.Status > 2 && (int)x.Coop.Status < 13
+                             && CoopStatusSets.OpenForAssignment.Contains(x.Coop.Status)
                              && x.Coop.CoopEnds > DateTimeOffset.UtcNow && !x.Coop.PseudoExpired)
                     .Select(x => new AssignedCoop(x.Coop.Id, x.Coop.ThreadID, x.Coop.Name, x.Coop.ContractID))
                     .ToListAsync())
@@ -726,8 +728,8 @@ namespace EGG9000.Bot.Commands {
             var account = user.EggIncAccounts.First(x => x.Id == data.Split("|")[1]);
 
             var guildContract = await Db.GuildContracts.FirstAsync(gc => gc.GuildID == user.GuildId && gc.Contract == contract);
-            var existingXrefs = await Db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User == user && x.Coop.Contract == contract && x.Coop.Status != CoopStatusEnum.Failed && x.Coop.Status != CoopStatusEnum.Completed && x.Coop.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
-            var activeXrefs = await Db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User == user && x.Coop.Status != CoopStatusEnum.Failed && x.Coop.Status != CoopStatusEnum.Completed && x.Coop.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
+            var activeXrefs = await ContractCommandsSlash.GetActiveUserCoopXrefsAsync(Db, user);
+            var existingXrefs = activeXrefs.Where(x => x.Coop.Contract == contract).ToList();
 
             var userList = new List<UserByAccount> { new() {
                     Account = account,
@@ -825,13 +827,13 @@ namespace EGG9000.Bot.Commands {
                     return;
                 case ContractCommandsSlash.PotentialCoopCode.NoSpots1:
                 case ContractCommandsSlash.PotentialCoopCode.NoSpots2:
-                    _ = Emote.TryParse(PlayerGradeDetails.GetEmoji(account.LastGrade), out var emote);
-                    await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"No open{(contract.cc_only ? "" : $" Grade {PlayerGradeDetails.GetEmoji(account.GetGrade())}")} coop spots found for {contract.Name}"); });
+                    _ = Emote.TryParse(PlayerGradeDetails.GetEmoji(account.GetGrade()), out var gradeEmote);
+                    await component.ModifyOriginalResponseAsync(x => { x.Content = ""; x.Embed = EmbedError($"No open{(contract.cc_only ? "" : $" {gradeEmote}")} coop spots found for {contract.Name}"); });
                     return;
                 default:
                     var customEggs = await Db.GetCustomEggsAsync();
                     var coop = newCoopResponse.FoundCoop;
-                    var users = coop.UserCoopsXrefs.Select(c => c.User).ToList().SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList();
+                    var users = coop.UserCoopsXrefs.Select(c => c.User).SelectMany(x => x.EggIncAccounts.Select(y => new UserWithBackup { Backup = y.Backup, User = x })).ToList();
                     var statusReponse = await EggIncApi.GetCoopStatus(coop.ContractID, coop.Name);
                     if(statusReponse is null || !statusReponse.Success || statusReponse.Contributors is null) {
                         statusReponse = coop.LastStatusUpdate; //Fallback to last known status
@@ -1009,8 +1011,8 @@ namespace EGG9000.Bot.Commands {
             var account = user.EggIncAccounts.First(x => x.Id == data.Split("|")[1]);
 
             var guildContract = await Db.GuildContracts.FirstAsync(gc => gc.GuildID == user.GuildId && gc.Contract == contract);
-            var existingXrefs = await Db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User == user && x.Coop.Contract == contract && x.Coop.Status != CoopStatusEnum.Failed && x.Coop.Status != CoopStatusEnum.Completed && x.Coop.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
-            var activeXrefs = await Db.UserCoopXrefs.Include(x => x.Coop).Where(x => x.User == user && x.Coop.Status != CoopStatusEnum.Failed && x.Coop.Status != CoopStatusEnum.Completed && x.Coop.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
+            var activeXrefs = await ContractCommandsSlash.GetActiveUserCoopXrefsAsync(Db, user);
+            var existingXrefs = activeXrefs.Where(x => x.Coop.Contract == contract).ToList();
 
             var userList = new List<UserByAccount> { new() {
                 Account = account,
@@ -1138,8 +1140,8 @@ namespace EGG9000.Bot.Commands {
             var verbiage = response.Success ? "is now private." : "**may** now be private.\n-# (API success was false)";
             var embedType = response.Success ? EmbedHelpers.EmbedType.Success : EmbedHelpers.EmbedType.Warning;
             await Context.Interaction.ModifyOriginalResponseAsync(x => {
-               x.Content = "";
-               x.Embed =  EmbedCustom(embedType, titleVerbiage, $"{coop.Name} {verbiage}");
+                x.Content = "";
+                x.Embed = EmbedCustom(embedType, titleVerbiage, $"{coop.Name} {verbiage}");
             });
         }
 

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -122,8 +122,9 @@ namespace EGG9000.Bot.Commands {
         }
 
         internal static async Task<List<UserCoopXref>> GetActiveUserCoopXrefsAsync(ApplicationDbContext db, DBUser user) {
-            var xrefs = await db.UserCoopXrefs.Include(x => x.Coop).ThenInclude(x => x.Contract).Where(x => x.User == user).ToListAsync();
-            return [.. xrefs.Where(x => !x.Coop.FinishedOrFailedOrExpired())];
+            return await db.UserCoopXrefs.Include(x => x.Coop).ThenInclude(x => x.Contract)
+                .Where(x => x.User == user && !CoopStatusSets.FinishedOrFailed.Contains(x.Coop.Status) && x.Coop.CoopEnds > DateTimeOffset.UtcNow)
+                .ToListAsync();
         }
 
         public static async Task<PotentialCoopResponse> FindPotentialCoopForUser(EggIncAccount account, DBContract contract, Guild guild, DiscordSocketClient _client, ApplicationDbContext db, FindCoopPrioritization priority = FindCoopPrioritization.FinishTimeLow) {
@@ -313,7 +314,7 @@ namespace EGG9000.Bot.Commands {
 
             if(gradeRole != null) {
                 var mainGuild = _gateway.Guilds.FirstOrDefault(g => g.Id == dbGuild.DiscordSeverId);
-                var socketGradeRole = mainGuild.GetRole(gradeRole.Id);
+                var socketGradeRole = await mainGuild.GetRoleAsync(gradeRole.Id);
                 await mainGuild.GetUser(dbuser.DiscordId).AddRoleAsync(socketGradeRole.Id);
                 if(mainGuild.Id != currentGuild.Id) {
                     var currentGuildSocketRole = currentGuild.Roles.FirstOrDefault(r => r.Name == socketGradeRole.Name);
@@ -323,7 +324,7 @@ namespace EGG9000.Bot.Commands {
                 }
             }
 
-            var coopChannel = _gateway.GetChannel(newCoop.ThreadID);
+            var coopChannel = await _gateway.GetChannelAsync(newCoop.ThreadID);
 
             var newxref = await CreateCoopsV2.MoveUser(newCoop, dbuser.Id, account.Id, account.Backup?.UserName ?? "(No Name)", Db, discordUser, dbuser, (SocketThreadChannel)coopChannel, (SocketTextChannel)Context.Channel);
             if(newxref == null) {

--- a/EGG9000.Bot/Commands/StaffCommands.cs
+++ b/EGG9000.Bot/Commands/StaffCommands.cs
@@ -372,7 +372,7 @@ namespace EGG9000.Bot.Commands {
         public async Task CoopStats() {
             var command = Context.Interaction;
             await command.DeferAsync();
-            var coops = await Db.Coops.Where(x => !x.Finished && x.Status != CoopStatusEnum.Failed && x.GuildId == command.GuildId && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
+            var coops = await Db.Coops.Where(x => !x.Finished && x.Status != CoopStatus.Failed && x.GuildId == command.GuildId && x.CoopEnds > DateTimeOffset.UtcNow).ToListAsync();
             var stats = new StringBuilder();
             stats.AppendLine($"**Coop Threads Last Updated**");
             var coopGroups = coops.Where(x => x.LastUpdateToChannel is not null).GroupBy(x => Math.Ceiling((DateTimeOffset.UtcNow - x.LastUpdateToChannel.Value).TotalHours));

--- a/EGG9000.Bot/Commands/TestSuiteCommands.cs
+++ b/EGG9000.Bot/Commands/TestSuiteCommands.cs
@@ -54,7 +54,7 @@ namespace EGG9000.Bot.Commands {
             }
 
             var maxUsers = contract.MaxUsers > 0 ? contract.MaxUsers : 10;
-            CoopStatusEnum[] cycle = [CoopStatusEnum.AllAssignedJoined, CoopStatusEnum.WaitingOnThread, CoopStatusEnum.Completed];
+            CoopStatus[] cycle = [CoopStatus.AllAssignedJoined, CoopStatus.WaitingOnThread, CoopStatus.Completed];
 
             var seeded = new List<Coop>();
             for(var i = 0; i < count; i++) {
@@ -66,8 +66,8 @@ namespace EGG9000.Bot.Commands {
                     Status = status,
                     League = 0,
                     MaxUsers = maxUsers,
-                    CurrentUsers = status == CoopStatusEnum.WaitingOnThread ? 0 : 1 + (i % maxUsers),
-                    ThreadID = status == CoopStatusEnum.WaitingOnThread ? 0ul : (ulong)(1_000_000 + i),
+                    CurrentUsers = status == CoopStatus.WaitingOnThread ? 0 : 1 + (i % maxUsers),
+                    ThreadID = status == CoopStatus.WaitingOnThread ? 0ul : (ulong)(1_000_000 + i),
                     CoopEnds = DateTimeOffset.UtcNow.AddDays(2),
                     Created = DateTimeOffset.UtcNow,
                     AddedFromBackup = true,
@@ -84,7 +84,7 @@ namespace EGG9000.Bot.Commands {
                 var gc = await Db.GuildContracts.FirstOrDefaultAsync(c => c.GuildID == guildId && c.ContractID == contractid);
                 if(_client.GetChannel(gc?.DiscordChannelId ?? 0) is ITextChannel channel) {
                     var made = 0;
-                    foreach(var coop in seeded.Where(c => c.Status != CoopStatusEnum.WaitingOnThread)) {
+                    foreach(var coop in seeded.Where(c => c.Status != CoopStatus.WaitingOnThread)) {
                         try {
                             var thread = await channel.CreateThreadAsync(coop.Name, autoArchiveDuration: ThreadArchiveDuration.OneDay, type: ThreadType.PublicThread);
                             coop.ThreadID = thread.Id;
@@ -171,7 +171,7 @@ namespace EGG9000.Bot.Commands {
                 ContractID = contractid,
                 Name = $"{SeedPrefix}{ShortId()}",
                 GuildId = Context.Guild?.Id ?? 0,
-                Status = CoopStatusEnum.AllAssignedJoined,
+                Status = CoopStatus.AllAssignedJoined,
                 League = 0,
                 MaxUsers = contract.MaxUsers > 0 ? contract.MaxUsers : 10,
                 CurrentUsers = 1,

--- a/EGG9000.Common/Database/CoopStatsCache.cs
+++ b/EGG9000.Common/Database/CoopStatsCache.cs
@@ -41,7 +41,7 @@ namespace EGG9000.Common.Database {
             public ulong GuildId { get; init; }
             public string ContractID { get; init; }
             public Guid CoopId { get; init; }
-            public CoopStatusEnum Status { get; init; }
+            public CoopStatus Status { get; init; }
             public ulong ThreadID { get; init; }
             public int? CurrentUsers { get; init; }
             public int? MaxUsers { get; init; }
@@ -85,12 +85,11 @@ namespace EGG9000.Common.Database {
                     .ToDictionary(g => g.Key, g => g.Select(x => x.UserId).ToHashSet());
 
                 static bool IsActive(CoopRow c, DateTimeOffset n) =>
-                    (int)c.Status > 2 && (int)c.Status < 13 && c.CoopEnds > n;
+                    CoopStatusSets.OpenForAssignment.Contains(c.Status) && c.CoopEnds > n;
                 static bool IsPending(CoopRow c) =>
-                    c.Status == CoopStatusEnum.WaitingOnThread && c.ThreadID == 0;
+                    c.Status == CoopStatus.WaitingOnThread && c.ThreadID == 0;
                 static bool IsFinished(CoopRow c) =>
-                    c.Status == CoopStatusEnum.Completed || c.Status == CoopStatusEnum.Failed
-                    || c.Status == CoopStatusEnum.CompletedAllCheckIn;
+                    CoopStatusSets.FinishedOrFailed.Contains(c.Status);
 
                 var contractStats = new Dictionary<(ulong, string), ContractStats>();
 

--- a/EGG9000.Common/Database/Entities/Coops.cs
+++ b/EGG9000.Common/Database/Entities/Coops.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Text;
 
 namespace EGG9000.Common.Database.Entities {
@@ -59,7 +60,7 @@ namespace EGG9000.Common.Database.Entities {
         public bool RolesAddedToThread { get; set; } = false;
 
 
-        public CoopStatusEnum Status { get; set; }
+        public CoopStatus Status { get; set; }
         public bool PseudoExpired { get; set; } = false;
 
         public DBContract Contract { get; set; }
@@ -73,19 +74,17 @@ namespace EGG9000.Common.Database.Entities {
         [NotMapped]
         public Ei.ContractCoopStatusResponse LastStatusUpdate {
             get {
-                if(_status != null)
-                    return _status;
-                if(_StatusCompressed == null)
-                    return null;
-                using(var msi = new MemoryStream(_StatusCompressed))
-                using(var mso = new MemoryStream()) {
-                    using(var gs = new GZipStream(msi, CompressionMode.Decompress)) {
-                        CopyTo(gs, mso);
-                    }
+                if(_status != null) return _status;
+                if(_StatusCompressed == null) return null;
 
-                    _status = JsonConvert.DeserializeObject<Ei.ContractCoopStatusResponse>(Encoding.UTF8.GetString(mso.ToArray()));
-                    return _status;
+                using var msi = new MemoryStream(_StatusCompressed);
+                using var mso = new MemoryStream();
+                using(var gs = new GZipStream(msi, CompressionMode.Decompress)) {
+                    CopyTo(gs, mso);
                 }
+
+                _status = JsonConvert.DeserializeObject<Ei.ContractCoopStatusResponse>(Encoding.UTF8.GetString(mso.ToArray()));
+                return _status;
             }
             set {
                 _status = value;
@@ -120,19 +119,23 @@ namespace EGG9000.Common.Database.Entities {
         }
 
         public bool FinishedOrFailed() {
-            return Status == CoopStatusEnum.Completed || Status == CoopStatusEnum.Failed || Status == CoopStatusEnum.CompletedAllCheckIn;
+            return CoopStatusSets.FinishedOrFailed.Contains(Status);
         }
 
         public bool FinalizedFinishedOrFailed() {
-            return Status == CoopStatusEnum.CompletedAllCheckIn || Status == CoopStatusEnum.Failed;
+            return CoopStatusSets.FinalizedFinishedOrFailed.Contains(Status);
         }
 
         public bool FinishedOrFailedOrExpired() {
-            return Status == CoopStatusEnum.Completed || Status == CoopStatusEnum.Failed || CoopEnds < DateTimeOffset.UtcNow || Status == CoopStatusEnum.CompletedAllCheckIn;
+            return FinishedOrFailed() || CoopEnds < DateTimeOffset.UtcNow;
+        }
+
+        public bool IsOpenForAssignment() {
+            return CoopStatusSets.OpenForAssignment.Contains(Status);
         }
     }
 
-    public enum CoopStatusEnum {
+    public enum CoopStatus {
         ManualWaitingOnCreation = 1,
         WaitingOnCreation = 2,
         WaitingOnThread = 3,
@@ -143,5 +146,11 @@ namespace EGG9000.Common.Database.Entities {
         Completed = 14,
         CompletedAllCheckIn = 15,
         Failed = -1
+    }
+
+    public static class CoopStatusSets {
+        public static readonly CoopStatus[] FinishedOrFailed = [CoopStatus.Completed, CoopStatus.Failed, CoopStatus.CompletedAllCheckIn];
+        public static readonly CoopStatus[] FinalizedFinishedOrFailed = [CoopStatus.CompletedAllCheckIn, CoopStatus.Failed];
+        public static readonly CoopStatus[] OpenForAssignment = [CoopStatus.WaitingOnThread, CoopStatus.WaitingOnStarter, CoopStatus.WaitingOnAssigned, CoopStatus.AllAssignedJoined];
     }
 }

--- a/EGG9000.Common/Helpers/CreateCoopsV2.cs
+++ b/EGG9000.Common/Helpers/CreateCoopsV2.cs
@@ -60,7 +60,7 @@ namespace EGG9000.Common.Helpers {
                 GuildId = guild.Id,
                 Name = words.GetCoopName(accounts, guild, dbGuild),
                 MaxUsers = contract.MaxUsers,
-                Status = CoopStatusEnum.WaitingOnCreation,
+                Status = CoopStatus.WaitingOnCreation,
                 League = (uint)grade,
                 AnyLeague = allowAllGrades,
                 CoopEnds = coopEnds,

--- a/EGG9000.Common/Helpers/Prefarm.cs
+++ b/EGG9000.Common/Helpers/Prefarm.cs
@@ -369,7 +369,7 @@ namespace EGG9000.Common.Helpers {
                     var joined = contribution is not null;
 
 
-                    if(coop.Status == CoopStatusEnum.Failed && string.IsNullOrEmpty(prefarm.CoopName)) {
+                    if(coop.Status == CoopStatus.Failed && string.IsNullOrEmpty(prefarm.CoopName)) {
                         prefarm.Coop = "";
                     } else {
                         prefarm.Coop = joined ? "✔️" : $"❌{prefarm.TimeLeft?.Humanize(precision: 2).ShortenTime().Replace(" ", "").Replace(",", "")}";

--- a/EGG9000.Common/Services/BotLogger.cs
+++ b/EGG9000.Common/Services/BotLogger.cs
@@ -112,12 +112,12 @@ namespace EGG9000.Common.Services {
                 var since = status.Since.AddMinutes(-5);
                 var coops = await scopedDb.Coops.AsNoTracking()
                     .Where(c => c.ContractID == contractid && c.GuildId == guildId && c.Group == group
-                        && c.Created >= since && c.Status != CoopStatusEnum.Failed)
+                        && c.Created >= since && c.Status != CoopStatus.Failed)
                     .Select(c => new { c.Status, c.ThreadID })
                     .ToListAsync();
 
                 status.CoopCount = coops.Count;
-                status.StartedCount = coops.Count(c => (int)c.Status >= (int)CoopStatusEnum.WaitingOnThread);
+                status.StartedCount = coops.Count(c => (int)c.Status >= (int)CoopStatus.WaitingOnThread);
                 status.ThreadCreatedCount = coops.Count(c => c.ThreadID != 0);
 
                 await status.Message.ModifyAsync(m => m.Embed = GenerateBoardingGroupEmbed(status));

--- a/EGG9000.Site/Controllers/AdminController.cs
+++ b/EGG9000.Site/Controllers/AdminController.cs
@@ -195,7 +195,7 @@ namespace EGG9000.Site.Controllers {
                 })],
                 Guild = guild,
                 ContractsToScore = contractsToScore,
-                CoopsWithoutThreads = await _db.Coops.CountAsync(x => x.ThreadID == 0 && (x.Status == CoopStatusEnum.WaitingOnThread || x.Status == CoopStatusEnum.WaitingOnCreation) && x.CoopEnds > DateTimeOffset.UtcNow)
+                CoopsWithoutThreads = await _db.Coops.CountAsync(x => x.ThreadID == 0 && (x.Status == CoopStatus.WaitingOnThread || x.Status == CoopStatus.WaitingOnCreation) && x.CoopEnds > DateTimeOffset.UtcNow)
             });
         }
 

--- a/EGG9000.Site/Controllers/ContractController.cs
+++ b/EGG9000.Site/Controllers/ContractController.cs
@@ -218,7 +218,7 @@ namespace EGG9000.Site.Controllers {
             var targetCoop = await _db.Coops.Include(x => x.Contract).FirstAsync(x => x.Id == CoopId);
             var dbuser = await _db.DBUsers.FirstAsync(x => x.Id == UserId);
 
-            var existingXref = await _db.UserCoopXrefs.FirstOrDefaultAsync(x => x.Coop.Created > DateTimeOffset.UtcNow.AddMonths(-6) && x.Coop.ContractID == targetCoop.ContractID && x.EggIncId == EggIncId && x.Coop.Status != CoopStatusEnum.Failed);
+            var existingXref = await _db.UserCoopXrefs.FirstOrDefaultAsync(x => x.Coop.Created > DateTimeOffset.UtcNow.AddMonths(-6) && x.Coop.ContractID == targetCoop.ContractID && x.EggIncId == EggIncId && x.Coop.Status != CoopStatus.Failed);
             if(existingXref != null) {
                 return Json(new { error = $"{dbuser.DiscordUsername} has already been assigned a co-op." });
             }
@@ -273,7 +273,7 @@ namespace EGG9000.Site.Controllers {
             var contracts = await _db.Contracts.OrderByDescending(x => x.Created).Take(10).ToListAsync();
             times.Set("Get Contracts");
             var contractIDs = contracts.Select(x => x.ID).ToArray();
-            var coops = await _db.Coops.Include(x => x.UserCoopsXrefs).Where(x => contractIDs.Contains(x.ContractID) && x.Status == CoopStatusEnum.Completed && x.GuildId == guildid).ToListAsync();
+            var coops = await _db.Coops.Include(x => x.UserCoopsXrefs).Where(x => contractIDs.Contains(x.ContractID) && x.Status == CoopStatus.Completed && x.GuildId == guildid).ToListAsync();
             times.Set("Get Coops");
             var userids = coops.SelectMany(x => x.UserCoopsXrefs).Select(x => x.UserId).Distinct().ToArray();
             var users = await _db.DBUsers.Where(x => userids.Contains(x.Id)).ToListAsync();

--- a/EGG9000.Site/Services/NewCoopChecker.cs
+++ b/EGG9000.Site/Services/NewCoopChecker.cs
@@ -22,7 +22,7 @@ namespace EGG9000.Site.Services {
             var sw = Stopwatch.StartNew();
             using var scope = factory.CreateScope();
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            var coopCount = await db.Coops.Where(x => x.Status == CoopStatusEnum.WaitingOnThread || x.Status == CoopStatusEnum.WaitingOnCreation).CountAsync(cancellationToken);
+            var coopCount = await db.Coops.Where(x => x.Status == CoopStatus.WaitingOnThread || x.Status == CoopStatus.WaitingOnCreation).CountAsync(cancellationToken);
             if(coopCount > 20 && WaitingOnCoops == false)
                 WaitingOnCoops = true;
             else if(coopCount < 10 && WaitingOnCoops == true)

--- a/EGG9000.Site/Views/MyFarms/Temporary.cshtml
+++ b/EGG9000.Site/Views/MyFarms/Temporary.cshtml
@@ -11,7 +11,7 @@
             <div>
 
                 Coop <u>@xref.Coop.Name</u>
-                @if (xref.Coop.Status == CoopStatusEnum.WaitingOnCreation)
+                @if (xref.Coop.Status == CoopStatus.WaitingOnCreation)
                 {
                     @:<span class="text-muted">(pending creation)</span>
                 }

--- a/EGG9000.Test.Integration/DepartedMemberPurgeTests.cs
+++ b/EGG9000.Test.Integration/DepartedMemberPurgeTests.cs
@@ -40,11 +40,11 @@ public class DepartedMemberPurgeTests {
         ctx.DBUsers.Add(new DBUser { Id = userId, DiscordId = 999_111_001, GuildId = 0, DiscordUsername = "departed" });
         ctx.Contracts.Add(new DBContract { ID = "test-contract", Created = now });
 
-        var match = NewCoop(guildId, CoopStatusEnum.WaitingOnAssigned, now.AddDays(1));
-        var joined = NewCoop(guildId, CoopStatusEnum.WaitingOnAssigned, now.AddDays(1));
-        var wrongGuild = NewCoop(otherGuildId, CoopStatusEnum.WaitingOnAssigned, now.AddDays(1));
-        var expired = NewCoop(guildId, CoopStatusEnum.WaitingOnAssigned, now.AddDays(-1));
-        var full = NewCoop(guildId, CoopStatusEnum.Full, now.AddDays(1));
+        var match = NewCoop(guildId, CoopStatus.WaitingOnAssigned, now.AddDays(1));
+        var joined = NewCoop(guildId, CoopStatus.WaitingOnAssigned, now.AddDays(1));
+        var wrongGuild = NewCoop(otherGuildId, CoopStatus.WaitingOnAssigned, now.AddDays(1));
+        var expired = NewCoop(guildId, CoopStatus.WaitingOnAssigned, now.AddDays(-1));
+        var full = NewCoop(guildId, CoopStatus.Full, now.AddDays(1));
         ctx.Coops.AddRange(match, joined, wrongGuild, expired, full);
 
         ctx.UserCoopXrefs.AddRange(
@@ -65,7 +65,7 @@ public class DepartedMemberPurgeTests {
             "Only the active, unjoined, same-guild assignment should be selected for purge.");
     }
 
-    private static Coop NewCoop(ulong guildId, CoopStatusEnum status, DateTimeOffset ends) {
+    private static Coop NewCoop(ulong guildId, CoopStatus status, DateTimeOffset ends) {
         return new() {
             Id = Guid.NewGuid(),
             ContractID = "test-contract",


### PR DESCRIPTION
RE: https://discord.com/channels/656455567858073601/777303939442802710/1541226906974687273

- Fixed issues where some Xref lookups would block valid actions due to mismatched "completed detection"
- Renamed `CoopStatusEnum` => `CoopStatus` (C# standard, "don't use Enum in enum names")
- Removed hard-coded "checks" against the enums, in favor of the "wrapper methods"
- Added "state sets," for more structured contain comparisons
