### PR TITLE
Fix: Various Buglink Findings

### DIFF
--- a/EGG9000.Common/Database/CustomBackup.cs
+++ b/EGG9000.Common/Database/CustomBackup.cs
@@ -136,7 +136,11 @@ namespace EGG9000.Common.Database {
         //public uint EoV { get; set; } = 0;
 
         [Key(44)]
-        public double[] VirtueEggsDelivered { get; set; } = [];
+        public double[] VirtueEggsDelivered {
+            get => _virtueEggsDelivered ?? [];
+            set => _virtueEggsDelivered = value;
+        }
+        private double[] _virtueEggsDelivered = [];
         [Key(45)]
         public uint Resets { get; set; }
         [Key(46)]

--- a/EGG9000.Common/Helpers/DiscordHelpers.cs
+++ b/EGG9000.Common/Helpers/DiscordHelpers.cs
@@ -107,28 +107,15 @@ namespace EGG9000.Common.Helpers {
             return result;
         }
 
-        public static Task ModifyWithTimeoutAsync(this IUserMessage message, Action<MessageProperties> msgProperties, RequestOptions options = null) {
-            var tokenSource2 = new CancellationTokenSource();
-            var token2 = tokenSource2.Token;
+        public static async Task ModifyWithTimeoutAsync(this IUserMessage message, Action<MessageProperties> msgProperties, RequestOptions options = null) {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(9));
             options ??= new RequestOptions();
-            options.CancelToken = token2;
-
-            var thread = message.ModifyAsync(msgProperties, options);
-            tokenSource2.CancelAfter(9000);
-            var tokenSource = new CancellationTokenSource();
-            var token = tokenSource.Token;
-            var timer = Task.Delay(10000, token);
-            Task.WaitAny(thread, timer);
-            if(timer.IsCompleted) {
-                GetLogger<IUserMessage>().LogWarning($"Timer Expired");
-            } else {
-                tokenSource.Cancel();
-                if(thread.IsCanceled) {
-                    GetLogger<IUserMessage>().LogWarning($"Modify Task CANCELLED!");
-                }
+            options.CancelToken = cts.Token;
+            try {
+                await message.ModifyAsync(msgProperties, options);
+            } catch(OperationCanceledException) when(cts.IsCancellationRequested) {
+                GetLogger<IUserMessage>().LogWarning("Modify timed out after 9s for message {MessageId}", message.Id);
             }
-
-            return Task.CompletedTask;
         }
 
         public static FileAttachment GetFileAttachment(this SixLabors.ImageSharp.Image image, string imageName = "Image.png", string imageDescription = "An image") {

--- a/EGG9000.Common/Helpers/VirtueHelper.cs
+++ b/EGG9000.Common/Helpers/VirtueHelper.cs
@@ -1,6 +1,7 @@
 ﻿using EGG9000.Common.Database;
 
 using System;
+using System.Linq;
 
 namespace EGG9000.Common.Helpers {
     public class VirtueHelper {
@@ -10,7 +11,7 @@ namespace EGG9000.Common.Helpers {
         ];
 
         public static VirtueEggStats EggStats(CustomBackup backup, Ei.Egg egg) {
-            return EggStats(backup.VirtueEggsDelivered[(int)egg - 50]);
+            return EggStats(backup.VirtueEggsDelivered.ElementAtOrDefault((int)egg - 50));
         }
 
         public static VirtueEggStats EggStats(double eggsShipped) {

--- a/EGG9000.Common/Proto/EiExtensions.cs
+++ b/EGG9000.Common/Proto/EiExtensions.cs
@@ -82,17 +82,20 @@ namespace Ei {
     public partial class Contract {
 
         public List<Goal> GetGoals(int league) {
-            if(GradeSpecs.Count > 0)
+            if(league >= 1 && league <= GradeSpecs.Count)
                 return [.. GradeSpecs[league - 1].Goals];
-            else return [.. GoalSets[league].Goals];
+            if(league >= 0 && league < GoalSets.Count)
+                return [.. GoalSets[league].Goals];
+            return [.. Goals];
         }
         public List<Goal> GetGoals(LocalContract contract) {
-            if(contract.Grade != PlayerGrade.GradeUnset)
-                return [.. GradeSpecs[(int)contract.Grade - 1].Goals];
-            else if(GoalSets.Count > 0)
-                return [.. GoalSets[(int)contract.League].Goals];
-            else
-                return [.. Goals];
+            var grade = (int)contract.Grade;
+            if(grade >= 1 && grade <= GradeSpecs.Count)
+                return [.. GradeSpecs[grade - 1].Goals];
+            var league = (int)contract.League;
+            if(league >= 0 && league < GoalSets.Count)
+                return [.. GoalSets[league].Goals];
+            return [.. Goals];
         }
 
         public int GetPossiblePE() {

--- a/EGG9000.Site/Controllers/HomeController.cs
+++ b/EGG9000.Site/Controllers/HomeController.cs
@@ -201,7 +201,8 @@ namespace EGG9000.Site.Controllers {
         public async Task<List<LeaderboardUser>> _getLeaderboard(ulong guildid) {
             var dbguild = await _db.Guilds.FirstAsync(x => x.Id == guildid);
 
-            var guild = _discord.Guilds.First(g => g.Id == guildid);
+            var guild = _discord.Guilds.FirstOrDefault(g => g.Id == guildid);
+            if(guild is null) return [];
             // Membership is the DB GuildId, not the live Discord cache. The site runs its own bare
             // socket client whose member cache can read "complete" while actually partial, and gating
             // on it dropped real members from the board (the recurring CSLeaderboard "few users" bug).
@@ -234,6 +235,7 @@ namespace EGG9000.Site.Controllers {
             ViewBag.SortBy = sortby;
 
             var leaderboard = (await ResolveGuildLeaderboardAsync(guildid)).Board;
+            if(leaderboard is null) return View("Message", NoLinkedGuildMessage);
 
             if(oldest) {
                 return View(leaderboard.Where(x => x.Backup.PermitLevel == 0 && x.User.EggIncAccounts.Count == 1).OrderBy(x => x.User.Registered).ToList());
@@ -292,6 +294,7 @@ namespace EGG9000.Site.Controllers {
 
         public async Task<IActionResult> CraftingLevelLeaderboard([FromQuery] ulong guildid = 0) {
             var leaderboard = (await ResolveGuildLeaderboardAsync(guildid)).Board;
+            if(leaderboard is null) return View("Message", NoLinkedGuildMessage);
             leaderboard = [.. leaderboard.OrderByDescending(x => x.TotalCraftingXP).Where(x => x.TotalCraftingXP > 0)];
             return View(leaderboard);
         }
@@ -300,6 +303,7 @@ namespace EGG9000.Site.Controllers {
             ViewBag.CSType = cstype;
 
             var leaderboard = (await ResolveGuildLeaderboardAsync(guildid)).Board;
+            if(leaderboard is null) return View("Message", NoLinkedGuildMessage);
 
             switch(cstype) {
                 case "season":
@@ -523,18 +527,24 @@ namespace EGG9000.Site.Controllers {
             return Json(result);
         }
 
+        private const string NoLinkedGuildMessage = "Your account is not linked to a Discord server this site knows about.";
+
         private async Task<(DBUser User, ulong Guildid, List<LeaderboardUser> Board)> ResolveGuildLeaderboardAsync(ulong guildid) {
             var user = await GetCurrentDbUserAsync();
             if(guildid == 0 || !User.IsInRole("Admin")) {
                 guildid = user.GuildId;
             }
-            await _discord.Guilds.First(x => x.Id == guildid).DownloadUsersAsync();
+            var guild = _discord.Guilds.FirstOrDefault(x => x.Id == guildid);
+            if(guild is null) return (user, guildid, null);
+            await guild.DownloadUsersAsync();
             return (user, guildid, await _getLeaderboard(guildid));
         }
 
         private async Task<(List<T> All, List<T> Mine, List<string> MyNames)> BuildComparison<T>(Func<LeaderboardUser, T> project, Func<IEnumerable<LeaderboardUser>, IEnumerable<LeaderboardUser>> filter = null) {
             var user = await GetCurrentDbUserAsync();
-            await _discord.Guilds.First(x => x.Id == user.GuildId).DownloadUsersAsync();
+            var guild = _discord.Guilds.FirstOrDefault(x => x.Id == user.GuildId);
+            if(guild is null) return (null, null, null);
+            await guild.DownloadUsersAsync();
 
             IEnumerable<LeaderboardUser> leaderboard = await _getLeaderboard(user.GuildId);
             if(filter is not null) leaderboard = filter(leaderboard);
@@ -557,6 +567,7 @@ namespace EGG9000.Site.Controllers {
             var (all, mine, myNames) = await BuildComparison(u => new Tuple<double, string>(
                 u.Backup.EarningsBonus,
                 SIPrefix.GetPrefixFromEB(u.Backup.EarningsBonus).RankWithSubRank));
+            if(all is null) return View("Message", NoLinkedGuildMessage);
 
             ViewBag.ListOfEb = all;
             ViewBag.MyEbs = mine;
@@ -571,6 +582,7 @@ namespace EGG9000.Site.Controllers {
             var (all, mine, myNames) = await BuildComparison(u => new Tuple<int, double>(
                 (int)(u?.Account?.LastGrade ?? Ei.Contract.Types.PlayerGrade.GradeUnset),
                 u?.Backup?.TotalCS ?? 0));
+            if(all is null) return View("Message", NoLinkedGuildMessage);
 
             ViewBag.MyGradeData = mine;
             ViewBag.MyNames = myNames;
@@ -586,6 +598,7 @@ namespace EGG9000.Site.Controllers {
                 (int)u?.Account?.Backup.GetCraftingLevel(),
                 (double)(u?.Account?.Backup?.CraftingXP)),
                 leaderboard => leaderboard.Where(x => x.TotalCraftingXP > 0));
+            if(all is null) return View("Message", NoLinkedGuildMessage);
 
             ViewBag.MyCraftingData = mine;
             ViewBag.MyNames = myNames;
@@ -673,9 +686,15 @@ namespace EGG9000.Site.Controllers {
             }));
 
             if(model.Contract.Details == null) {
-                var firstContact = await EggIncApi.FirstContact(model.UserInfos.Where(x => x.Backup != null).First().Backup.EggIncId);
-                var contract = firstContact.Backup.Contracts.Archive.First(c => c.Contract.Identifier == ContractId);
-                model.Contract._response = JsonConvert.SerializeObject(contract.Contract);
+                var carrier = model.UserInfos.FirstOrDefault(x => x.Backup != null);
+                if(carrier is null) return View("Message", $"Unable to find contract definition for {ContractId}.");
+                var firstContact = await EggIncApi.FirstContact(carrier.Backup.EggIncId);
+                var myContracts = firstContact?.Backup?.Contracts;
+                var contract = myContracts is null
+                    ? null
+                    : myContracts.Archive.Concat(myContracts.Contracts).FirstOrDefault(c => c.Contract is not null && (c.Contract.Identifier == ContractId || c.ContractIdentifier == ContractId));
+                if(contract is null) return View("Message", $"Unable to find contract definition for {ContractId}.");
+                model.Contract.OverwriteDetails(contract.Contract);
                 await _db.SaveChangesAsync();
             }
 

--- a/EGG9000.Site/Controllers/MyFarmsController.cs
+++ b/EGG9000.Site/Controllers/MyFarmsController.cs
@@ -57,6 +57,7 @@ namespace EGG9000.Site.Controllers {
         [Authorize(Roles = "Admin,GuildAdmin,GuildLesserAdmin,GuildReadOnlyAdmin")]
         public async Task<IActionResult> ViewUser(ulong discordId) {
             var model = await BuildViewUserModel(discordId);
+            if(model is null) return NotFound();
             return View("Index", model);
         }
 
@@ -70,6 +71,7 @@ namespace EGG9000.Site.Controllers {
             if(discordId != loginUserId && !isStaff) return Forbid();
 
             var model = await BuildViewUserModel(discordId);
+            if(model is null) return NotFound();
             return PartialView("Index", model);
         }
 
@@ -81,6 +83,7 @@ namespace EGG9000.Site.Controllers {
             var loginUserId = await GetLoginDiscordIdAsync();
             var isSelf = loginUserId == discordId;
             var user = await _db.DBUsers.Include(x => x.UserCoopXrefs).ThenInclude(x => x.Coop).FirstOrDefaultAsync(x => x.DiscordId == discordId);
+            if(user is null) return null;
             Sentry.SentrySdk.AddBreadcrumb($"DiscordId: {discordId}");
             _bugsnag.Breadcrumbs.Leave($"DiscordId: {discordId}");
             _bugsnag.Breadcrumbs.Leave($"DiscordUsername: {user.DiscordUsername}");
@@ -438,7 +441,7 @@ namespace EGG9000.Site.Controllers {
         public Dictionary<string, List<DBContract>> GetUncompletedPEContracts(DBUser user, List<DBContract> contracts) {
             var contractsById = new Dictionary<string, DBContract>(StringComparer.CurrentCultureIgnoreCase);
             foreach(var c in contracts) contractsById[c.ID] = c;
-            var pePossibleContracts = contracts.Where(c => c.Details.GetPossiblePE() > 0).ToList();
+            var pePossibleContracts = contracts.Where(c => c.Details?.GetPossiblePE() > 0).ToList();
 
             return user.EggIncAccounts.ToDictionary(
                 account => account.Id,

--- a/EGG9000.Site/Program.cs
+++ b/EGG9000.Site/Program.cs
@@ -211,6 +211,16 @@ void ConfigureServices(IServiceCollection services, IConfiguration Configuration
         options.Events = new Microsoft.AspNetCore.Authentication.OAuth.OAuthEvents {
             OnTicketReceived = context => {
                 return Task.FromResult(0);
+            },
+            OnRemoteFailure = context => {
+                var target = "/Identity/Account/Login";
+                var returnUrl = context.Properties?.RedirectUri;
+                if(!string.IsNullOrEmpty(returnUrl) && returnUrl.StartsWith('/') && !returnUrl.StartsWith("//")) {
+                    target += "?returnUrl=" + Uri.EscapeDataString(returnUrl);
+                }
+                context.Response.Redirect(target);
+                context.HandleResponse();
+                return Task.CompletedTask;
             }
         };
         options.SaveTokens = true;

--- a/EGG9000.Test/ContractGetGoalsTests.cs
+++ b/EGG9000.Test/ContractGetGoalsTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System.Linq;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ContractGetGoalsTests {
+        private const double BaseTarget = 10;
+        private const double GoalSetBase = 100;
+        private const double GradeSpecBase = 1000;
+
+        private static Ei.Contract Build(int gradeSpecs, int goalSets, bool baseGoals) {
+            var contract = new Ei.Contract { Identifier = "test" };
+            if(baseGoals)
+                contract.Goals.Add(new Ei.Contract.Types.Goal { TargetAmount = BaseTarget });
+            for(var i = 0; i < goalSets; i++) {
+                var set = new Ei.Contract.Types.GoalSet();
+                set.Goals.Add(new Ei.Contract.Types.Goal { TargetAmount = GoalSetBase + i });
+                contract.GoalSets.Add(set);
+            }
+            for(var i = 0; i < gradeSpecs; i++) {
+                var spec = new Ei.Contract.Types.GradeSpec { Grade = (Ei.Contract.Types.PlayerGrade)(i + 1) };
+                spec.Goals.Add(new Ei.Contract.Types.Goal { TargetAmount = GradeSpecBase + i });
+                contract.GradeSpecs.Add(spec);
+            }
+            return contract;
+        }
+
+        private static double Single(System.Collections.Generic.List<Ei.Contract.Types.Goal> goals) {
+            Assert.HasCount(1, goals);
+            return goals.Single().TargetAmount;
+        }
+
+        [TestMethod]
+        public void LeagueZero_WithGradeSpecsAndGoalSets_FallsBackToFirstGoalSet() {
+            var contract = Build(5, 2, true);
+
+            Assert.AreEqual(GoalSetBase, Single(contract.GetGoals(0)));
+        }
+
+        [TestMethod]
+        public void LeagueZero_WithGradeSpecsOnly_FallsBackToBaseGoals() {
+            var contract = Build(5, 0, true);
+
+            Assert.AreEqual(BaseTarget, Single(contract.GetGoals(0)));
+        }
+
+        [TestMethod]
+        public void LeagueZero_WithBaseGoalsOnly_ReturnsBaseGoals() {
+            var contract = Build(0, 0, true);
+
+            Assert.AreEqual(BaseTarget, Single(contract.GetGoals(0)));
+        }
+
+        [TestMethod]
+        public void LeagueInRange_WithGradeSpecs_ReturnsThatGradeSpec() {
+            var contract = Build(5, 2, true);
+
+            Assert.AreEqual(GradeSpecBase + 2, Single(contract.GetGoals(3)));
+        }
+
+        [TestMethod]
+        public void LeagueInRange_WithGoalSetsOnly_ReturnsThatGoalSet() {
+            var contract = Build(0, 2, true);
+
+            Assert.AreEqual(GoalSetBase + 1, Single(contract.GetGoals(1)));
+        }
+
+        [TestMethod]
+        public void LeagueAboveGradeSpecs_FallsThroughToGoalSetsThenGoals() {
+            var withGoalSets = Build(5, 2, true);
+            var withoutGoalSets = Build(5, 0, true);
+
+            Assert.AreEqual(BaseTarget, Single(withGoalSets.GetGoals(7)));
+            Assert.AreEqual(BaseTarget, Single(withoutGoalSets.GetGoals(7)));
+        }
+
+        [TestMethod]
+        public void LocalContract_GradeUnset_LeagueOutOfRange_FallsBackToBaseGoals() {
+            var contract = Build(5, 2, true);
+            var local = new Ei.LocalContract { Grade = Ei.Contract.Types.PlayerGrade.GradeUnset, League = 9 };
+
+            Assert.AreEqual(BaseTarget, Single(contract.GetGoals(local)));
+        }
+
+        [TestMethod]
+        public void LocalContract_GradeSet_ReturnsThatGradeSpec() {
+            var contract = Build(5, 2, true);
+            var local = new Ei.LocalContract { Grade = Ei.Contract.Types.PlayerGrade.GradeAa, League = 0 };
+
+            Assert.AreEqual(GradeSpecBase + 3, Single(contract.GetGoals(local)));
+        }
+    }
+}

--- a/EGG9000.Test/CustomBackupVirtueTests.cs
+++ b/EGG9000.Test/CustomBackupVirtueTests.cs
@@ -1,0 +1,43 @@
+using EGG9000.Common.Database;
+using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Helpers;
+
+using MessagePack;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class CustomBackupVirtueTests {
+        private static CustomBackup RoundTripWithNullVirtueEggs() {
+            var backup = new CustomBackup {
+                EggIncId = "EI0000000000000000",
+                UserName = "legacy",
+                Farms = [],
+                VirtueEggsDelivered = null!
+            };
+            var bytes = MessagePackSerializer.Serialize(backup, DBUser.lz4Options);
+            return MessagePackSerializer.Deserialize<CustomBackup>(bytes, DBUser.lz4Options);
+        }
+
+        [TestMethod]
+        public void VirtueEggsDelivered_NilSlot_DeserializesToEmptyArray() {
+            var back = RoundTripWithNullVirtueEggs();
+
+            Assert.IsNotNull(back.VirtueEggsDelivered);
+            Assert.AreEqual(0, back.VirtueEggsDelivered.Length);
+        }
+
+        [TestMethod]
+        public void EggStats_NilSlot_ReturnsZeroDeliveredStats() {
+            var back = RoundTripWithNullVirtueEggs();
+
+            var stats = VirtueHelper.EggStats(back, Ei.Egg.Curiosity);
+
+            Assert.AreEqual(0d, stats.Delivered);
+            Assert.AreEqual(0, stats.Level);
+            Assert.AreEqual(0, back.EggsOfTruthTotal);
+        }
+    }
+}

--- a/EGG9000.Test/Discord/ModifyWithTimeoutTests.cs
+++ b/EGG9000.Test/Discord/ModifyWithTimeoutTests.cs
@@ -1,0 +1,119 @@
+using Discord;
+
+using EGG9000.Common.Helpers;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class ModifyWithTimeoutTests {
+        [TestMethod]
+        public async Task ModifyWithTimeoutAsync_PropagatesModifyFailure() {
+            var stub = new FailingModifyMessage(Guid.NewGuid().ToString("N"));
+            await Assert.ThrowsExactlyAsync<HttpRequestException>(() => stub.ModifyWithTimeoutAsync(_ => { }));
+        }
+
+        [TestMethod]
+        public async Task ModifyWithTimeoutAsync_DoesNotLeakUnobservedException() {
+            var marker = Guid.NewGuid().ToString("N");
+            var captured = new List<Exception>();
+            EventHandler<UnobservedTaskExceptionEventArgs> handler = (_, e) => {
+                foreach(var inner in e.Exception.Flatten().InnerExceptions) {
+                    if(inner.Message.Contains(marker)) {
+                        lock(captured) captured.Add(inner);
+                    }
+                }
+                e.SetObserved();
+            };
+            TaskScheduler.UnobservedTaskException += handler;
+            try {
+                await InvokeAndSwallowAsync(marker);
+                for(var i = 0; i < 10; i++) {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    await Task.Delay(50);
+                    lock(captured) if(captured.Count > 0) break;
+                }
+                lock(captured) Assert.AreEqual(0, captured.Count, "faulted ModifyAsync task escaped as UnobservedTaskException");
+            } finally {
+                TaskScheduler.UnobservedTaskException -= handler;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task InvokeAndSwallowAsync(string marker) {
+            var stub = new FailingModifyMessage(marker);
+            try {
+                await stub.ModifyWithTimeoutAsync(_ => { });
+            } catch(Exception) {
+            }
+        }
+
+        private sealed class FailingModifyMessage(string marker) : IUserMessage {
+            public Task ModifyAsync(Action<MessageProperties> func, RequestOptions? options = null) {
+                return Task.FromException(new HttpRequestException("Resource temporarily unavailable (discord.com:443) " + marker));
+            }
+
+            ulong IEntity<ulong>.Id => 1;
+            DateTimeOffset ISnowflakeEntity.CreatedAt => throw new NotImplementedException();
+            Task IDeletable.DeleteAsync(RequestOptions options) => throw new NotImplementedException();
+
+            Task IUserMessage.PinAsync(RequestOptions options) => throw new NotImplementedException();
+            Task IUserMessage.UnpinAsync(RequestOptions options) => throw new NotImplementedException();
+            Task IUserMessage.CrosspostAsync(RequestOptions options) => throw new NotImplementedException();
+            string IUserMessage.Resolve(TagHandling userHandling, TagHandling channelHandling, TagHandling roleHandling, TagHandling everyoneHandling, TagHandling emojiHandling) => throw new NotImplementedException();
+            Task IUserMessage.EndPollAsync(RequestOptions options) => throw new NotImplementedException();
+            IAsyncEnumerable<IReadOnlyCollection<IUser>> IUserMessage.GetPollAnswerVotersAsync(uint answerId, int? limit, ulong? afterId, RequestOptions options) => throw new NotImplementedException();
+            MessageResolvedData IUserMessage.ResolvedData => throw new NotImplementedException();
+            IUserMessage IUserMessage.ReferencedMessage => throw new NotImplementedException();
+            IMessageInteractionMetadata IUserMessage.InteractionMetadata => throw new NotImplementedException();
+            IReadOnlyCollection<MessageSnapshot> IUserMessage.ForwardedMessages => throw new NotImplementedException();
+            Poll? IUserMessage.Poll => throw new NotImplementedException();
+
+            Task IMessage.AddReactionAsync(IEmote emote, RequestOptions options) => throw new NotImplementedException();
+            Task IMessage.RemoveReactionAsync(IEmote emote, IUser user, RequestOptions options) => throw new NotImplementedException();
+            Task IMessage.RemoveReactionAsync(IEmote emote, ulong userId, RequestOptions options) => throw new NotImplementedException();
+            Task IMessage.RemoveAllReactionsAsync(RequestOptions options) => throw new NotImplementedException();
+            Task IMessage.RemoveAllReactionsForEmoteAsync(IEmote emote, RequestOptions options) => throw new NotImplementedException();
+            IAsyncEnumerable<IReadOnlyCollection<IUser>> IMessage.GetReactionUsersAsync(IEmote emoji, int limit, RequestOptions options, ReactionType type) => throw new NotImplementedException();
+            MessageType IMessage.Type => throw new NotImplementedException();
+            MessageSource IMessage.Source => throw new NotImplementedException();
+            bool IMessage.IsTTS => throw new NotImplementedException();
+            bool IMessage.IsPinned => throw new NotImplementedException();
+            bool IMessage.IsSuppressed => throw new NotImplementedException();
+            bool IMessage.MentionedEveryone => throw new NotImplementedException();
+            string IMessage.Content => throw new NotImplementedException();
+            string IMessage.CleanContent => throw new NotImplementedException();
+            DateTimeOffset IMessage.Timestamp => throw new NotImplementedException();
+            DateTimeOffset? IMessage.EditedTimestamp => throw new NotImplementedException();
+            IMessageChannel IMessage.Channel => throw new NotImplementedException();
+            IUser IMessage.Author => throw new NotImplementedException();
+            IThreadChannel IMessage.Thread => throw new NotImplementedException();
+            IReadOnlyCollection<IAttachment> IMessage.Attachments => throw new NotImplementedException();
+            IReadOnlyCollection<IEmbed> IMessage.Embeds => throw new NotImplementedException();
+            IReadOnlyCollection<ITag> IMessage.Tags => throw new NotImplementedException();
+            IReadOnlyCollection<ulong> IMessage.MentionedChannelIds => throw new NotImplementedException();
+            IReadOnlyCollection<ulong> IMessage.MentionedRoleIds => throw new NotImplementedException();
+            IReadOnlyCollection<ulong> IMessage.MentionedUserIds => throw new NotImplementedException();
+            MessageActivity IMessage.Activity => throw new NotImplementedException();
+            MessageApplication IMessage.Application => throw new NotImplementedException();
+            MessageReference IMessage.Reference => throw new NotImplementedException();
+            IReadOnlyDictionary<IEmote, ReactionMetadata> IMessage.Reactions => throw new NotImplementedException();
+            IReadOnlyCollection<IMessageComponent> IMessage.Components => throw new NotImplementedException();
+            IReadOnlyCollection<IStickerItem> IMessage.Stickers => throw new NotImplementedException();
+            MessageFlags? IMessage.Flags => throw new NotImplementedException();
+            IMessageInteraction IMessage.Interaction => throw new NotImplementedException();
+            MessageRoleSubscriptionData IMessage.RoleSubscriptionData => throw new NotImplementedException();
+            PurchaseNotification IMessage.PurchaseNotification => throw new NotImplementedException();
+            MessageCallData? IMessage.CallData => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Should fix all of the following BugSink issues:
- [System.NullReferenceException - MyFarms/User](https://bugsink.dev.sglade.com/issues/issue/cf52b3f6-97a4-427a-b386-442715bc7d8a/event/65f4d4af-95cc-43bb-a641-02031581d22e/)
  - `curl`-ing a non-existent Discord ID was causing a 500, instead of a 404.
- [System.InvalidOperationException - Home/Leaderboard](https://bugsink.dev.sglade.com/issues/issue/6a385241-ee14-4f13-b41a-eb88fa6e0772/event/last/)
  - Unparsed handling when user was not in the guild they were attempting to view. 500 before, 200 after.
- [System.ArgumentNullException - MyFarms/User](https://bugsink.dev.sglade.com/issues/issue/2674953a-c64a-4374-a61f-6365d5c4acd9/event/last/)
  - Wrapped the potential `nil` from DB/backup in a messagepack byte struct.
- [System.ArgumentOutOfRangeException - Contracts](https://bugsink.dev.sglade.com/issues/issue/cfb6d51f-9b02-4ee9-9b40-73e4175724d2/event/last/)
  - Added bounds checking to `GetGoals`, and added a test for this.
- [System.AggregateException - Discord Queries](https://bugsink.dev.sglade.com/issues/issue/ca2e65ee-f102-4d1b-9eed-6ffe00d0d598/event/last/)
  - `ModifyWithTimeoutTests` should show the issue here. Running tests on "pre-pr" code will cause failures.
- [Microsoft.AspNetCore.Authentication.AuthenticationFailureException - Site login](https://bugsink.dev.sglade.com/issues/issue/573dff19-d606-492d-9667-86518dfcac39/event/last/)
  - `OnRemoteFailure` was sending users to `/login`, which was the cause here. `curl` should show 500 'now', and 302 'after'.