### PR TITLE
Fix: Cheated Artifact Detection Criteria

### DIFF
--- a/EGG9000.Bot/Automated/ArtifactCheaters.cs
+++ b/EGG9000.Bot/Automated/ArtifactCheaters.cs
@@ -91,16 +91,6 @@ namespace EGG9000.Bot.Automated {
             }
         }
 
-        // An account's legendary count vs. what its actual ship launches/crafts predict (LLC.LLCPercent)
-        // is the strongest single cheat signal since it's grounded in that account's own play history,
-        // not a population comparison. AFS (relative artifact-rarity stacking) is corroborating only -
-        // it catches inventory anomalies LLC doesn't model (e.g. hoarded rares with no legendary craft),
-        // but alone it flags legit whales with huge launch counts, so it never fires without LLC agreeing
-        // something is at least somewhat off too.
-        private const int LLCPercentHardCutoff = 50;
-        private const int LLCPercentSoftCutoff = 15;
-        private const double AFSZScoreCutoff = 1.0;
-
         public async override Task Run(object state, CancellationToken cancellationToken) {
             var _db = _provider.CreateScope().ServiceProvider.GetRequiredService<ApplicationDbContext>();
             var _cache = _provider.CreateScope().ServiceProvider.GetRequiredService<IMemoryCache>();
@@ -137,7 +127,7 @@ namespace EGG9000.Bot.Automated {
                 // concurrency instead of firing one request per account at once.
                 var throttler = new SemaphoreSlim(8);
                 var tasks = candidateAccounts
-                    .Where(a => afsZScores.TryGetValue(a, out var z) && z > AFSZScoreCutoff / 2)
+                    .Where(a => afsZScores.TryGetValue(a, out var z) && z > ArtifactHelpers.AFSZScoreCutoff / 2)
                     .Select(async account => {
                         await throttler.WaitAsync(cancellationToken);
                         try {
@@ -154,15 +144,10 @@ namespace EGG9000.Bot.Automated {
                 await Task.WhenAll(tasks);
             }
 
-            // Informed combination: a lone-standing implausible legendary excess is damning on its own.
-            // A merely elevated one only counts alongside a corroborating AFS outlier, so a legit whale
-            // with a big launch history (which pushes AFS up too, but LLC stays near zero) never flags.
             bool IsFlagged(EggIncAccount account) {
                 var hasLlc = llcResults.TryGetValue(account, out var llc);
                 var hasAfs = afsZScores.TryGetValue(account, out var afsZ);
-                if(hasLlc && llc.LLCPercent >= LLCPercentHardCutoff) return true;
-                if(hasLlc && hasAfs && llc.LLCPercent >= LLCPercentSoftCutoff && afsZ > AFSZScoreCutoff) return true;
-                return false;
+                return ArtifactHelpers.IsCheatFlagged(hasLlc, hasLlc ? llc.LLCPercent : 0, hasAfs, hasAfs ? afsZ : 0);
             }
 
             var upperOutliers = scoreSet

--- a/EGG9000.Common/Helpers/ArtifactHelpers.cs
+++ b/EGG9000.Common/Helpers/ArtifactHelpers.cs
@@ -162,6 +162,12 @@ namespace EGG9000.Common.Helpers {
 
         public record LegendaryLuckResult(double ExpectedLeggies, int LegCount, uint PossibleCraftCount, double LLC, int LLCPercent);
 
+        public const int LLCPercentHardCutoff = 50;
+        public const int LLCPercentSoftCutoff = 15;
+        public const double AFSZScoreCutoff = 1.0;
+        public const double AFSZScoreAloneCutoff = 3.0;
+        public const int NoBaselineLLCPercent = 999;
+
         // Legendary Luck Coefficient: how many legendaries an account "should" have given its actual
         // ship launches (by ship/duration/level, weighted against Menno's crowd-sourced drop rates) and
         // its crafting history (simulated per-craft odds from crafting XP/level at the time of each
@@ -219,9 +225,18 @@ namespace EGG9000.Common.Helpers {
 
             var newExpectedLeggies = newLLCSum + sumOfRatios;
             var newLLC = Math.Round(legCount - newExpectedLeggies, 2);
-            var newLLCPercent = newExpectedLeggies != 0 ? (int)Math.Round((legCount * 100 / newExpectedLeggies) - 100) : 0;
+            var newLLCPercent = newExpectedLeggies != 0
+                ? (int)Math.Round((legCount * 100 / newExpectedLeggies) - 100)
+                : (legCount > 0 ? NoBaselineLLCPercent : 0);
 
             return new LegendaryLuckResult(newExpectedLeggies, legCount, craftCount, newLLC, newLLCPercent);
+        }
+
+        public static bool IsCheatFlagged(bool hasLlc, int llcPercent, bool hasAfs, double afsZ) {
+            if(hasLlc && llcPercent >= LLCPercentHardCutoff) return true;
+            if(hasLlc && hasAfs && llcPercent >= LLCPercentSoftCutoff && afsZ > AFSZScoreCutoff) return true;
+            if(hasAfs && afsZ >= AFSZScoreAloneCutoff) return true;
+            return false;
         }
 
         public static double GetArtifactFairnessScore(List<ArtifactCount> ArtifactHall) {

--- a/EGG9000.Test/ArtifactCheatDetectionTests.cs
+++ b/EGG9000.Test/ArtifactCheatDetectionTests.cs
@@ -1,0 +1,83 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ArtifactCheatDetectionTests {
+        private static EggIncAccount AccountWithLegendaries(int legendaryCount, double craftingXp = 0) {
+            var hall = new List<ArtifactCount>();
+            for(var i = 0; i < legendaryCount; i++) {
+                hall.Add(new ArtifactCount {
+                    Count = 1000,
+                    NumberCrafted = 0,
+                    Artifact = new EggIncArtifactInstance { Id = 26, Tier = 4, Rarity = 4, Stones = [] }
+                });
+            }
+            return new EggIncAccount {
+                Id = "EI0000000000000000",
+                Name = "cheater",
+                Backup = new CustomBackup {
+                    ArtifactHall = hall,
+                    CraftingXP = craftingXp
+                }
+            };
+        }
+
+        [TestMethod]
+        public void GetLegendaryLuckCoefficient_ZeroBaselineWithLegendaries_DoesNotCollapseToZeroPercent() {
+            var account = AccountWithLegendaries(legendaryCount: 5);
+            var freshBackup = new Ei.Backup { ArtifactsDb = new Ei.ArtifactsDB() };
+
+            var result = ArtifactHelpers.GetLegendaryLuckCoefficient(account, freshBackup, []);
+
+            Assert.AreEqual(0, result.ExpectedLeggies, "test setup should exercise the zero-expected-leggies branch");
+            Assert.AreEqual(ArtifactHelpers.NoBaselineLLCPercent, result.LLCPercent);
+            Assert.IsTrue(result.LLCPercent >= ArtifactHelpers.LLCPercentHardCutoff);
+        }
+
+        [TestMethod]
+        public void GetLegendaryLuckCoefficient_ZeroBaselineNoLegendaries_StaysZeroPercent() {
+            var account = AccountWithLegendaries(legendaryCount: 0);
+            var freshBackup = new Ei.Backup { ArtifactsDb = new Ei.ArtifactsDB() };
+
+            var result = ArtifactHelpers.GetLegendaryLuckCoefficient(account, freshBackup, []);
+
+            Assert.AreEqual(0, result.ExpectedLeggies);
+            Assert.AreEqual(0, result.LLCPercent);
+        }
+
+        [TestMethod]
+        public void IsCheatFlagged_HardCutoffAlone_Flags() {
+            Assert.IsTrue(ArtifactHelpers.IsCheatFlagged(hasLlc: true, llcPercent: ArtifactHelpers.LLCPercentHardCutoff, hasAfs: false, afsZ: 0));
+        }
+
+        [TestMethod]
+        public void IsCheatFlagged_SoftCutoffWithAfsCorroboration_Flags() {
+            Assert.IsTrue(ArtifactHelpers.IsCheatFlagged(hasLlc: true, llcPercent: ArtifactHelpers.LLCPercentSoftCutoff, hasAfs: true, afsZ: ArtifactHelpers.AFSZScoreCutoff + 0.1));
+        }
+
+        [TestMethod]
+        public void IsCheatFlagged_SoftCutoffWithoutAfs_DoesNotFlag() {
+            Assert.IsFalse(ArtifactHelpers.IsCheatFlagged(hasLlc: true, llcPercent: ArtifactHelpers.LLCPercentSoftCutoff, hasAfs: false, afsZ: 0));
+        }
+
+        [TestMethod]
+        public void IsCheatFlagged_LlcUnavailable_ExtremeAfsAlone_Flags() {
+            Assert.IsTrue(ArtifactHelpers.IsCheatFlagged(hasLlc: false, llcPercent: 0, hasAfs: true, afsZ: ArtifactHelpers.AFSZScoreAloneCutoff));
+        }
+
+        [TestMethod]
+        public void IsCheatFlagged_LlcUnavailable_ModerateAfsAlone_DoesNotFlag() {
+            Assert.IsFalse(ArtifactHelpers.IsCheatFlagged(hasLlc: false, llcPercent: 0, hasAfs: true, afsZ: ArtifactHelpers.AFSZScoreAloneCutoff - 0.1));
+        }
+
+        [TestMethod]
+        public void IsCheatFlagged_NeitherSignal_DoesNotFlag() {
+            Assert.IsFalse(ArtifactHelpers.IsCheatFlagged(hasLlc: false, llcPercent: 0, hasAfs: false, afsZ: 0));
+        }
+    }
+}


### PR DESCRIPTION
RE: https://discord.com/channels/1108127105088241746/1108138244220141698/1541434309032935424

Fixed the cheat detection so that true outliers (like the one in the above message), are still flagged, even if the "corroborating data" we look for, doesn't exist.