### PR TITLE
Fix + Chore: Misc. Backlog Items

### DIFF
--- a/EGG9000.Bot/Commands/AdminStatusModule.cs
+++ b/EGG9000.Bot/Commands/AdminStatusModule.cs
@@ -9,7 +9,6 @@ using EGG9000.Common.Helpers.Discord;
 using EGG9000.Common.Services;
 using Humanizer;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
@@ -56,10 +55,21 @@ namespace EGG9000.Bot.Commands {
 
         private sealed record ServiceRow(string Name, string Avg, string Last, int Attempts, string Status);
 
+        private sealed record PgStats(
+            long Commits, long Rollbacks, long BlksHit, long BlksRead,
+            long TupReturned, long TupFetched, long TupInserted, long TupUpdated, long TupDeleted,
+            long Deadlocks, long Backends, long Conflicts, long TempFiles, long LocksWaiting, DateTimeOffset At);
+
+        private sealed record PgRates(
+            double Commits, double Rollbacks, double Returned, double Fetched,
+            double Inserted, double Updated, double Deleted, double RollbackRatio);
+
         private sealed record SysLoadSnapshot(
-            long Ping, double WorkingMb, double GcHeapMb, int Threads, double CpuMin, int CacheCount,
-            int Tracked, int Pending, int ActiveCoops, int DbUsers, int Contracts, int Events, int AutoLogs,
+            long Ping, double WorkingMb, double GcHeapMb, int Threads, double CpuMin,
             long ApiCalls, long ApiFails, long DbQueries, long Commands, long CmdFails, long DiscordOps,
+            long DbReads, long DbWrites, long DbFailures, long DbRetries, long DbSlow,
+            double DbMeanMs, double DbP50, double DbP95, double DbP99, double DbMax,
+            PgStats Pg, PgRates Rates,
             int Latency, int Guilds, int QHigh, int QLow, int QHighW, int QLowW,
             double RuntimeHealth, double DiscordHealth, double ProcessHealth, double DbHealth,
             long StartedUnix, long NowUnix, IReadOnlyList<ServiceRow> Services) {
@@ -70,6 +80,55 @@ namespace EGG9000.Bot.Commands {
             }
         }
 
+        private const string PgStatsSql = @"
+            SELECT d.xact_commit, d.xact_rollback, d.blks_hit, d.blks_read,
+                   d.tup_returned, d.tup_fetched, d.tup_inserted, d.tup_updated, d.tup_deleted,
+                   d.deadlocks, d.numbackends, d.conflicts, d.temp_files,
+                   (SELECT count(*) FROM pg_stat_activity WHERE wait_event_type = 'Lock') AS locks_waiting
+            FROM pg_stat_database d
+            WHERE d.datname = current_database()";
+
+        private static PgStats _prevPg;
+
+        private static double PgCacheHit(PgStats p) {
+            var total = p.BlksHit + p.BlksRead;
+            return total <= 0 ? 100 : 100.0 * p.BlksHit / total;
+        }
+
+        private static async Task<PgStats> ReadPgStats(ApplicationDbContext db) {
+            try {
+                await db.Database.OpenConnectionAsync();
+                try {
+                    await using var cmd = db.Database.GetDbConnection().CreateCommand();
+                    cmd.CommandText = PgStatsSql;
+                    await using var reader = await cmd.ExecuteReaderAsync();
+                    if(!await reader.ReadAsync()) return null;
+                    long L(int i) => reader.IsDBNull(i) ? 0 : Convert.ToInt64(reader.GetValue(i));
+                    return new PgStats(L(0), L(1), L(2), L(3), L(4), L(5), L(6), L(7), L(8), L(9), L(10), L(11), L(12), L(13), DateTimeOffset.UtcNow);
+                } finally {
+                    await db.Database.CloseConnectionAsync();
+                }
+            } catch(Exception) {
+                return null;
+            }
+        }
+
+        private static PgRates ComputePgRates(PgStats now) {
+            if(now is null) return null;
+            var prev = Interlocked.Exchange(ref _prevPg, now);
+            if(prev is null) return null;
+            var secs = (now.At - prev.At).TotalSeconds;
+            if(secs <= 0 || now.Commits < prev.Commits) return null;
+            double Rate(long a, long b) => Math.Max(a - b, 0) / secs;
+            var commits = Math.Max(now.Commits - prev.Commits, 0);
+            var rollbacks = Math.Max(now.Rollbacks - prev.Rollbacks, 0);
+            var txns = commits + rollbacks;
+            return new PgRates(Rate(now.Commits, prev.Commits), Rate(now.Rollbacks, prev.Rollbacks),
+                Rate(now.TupReturned, prev.TupReturned), Rate(now.TupFetched, prev.TupFetched),
+                Rate(now.TupInserted, prev.TupInserted), Rate(now.TupUpdated, prev.TupUpdated),
+                Rate(now.TupDeleted, prev.TupDeleted), txns == 0 ? 0 : (double)rollbacks / txns);
+        }
+
         private static async Task<SysLoadSnapshot> GatherSysLoad(ApplicationDbContext db, DiscordSocketClient client, IDiscordQueue queue, IServiceProvider serviceProvider) {
             var sw = Stopwatch.StartNew();
             await db.Database.ExecuteSqlRawAsync("SELECT 1");
@@ -78,15 +137,9 @@ namespace EGG9000.Bot.Commands {
             var proc = Process.GetCurrentProcess();
             var workingMb = proc.WorkingSet64 / 1_048_576.0;
             var gcHeapMb = GC.GetTotalMemory(false) / 1_048_576.0;
-            var cacheCount = db._cache is MemoryCache mc ? mc.Count : -1;
-            var pending = db.ChangeTracker.Entries().Count(e => e.State is EntityState.Added or EntityState.Modified or EntityState.Deleted);
-            var tracked = db.ChangeTracker.Entries().Count();
 
-            var activeCoops = await db.Coops.CountAsync(x => !x.Finished && x.CoopEnds > DateTimeOffset.UtcNow);
-            var dbUsers = await db.DBUsers.CountAsync();
-            var contracts = await db.Contracts.CountAsync();
-            var events = await db.Events.CountAsync();
-            var autoLogs = await db.AutomationLogs.CountAsync(x => x.StartTime > DateTimeOffset.UtcNow.AddDays(-1));
+            var pg = await ReadPgStats(db);
+            var rates = ComputePgRates(pg);
 
             var latency = client?.Latency ?? -1;
             var guilds = client?.Guilds?.Count ?? 0;
@@ -102,7 +155,15 @@ namespace EGG9000.Bot.Commands {
             var runtimeHealth = Math.Min(apiCalls == 0 ? 1 : 1 - (double)apiFails / apiCalls, commands == 0 ? 1 : 1 - (double)cmdFails / commands);
             var discordHealth = Math.Min(latency < 0 ? 1 : HealthRange(latency, 150, 1000), HealthRange(backlog, 25, 500));
             var processHealth = Math.Min(HealthRange(workingMb, 1200, 4000), HealthRange(gcHeapMb, 500, 3000));
-            var dbHealth = Math.Min(HealthRange(pingMs, 50, 500), HealthRange(pending, 25, 250));
+            var dbOps = RuntimeMetrics.DbQueries;
+            var dbFailures = RuntimeMetrics.DbFailures;
+            var (p50, p95, p99, pMax) = RuntimeMetrics.DbLatencyPercentiles();
+            var failPct = dbOps == 0 ? 0 : 100.0 * dbFailures / dbOps;
+            var rollbackPct = 100.0 * (rates?.RollbackRatio ?? 0);
+            var locksWaiting = pg?.LocksWaiting ?? 0;
+            var dbHealth = Math.Min(
+                Math.Min(HealthRange(p95, 50, 500), HealthRange(failPct, 0.1, 5)),
+                Math.Min(HealthRange(rollbackPct, 1, 25), HealthRange(locksWaiting, 0, 10)));
 
             var lastComplete = await db.AutomationLogs.Where(x => x.EndTime.HasValue).GroupBy(x => x.Type).Select(g => g.OrderByDescending(y => y.EndTime).First()).ToListAsync();
             var recentLogs = await db.AutomationLogs.Where(x => x.StartTime > DateTimeOffset.UtcNow.AddDays(-1)).ToListAsync();
@@ -120,9 +181,10 @@ namespace EGG9000.Bot.Commands {
                 serviceRows.Add(new ServiceRow(log.Type, avg, last, incompletes.Count, status));
             }
 
-            return new SysLoadSnapshot(pingMs, workingMb, gcHeapMb, proc.Threads.Count, proc.TotalProcessorTime.TotalMinutes, cacheCount,
-                tracked, pending, activeCoops, dbUsers, contracts, events, autoLogs,
-                apiCalls, apiFails, RuntimeMetrics.DbQueries, commands, cmdFails, RuntimeMetrics.DiscordOps,
+            return new SysLoadSnapshot(pingMs, workingMb, gcHeapMb, proc.Threads.Count, proc.TotalProcessorTime.TotalMinutes,
+                apiCalls, apiFails, dbOps, commands, cmdFails, RuntimeMetrics.DiscordOps,
+                RuntimeMetrics.DbReads, RuntimeMetrics.DbWrites, dbFailures, RuntimeMetrics.DbRetries, RuntimeMetrics.DbSlow,
+                RuntimeMetrics.DbMeanMs, p50, p95, p99, pMax, pg, rates,
                 latency, guilds, qHigh, qLow, queue?.HighWorkers ?? 0, queue?.LowWorkers ?? 0,
                 runtimeHealth, discordHealth, processHealth, dbHealth,
                 RuntimeMetrics.StartedAt.ToUnixTimeSeconds(), DateTimeOffset.UtcNow.ToUnixTimeSeconds(), serviceRows);
@@ -170,15 +232,19 @@ namespace EGG9000.Bot.Commands {
                 "database" => new EmbedBuilder()
                     .WithAuthor($"Database  -  {HealthPct(s.DbHealth)}% healthy")
                     .WithColor(HealthColor(s.DbHealth))
-                    .AddField("DB Ping", $"`{s.Ping}` ms", inline: true)
-                    .AddField("Tracked", $"`{s.Tracked}`", inline: true)
-                    .AddField("Pending", $"`{s.Pending}`", inline: true)
-                    .AddField("Mem Cache", s.CacheCount >= 0 ? $"`{s.CacheCount}`" : "`n/a`", inline: true)
-                    .AddField("DBUsers", $"`{s.DbUsers:N0}`", inline: true)
-                    .AddField("Active Coops", $"`{s.ActiveCoops:N0}`", inline: true)
-                    .AddField("Contracts", $"`{s.Contracts:N0}`", inline: true)
-                    .AddField("Events", $"`{s.Events:N0}`", inline: true)
-                    .AddField("AutoLogs 24h", $"`{s.AutoLogs:N0}`", inline: true)
+                    .AddField("Ops", Metric(s.DbQueries, RuntimeMetrics.PerMinute(s.DbQueries)) + $"\nR `{s.DbReads:N0}` / W `{s.DbWrites:N0}`", inline: true)
+                    .AddField("Latency", $"mean `{s.DbMeanMs:F1}` ms\nmax `{s.DbMax:F1}` ms\nping `{s.Ping}` ms", inline: true)
+                    .AddField("Percentiles", $"p50 `{s.DbP50:F1}` ms\np95 `{s.DbP95:F1}` ms\np99 `{s.DbP99:F1}` ms", inline: true)
+                    .AddField("Errors", $"`{s.DbFailures:N0}` failed\n`{s.DbRetries:N0}` retries\n`{s.DbSlow:N0}` slow >{RuntimeMetrics.DbSlowThresholdMs:F0}ms", inline: true)
+                    .AddField("Transactions", s.Pg is null ? "`n/a`" : s.Rates is null
+                        ? $"`{s.Pg.Commits:N0}` commits total\n`{s.Pg.Rollbacks:N0}` rollbacks total"
+                        : $"`{s.Rates.Commits:F1}`/s commits\n`{s.Rates.Rollbacks:F2}`/s rollbacks", inline: true)
+                    .AddField("Cache Hit", s.Pg is null ? "`n/a`" : $"`{PgCacheHit(s.Pg):F2}`%\n`{s.Pg.BlksRead:N0}` disk reads", inline: true)
+                    .AddField("Backends", s.Pg is null ? "`n/a`" : $"`{s.Pg.Backends}` active\n`{s.Pg.LocksWaiting}` lock waits", inline: true)
+                    .AddField("Contention", s.Pg is null ? "`n/a`" : $"`{s.Pg.Deadlocks:N0}` deadlocks\n`{s.Pg.Conflicts:N0}` conflicts\n`{s.Pg.TempFiles:N0}` temp files", inline: true)
+                    .AddField("Tuples", s.Pg is null ? "`n/a`" : s.Rates is null
+                        ? $"`{s.Pg.TupFetched:N0}` fetched total\n`{s.Pg.TupInserted + s.Pg.TupUpdated + s.Pg.TupDeleted:N0}` written total"
+                        : $"`{s.Rates.Returned:N0}`/s scanned\n`{s.Rates.Fetched:N0}`/s fetched\n`{s.Rates.Inserted:N0}`i `{s.Rates.Updated:N0}`u `{s.Rates.Deleted:N0}`d /s", inline: true)
                     .Build(),
                 "services" => new EmbedBuilder()
                     .WithAuthor($"Automated Services  -  {(s.Services.Count == 0 ? 100 : HealthPct((double)s.Services.Count(x => x.Status != "Stopped") / s.Services.Count))}% up")

--- a/EGG9000.Bot/Commands/ContractCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/ContractCommandsSlash.cs
@@ -596,6 +596,17 @@ namespace EGG9000.Bot.Commands {
             await Db.SaveChangesAsync();
             _lookup.Remove(xref.UserId, targetCoop.ContractID);
 
+            if(!await Db.UserCoopXrefs.AnyAsync(x => x.CoopId == targetCoop.Id && !x.Removed)) {
+                Db.Remove(targetCoop);
+                await Db.SaveChangesAsync();
+                await Context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Removed <@{xref.User.DiscordId}> ({username}) from co-op. No users left, co-op deleted from DB.");
+                await ((SocketThreadChannel)Context.Channel).ModifyAsync(c => {
+                    c.Archived = true;
+                    c.Locked = true;
+                });
+                return;
+            }
+
             await Context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Removed <@{xref.User.DiscordId}> ({username}) from co-op");
 
         }

--- a/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
+++ b/EGG9000.Bot/Commands/RegisterCommandsSlash.cs
@@ -1,4 +1,4 @@
-using Bugsnag;
+﻿using Bugsnag;
 using Discord;
 using Discord.Interactions;
 using Discord.Net;
@@ -317,7 +317,11 @@ namespace EGG9000.Bot.Commands {
             if(dbuser.EggIncAccounts.Count == 1) {
                 var overflowRole = guild.Roles.FirstOrDefault(x => x.Id == 775547850134257675);
                 if(overflowRole != null) {
-                    await socketGuildUser.AddRoleAsync(overflowRole);
+                    if(await OverflowSyncing.IsMissingFromAnyOverflowAsync(guildObj, _client, user.Id)) {
+                        await socketGuildUser.AddRoleAsync(overflowRole);
+                    } else if(socketGuildUser.RoleIds.Any(x => x == overflowRole.Id)) {
+                        await socketGuildUser.RemoveRoleAsync(overflowRole);
+                    }
                 }
             }
 
@@ -427,7 +431,11 @@ namespace EGG9000.Bot.Commands {
                 if(dbguild != null && dbguild.OverflowServers.Count > 0) {
                     var overflowRole = guild.Roles.FirstOrDefault(x => x.Id == 775547850134257675);
                     if(overflowRole != null) {
-                        await guildUser.AddRoleAsync(overflowRole);
+                        if(await OverflowSyncing.IsMissingFromAnyOverflowAsync(dbguild, _client, guildUser.Id)) {
+                            await guildUser.AddRoleAsync(overflowRole);
+                        } else if(guildUser.Roles.Any(x => x.Id == overflowRole.Id)) {
+                            await guildUser.RemoveRoleAsync(overflowRole);
+                        }
                     }
                 }
 

--- a/EGG9000.Bot/Interactions/UserParams.cs
+++ b/EGG9000.Bot/Interactions/UserParams.cs
@@ -24,8 +24,10 @@ namespace EGG9000.Bot.Interactions {
         [Summary("user5")] SocketUser user5 = null,
         [Summary("user6")] SocketUser user6 = null,
         [Summary("user7")] SocketUser user7 = null,
-        [Summary("user8")] SocketUser user8 = null) {
-        public SocketUser[] Users { get; } = new[] { user1, user2, user3, user4, user5, user6, user7, user8 }.Where(u => u is not null).ToArray();
+        [Summary("user8")] SocketUser user8 = null,
+        [Summary("user9")] SocketUser user9 = null,
+        [Summary("user10")] SocketUser user10 = null) {
+        public SocketUser[] Users { get; } = [.. new[] { user1, user2, user3, user4, user5, user6, user7, user8, user9, user10 }.Where(u => u is not null)];
     }
 
     [method: ComplexParameterCtor]
@@ -37,7 +39,9 @@ namespace EGG9000.Bot.Interactions {
         [Summary("user5")] SocketGuildUser user5 = null,
         [Summary("user6")] SocketGuildUser user6 = null,
         [Summary("user7")] SocketGuildUser user7 = null,
-        [Summary("user8")] SocketGuildUser user8 = null) {
-        public SocketGuildUser[] Users { get; } = new[] { user1, user2, user3, user4, user5, user6, user7, user8 }.Where(u => u is not null).ToArray();
+        [Summary("user8")] SocketGuildUser user8 = null,
+        [Summary("user9")] SocketGuildUser user9 = null,
+        [Summary("user10")] SocketGuildUser user10 = null) {
+        public SocketGuildUser[] Users { get; } = [.. new[] { user1, user2, user3, user4, user5, user6, user7, user8, user9, user10 }.Where(u => u is not null)];
     }
 }

--- a/EGG9000.Common/Database/QueryCountingInterceptor.cs
+++ b/EGG9000.Common/Database/QueryCountingInterceptor.cs
@@ -2,6 +2,7 @@ using EGG9000.Common.Services;
 
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
+using System;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,34 +14,79 @@ namespace EGG9000.Common.Database {
     /// thread safe, so a single instance can be shared across all contexts.
     /// </summary>
     public sealed class QueryCountingInterceptor : DbCommandInterceptor {
-        public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result) {
+        private static readonly char[] _verbSeparators = [' ', '\t', '\r', '\n', '(', ';'];
+
+        internal static bool IsWrite(string commandText, CommandSource source) {
+            var verb = LeadingVerb(commandText);
+            if(verb is "INSERT" or "UPDATE" or "DELETE" or "MERGE" or "COPY" or "TRUNCATE" or "CREATE" or "ALTER" or "DROP")
+                return true;
+            if(verb is "SELECT" or "WITH" or "SHOW" or "EXPLAIN")
+                return false;
+            return source is CommandSource.SaveChanges or CommandSource.Migrations;
+        }
+
+        private static string LeadingVerb(string text) {
+            if(string.IsNullOrEmpty(text)) return string.Empty;
+            var i = 0;
+            while(i < text.Length) {
+                if(char.IsWhiteSpace(text[i])) { i++; continue; }
+                if(text[i] == '-' && i + 1 < text.Length && text[i + 1] == '-') {
+                    var nl = text.IndexOf('\n', i);
+                    if(nl < 0) return string.Empty;
+                    i = nl + 1;
+                    continue;
+                }
+                break;
+            }
+            if(i >= text.Length) return string.Empty;
+            var end = text.IndexOfAny(_verbSeparators, i);
+            if(end < 0) end = text.Length;
+            return text[i..end].ToUpperInvariant();
+        }
+
+        private static void Record(DbCommand command, CommandExecutedEventData eventData) {
             RuntimeMetrics.AddDbQueries();
+            RuntimeMetrics.RecordDbCommand(eventData.Duration, IsWrite(command?.CommandText, eventData.CommandSource));
+        }
+
+        public override DbDataReader ReaderExecuted(DbCommand command, CommandExecutedEventData eventData, DbDataReader result) {
+            Record(command, eventData);
             return base.ReaderExecuted(command, eventData, result);
         }
 
         public override ValueTask<DbDataReader> ReaderExecutedAsync(DbCommand command, CommandExecutedEventData eventData, DbDataReader result, CancellationToken cancellationToken = default) {
-            RuntimeMetrics.AddDbQueries();
+            Record(command, eventData);
             return base.ReaderExecutedAsync(command, eventData, result, cancellationToken);
         }
 
         public override int NonQueryExecuted(DbCommand command, CommandExecutedEventData eventData, int result) {
-            RuntimeMetrics.AddDbQueries();
+            Record(command, eventData);
             return base.NonQueryExecuted(command, eventData, result);
         }
 
         public override ValueTask<int> NonQueryExecutedAsync(DbCommand command, CommandExecutedEventData eventData, int result, CancellationToken cancellationToken = default) {
-            RuntimeMetrics.AddDbQueries();
+            Record(command, eventData);
             return base.NonQueryExecutedAsync(command, eventData, result, cancellationToken);
         }
 
         public override object ScalarExecuted(DbCommand command, CommandExecutedEventData eventData, object result) {
-            RuntimeMetrics.AddDbQueries();
+            Record(command, eventData);
             return base.ScalarExecuted(command, eventData, result);
         }
 
         public override ValueTask<object> ScalarExecutedAsync(DbCommand command, CommandExecutedEventData eventData, object result, CancellationToken cancellationToken = default) {
-            RuntimeMetrics.AddDbQueries();
+            Record(command, eventData);
             return base.ScalarExecutedAsync(command, eventData, result, cancellationToken);
+        }
+
+        public override void CommandFailed(DbCommand command, CommandErrorEventData eventData) {
+            RuntimeMetrics.AddDbFailures();
+            base.CommandFailed(command, eventData);
+        }
+
+        public override Task CommandFailedAsync(DbCommand command, CommandErrorEventData eventData, CancellationToken cancellationToken = default) {
+            RuntimeMetrics.AddDbFailures();
+            return base.CommandFailedAsync(command, eventData, cancellationToken);
         }
     }
 }

--- a/EGG9000.Common/Helpers/DBHelpers.cs
+++ b/EGG9000.Common/Helpers/DBHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using EGG9000.Common.Database;
 using EGG9000.Common.Database.Entities;
+using EGG9000.Common.Services;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,7 @@ namespace EGG9000.Common.Helpers {
                         db.Database.SetCommandTimeout(TimeSpan.FromMinutes(1));
                         return (true, await db.SaveChangesAsync(cancellationToken));
                     } catch(Exception e) {
+                        RuntimeMetrics.AddDbRetries();
                         if(currentRetry++ > retryCount) {
                             logger?.LogError(e, "SaveChangesAsyncRetry Max Retries Reached");
                             return (false, -1);

--- a/EGG9000.Common/Helpers/Discord/OverflowSyncing.cs
+++ b/EGG9000.Common/Helpers/Discord/OverflowSyncing.cs
@@ -70,6 +70,28 @@ namespace EGG9000.Common.Helpers.Discord {
             return sb.ToString();
         }
 
+        public static async Task<bool> IsMissingFromAnyOverflowAsync(Guild guild, Services.DiscordHostedService client, ulong userId) {
+            if(guild is null)
+                return true;
+            if(guild.OverflowServers.Count == 0)
+                return false;
+
+            foreach(var overflowId in guild.OverflowServers) {
+                var overflowServer = client.GetGuild(overflowId);
+                if(overflowServer is null)
+                    return true;
+                if(overflowServer.GetUser(userId) is not null)
+                    continue;
+                try {
+                    if(await client.Rest.GetGuildUserAsync(overflowId, userId) is null)
+                        return true;
+                } catch {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public static List<RoleMap> GetRoleMaps(IList<SocketRole> rolesToSync, IEnumerable<SocketGuild> overflowServers) {
             var roleMaps = rolesToSync.Select(x => {
                 var map = new RoleMap {

--- a/EGG9000.Common/Helpers/Words.cs
+++ b/EGG9000.Common/Helpers/Words.cs
@@ -8,14 +8,8 @@ using System.Linq;
 
 namespace EGG9000.Common.Helpers {
     public class Words {
-        private readonly Random _rnd;
-
-        public Words() {
-            _rnd = new Random();
-        }
-
         public string GetRandomWord() {
-            return FirstCharToUpper(WordList[_rnd.Next(WordList.Count)]);
+            return FirstCharToUpper(WordList[Random.Shared.Next(WordList.Count)]);
         }
 
         // Pick a second word that does not start with the first word's last character (avoids
@@ -27,19 +21,19 @@ namespace EGG9000.Common.Helpers {
             var last = char.ToLowerInvariant(firstWord.Last());
             var excludeLiPair = last == 'l' || last == 'i';
             for(var attempt = 0; attempt < 16; attempt++) {
-                var candidate = WordList[_rnd.Next(WordList.Count)];
+                var candidate = WordList[Random.Shared.Next(WordList.Count)];
                 if(candidate.Length == 0) return FirstCharToUpper(candidate);
                 var first = char.ToLowerInvariant(candidate[0]);
                 var blocked = excludeLiPair ? (first == 'l' || first == 'i') : first == last;
                 if(!blocked)
                     return FirstCharToUpper(candidate);
             }
-            return FirstCharToUpper(WordList[_rnd.Next(WordList.Count)]);
+            return FirstCharToUpper(WordList[Random.Shared.Next(WordList.Count)]);
         }
 
         public string GetRandomNumber() {
             int number;
-            do { number = _rnd.Next(99); } while(number == 69);
+            do { number = Random.Shared.Next(99); } while(number == 69);
             return number.ToString();
         }
 

--- a/EGG9000.Common/Services/LatencyRing.cs
+++ b/EGG9000.Common/Services/LatencyRing.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading;
+
+namespace EGG9000.Common.Services {
+    public sealed class LatencyRing {
+        public const int Capacity = 512;
+
+        private readonly long[] _slots = new long[Capacity];
+        private long _index = -1;
+
+        public void Add(long value) {
+            var i = Interlocked.Increment(ref _index);
+            _slots[(int)((ulong)i % Capacity)] = value;
+        }
+
+        public int Count => (int)Math.Min(Math.Max(Interlocked.Read(ref _index) + 1, 0), Capacity);
+
+        public (long P50, long P95, long P99, long Max) Percentiles() {
+            var n = Count;
+            if(n <= 0) return (0, 0, 0, 0);
+            var copy = new long[n];
+            Array.Copy(_slots, copy, n);
+            Array.Sort(copy);
+            return (Quantile(copy, 0.50), Quantile(copy, 0.95), Quantile(copy, 0.99), copy[n - 1]);
+        }
+
+        private static long Quantile(long[] sorted, double q) {
+            var idx = (int)Math.Ceiling(q * sorted.Length) - 1;
+            return sorted[Math.Clamp(idx, 0, sorted.Length - 1)];
+        }
+    }
+}

--- a/EGG9000.Common/Services/RuntimeMetrics.cs
+++ b/EGG9000.Common/Services/RuntimeMetrics.cs
@@ -17,6 +17,14 @@ namespace EGG9000.Common.Services {
         private static long _commands;
         private static long _commandFailures;
         private static long _discordOps;
+        private static long _dbFailures;
+        private static long _dbRetries;
+        private static long _dbReads;
+        private static long _dbWrites;
+        private static long _dbSlow;
+        private static long _dbLatencyTicks;
+
+        private static readonly LatencyRing _dbLatency = new();
 
         public static long DbQueries => Interlocked.Read(ref _dbQueries);
         public static long ApiCalls => Interlocked.Read(ref _apiCalls);
@@ -32,6 +40,38 @@ namespace EGG9000.Common.Services {
         public static void AddCommands(long n = 1) => Interlocked.Add(ref _commands, n);
         public static void AddCommandFailures(long n = 1) => Interlocked.Add(ref _commandFailures, n);
         public static void AddDiscordOps(long n = 1) => Interlocked.Add(ref _discordOps, n);
+
+        public static long DbFailures => Interlocked.Read(ref _dbFailures);
+        public static long DbRetries => Interlocked.Read(ref _dbRetries);
+        public static long DbReads => Interlocked.Read(ref _dbReads);
+        public static long DbWrites => Interlocked.Read(ref _dbWrites);
+        public static long DbSlow => Interlocked.Read(ref _dbSlow);
+        public static long DbLatencyTicks => Interlocked.Read(ref _dbLatencyTicks);
+
+        public static double DbMeanMs {
+            get {
+                var n = DbQueries;
+                return n <= 0 ? 0 : DbLatencyTicks / (double)n / TimeSpan.TicksPerMillisecond;
+            }
+        }
+
+        public static void AddDbFailures(long n = 1) => Interlocked.Add(ref _dbFailures, n);
+        public static void AddDbRetries(long n = 1) => Interlocked.Add(ref _dbRetries, n);
+
+        public static void RecordDbCommand(TimeSpan duration, bool write) {
+            if(write) Interlocked.Increment(ref _dbWrites); else Interlocked.Increment(ref _dbReads);
+            Interlocked.Add(ref _dbLatencyTicks, duration.Ticks);
+            if(duration.TotalMilliseconds > DbSlowThresholdMs) Interlocked.Increment(ref _dbSlow);
+            _dbLatency.Add(duration.Ticks);
+        }
+
+        public const double DbSlowThresholdMs = 250;
+
+        public static (double P50, double P95, double P99, double Max) DbLatencyPercentiles() {
+            var (p50, p95, p99, max) = _dbLatency.Percentiles();
+            static double Ms(long ticks) => ticks / (double)TimeSpan.TicksPerMillisecond;
+            return (Ms(p50), Ms(p95), Ms(p99), Ms(max));
+        }
 
         public static TimeSpan Uptime => DateTimeOffset.UtcNow - StartedAt;
 

--- a/EGG9000.Site/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/EGG9000.Site/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
+using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace EGG9000.Site.Areas.Identity.Pages.Account {
@@ -11,17 +14,29 @@ namespace EGG9000.Site.Areas.Identity.Pages.Account {
         private readonly SignInManager<ApplicationUser> _signInManager = signInManager;
         private readonly ILogger<LogoutModel> _logger = logger;
 
-        public void OnGet() {
+        public async Task<IActionResult> OnGet() {
+            await SignOutEverywhereAsync();
+            return Page();
         }
 
         public async Task<IActionResult> OnPost(string returnUrl = null) {
-            await _signInManager.SignOutAsync();
-            _logger.LogInformation("User logged out.");
+            await SignOutEverywhereAsync();
             if(returnUrl != null) {
                 return LocalRedirect(returnUrl);
             } else {
                 return RedirectToPage();
             }
+        }
+
+        private async Task SignOutEverywhereAsync() {
+            await _signInManager.SignOutAsync();
+            await HttpContext.SignOutAsync(IdentityConstants.TwoFactorRememberMeScheme);
+            await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity());
+            Response.Headers.CacheControl = "no-store, no-cache, max-age=0, must-revalidate";
+            Response.Headers.Pragma = "no-cache";
+            Response.Headers.Expires = "0";
+            _logger.LogInformation("User logged out.");
         }
     }
 }

--- a/EGG9000.Site/Views/Shared/_LoginPartial.cshtml
+++ b/EGG9000.Site/Views/Shared/_LoginPartial.cshtml
@@ -10,7 +10,7 @@
 
     </li>
     <li class="nav-item">
-        <form  class="d-flex align-items-center gap-2" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
+        <form  method="post" class="d-flex align-items-center gap-2" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Action("Index", "Home", new { area = "" })">
             <button  type="submit" class="nav-link btn btn-link">Logout</button>
         </form>
     </li>

--- a/EGG9000.Test/CoopWordsTests.cs
+++ b/EGG9000.Test/CoopWordsTests.cs
@@ -1,8 +1,10 @@
-using EGG9000.Common.JsonData;
+﻿using EGG9000.Common.JsonData;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 
 namespace EGG9000.Test {
     [TestClass]
@@ -66,6 +68,18 @@ namespace EGG9000.Test {
                     second == 'l' || second == 'i',
                     $"'{first}' ends in l/i but next word starts with '{second}'");
             }
+        }
+
+        [TestMethod]
+        public void Concurrent_generation_does_not_tear_the_shared_rng() {
+            var words = new Common.Helpers.Words();
+            var names = new ConcurrentBag<string>();
+            Parallel.For(0, 1000, new ParallelOptions { MaxDegreeOfParallelism = 10 }, _ => {
+                var first = words.GetRandomWord();
+                names.Add(first + words.GetRandomSecondWord(first) + words.GetRandomNumber());
+            });
+            var dupes = names.GroupBy(x => x).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+            Assert.IsEmpty(dupes, $"concurrent generation produced identical names, shared Random is torn: {string.Join(", ", dupes.Take(10))}");
         }
 
         [GeneratedRegex("^[a-z]{3,5}$")]

--- a/EGG9000.Test/LatencyRingTests.cs
+++ b/EGG9000.Test/LatencyRingTests.cs
@@ -1,0 +1,69 @@
+using EGG9000.Common.Services;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EGG9000.Test {
+    [TestClass]
+    [TestCategory("Unit")]
+    public class LatencyRingTests {
+        [TestMethod]
+        public void EmptyRingIsAllZero() {
+            var ring = new LatencyRing();
+            Assert.AreEqual(0, ring.Count);
+            Assert.AreEqual((0L, 0L, 0L, 0L), ring.Percentiles());
+        }
+
+        [TestMethod]
+        public void PartialFillUsesOnlyWrittenSlots() {
+            var ring = new LatencyRing();
+            for(var i = 1; i <= 100; i++) ring.Add(i);
+            Assert.AreEqual(100, ring.Count);
+            var (p50, p95, p99, max) = ring.Percentiles();
+            Assert.AreEqual(50L, p50);
+            Assert.AreEqual(95L, p95);
+            Assert.AreEqual(99L, p99);
+            Assert.AreEqual(100L, max);
+        }
+
+        [TestMethod]
+        public void SingleSampleReportsItselfEverywhere() {
+            var ring = new LatencyRing();
+            ring.Add(42);
+            Assert.AreEqual(1, ring.Count);
+            Assert.AreEqual((42L, 42L, 42L, 42L), ring.Percentiles());
+        }
+
+        [TestMethod]
+        public void OverwritesOldestOnceFull() {
+            var ring = new LatencyRing();
+            for(var i = 0; i < LatencyRing.Capacity; i++) ring.Add(1);
+            Assert.AreEqual(LatencyRing.Capacity, ring.Count);
+            Assert.AreEqual((1L, 1L, 1L, 1L), ring.Percentiles());
+
+            for(var i = 0; i < LatencyRing.Capacity; i++) ring.Add(7);
+            Assert.AreEqual(LatencyRing.Capacity, ring.Count);
+            Assert.AreEqual((7L, 7L, 7L, 7L), ring.Percentiles());
+        }
+
+        [TestMethod]
+        public void WrapKeepsNewestWindow() {
+            var ring = new LatencyRing();
+            for(var i = 1; i <= LatencyRing.Capacity + 100; i++) ring.Add(i);
+            var (p50, _, _, max) = ring.Percentiles();
+            Assert.AreEqual(LatencyRing.Capacity + 100L, max);
+            Assert.IsTrue(p50 > 100, $"expected newest window, got p50 {p50}");
+        }
+
+        [TestMethod]
+        public void PercentilesIgnoreInsertionOrder() {
+            var ring = new LatencyRing();
+            long[] samples = [9, 1, 8, 2, 7, 3, 6, 4, 5, 10];
+            foreach(var s in samples) ring.Add(s);
+            var (p50, p95, p99, max) = ring.Percentiles();
+            Assert.AreEqual(5L, p50);
+            Assert.AreEqual(10L, p95);
+            Assert.AreEqual(10L, p99);
+            Assert.AreEqual(10L, max);
+        }
+    }
+}


### PR DESCRIPTION
- Reworked the DB stats in `/bot sysload` to be more informative
- Fixed the overflow role being set on `/register` even when the user is in the overflows
- Fixed possible "word overlap" instances for coop names
- Fixed `/Identity/Logout` not working to actually kill the session
- Made it so after `/removefromcoop`, if there are no users left in the coop, it will auto-delete